### PR TITLE
Fix the 'Unsupported function signature format.' error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,13 @@ function quux (...args) {
 function quux ({a, b}) {
 
 }
+
+/**
+ * @param foo
+ */
+function quux ({a, b} = {}) {
+
+}
 ```
 
 

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -11,7 +11,7 @@ const getFunctionParameterNames = (functionNode : Object) : Array<string> => {
       return param.left.name;
     }
 
-    if (param.type === 'ObjectPattern') {
+    if (param.type === 'ObjectPattern' || _.get(param, 'left.type') === 'ObjectPattern') {
       return '<ObjectPattern>';
     }
 

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -193,6 +193,16 @@ export default {
 
           }
       `
+    },
+    {
+      code: `
+          /**
+           * @param foo
+           */
+          function quux ({a, b} = {}) {
+
+          }
+      `
     }
   ]
 };


### PR DESCRIPTION
This fixes the 'Unsupported function signature format.' error as per https://github.com/gajus/eslint-plugin-jsdoc/issues/18.

I cannot say that the testing for this has been rigorous, but it does seem to work for all basic cases. Then again, the fix is really simple and should always work, unless I'm missing something.