### PR TITLE
Travis CI: Test on latest Node.js v4.x.x and v6.x.x branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-    - '5.0'
-    - '4.0'
+    - '5'
+    - '4'
 notifications:
     email: false
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
     - '6'
+    - '5'
     - '4'
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - '5'
+    - '6'
     - '4'
 notifications:
     email: false


### PR DESCRIPTION
Currently these latest versions are `4.4.7` for the 4.x branch and `6.2.2` for the 6.x branch
