### PR TITLE
Support @inheritdoc in the require-param rule

### DIFF
--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -24,6 +24,10 @@ const curryUtils = (functionNode, jsdoc, tagNamePreference) => {
     utils.isValidTag = (name) => {
         return jsdocUtils.isValidTag(name);
     };
+    
+    utils.hasTag = (name) => {
+        return jsdocUtils.hasTag(jsdoc, name);
+    };
 
     return utils;
 };

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -72,10 +72,18 @@ const isValidTag = (name : string) : boolean => {
     return _.includes(validTagNames, name);
 };
 
+const hasTag = (jsdoc : Object, targetTagName : string) : boolean => {
+    const targetTagLower = targetTagName.toLowerCase();
+    return _.some(jsdoc.tags, (doc : Object) => {
+        return doc.tag.toLowerCase() == targetTagLower;
+    });
+};
+
 export default {
     getFunctionParameterNames,
     getJsdocParameterNames,
     getJsdocParameterNamesDeep,
     getPreferredTagName,
-    isValidTag
+    isValidTag,
+    hasTag
 };

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -8,6 +8,11 @@ export default iterateJsdoc(({
     const functionParameterNames = utils.getFunctionParameterNames();
     const jsdocParameterNames = utils.getJsdocParameterNames();
 
+    // inheritdoc implies that all documentation is inherited; see http://usejsdoc.org/tags-inheritdoc.html
+    if (utils.hasTag('inheritdoc')) {
+        return;
+    }
+
     _.some(functionParameterNames, (functionParameterName, index) => {
         const jsdocParameterName = jsdocParameterNames[index];
 

--- a/tests/rules/assertions/requireParam.js
+++ b/tests/rules/assertions/requireParam.js
@@ -69,6 +69,16 @@ export default {
         {
             code: `
                 /**
+                 * @inheritdoc
+                 */
+                function quux (foo) {
+
+                }
+            `
+        },
+        {
+            code: `
+                /**
                  * @arg foo
                  */
                 function quux (foo) {


### PR DESCRIPTION
This fixes Issue #20.

See http://usejsdoc.org/tags-inheritdoc.html for the inheritdoc spec.
