### PR TITLE
Correct check for non-ASCII descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "build": "NODE_ENV=production babel ./src --out-dir ./dist --copy-files --source-maps",
     "generate-readme": "gitdown ./.README/README.md --output-file ./README.md && npm run add-assertions",
     "lint": "eslint ./src ./test",
-    "test": "mocha --compilers js:babel-register"
+    "test": "mocha --recursive --compilers js:babel-register"
   },
   "version": "2.4.0"
 }

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -21,6 +21,10 @@ const isNewLinePrecededByAPeriod = (text) => {
   });
 };
 
+const isCapitalized = (str) => {
+  return str[0] === str[0].toUpperCase();
+};
+
 const validateDescription = (description, report) => {
   if (!description) {
     return false;
@@ -29,7 +33,7 @@ const validateDescription = (description, report) => {
   const paragraphs = extractParagraphs(description);
 
   return _.some(paragraphs, (paragraph, index) => {
-    if (!/^[A-Z]/.test(paragraph)) {
+    if (!isCapitalized(paragraph)) {
       if (index === 0) {
         report('Description must start with an uppercase character.');
       } else {

--- a/test/rules/assertions/requireDescriptionCompleteSentence.js
+++ b/test/rules/assertions/requireDescriptionCompleteSentence.js
@@ -37,6 +37,21 @@ export default {
     {
       code: `
           /**
+           * тест.
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Description must start with an uppercase character.'
+        }
+      ]
+    },
+    {
+      code: `
+          /**
            * Foo
            */
           function quux () {
@@ -138,6 +153,16 @@ export default {
            * Foo.
            *
            * Bar.
+           */
+          function quux () {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * Тест.
            */
           function quux () {
 


### PR DESCRIPTION
Simple regex check fails on non-ASCII descriptions.