### PR TITLE
fix: Preserve JSDoc block start/end indentation (#41)

### DIFF
--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -45,8 +45,10 @@ export default (iterator) => {
         return;
       }
 
-      const jsdoc = commentParser('/*' + jsdocNode.value + '*/', {
-                // @see https://github.com/yavorskiy/comment-parser/issues/21
+      // Preserve JSDoc block start/end indentation.
+      const indent = _.repeat(' ', jsdocNode.loc.start.column);
+      const jsdoc = commentParser(indent + '/*' + jsdocNode.value + indent + '*/', {
+        // @see https://github.com/yavorskiy/comment-parser/issues/21
         parsers: [
           commentParser.PARSERS.parse_tag,
           commentParser.PARSERS.parse_type,


### PR DESCRIPTION
Package `comment-parser` used to parse comments and extract description and tags expects comment blocks to be aligned and correctly indented as per JSDoc docs.

As an example it does not handle incorrectly aligned JSDoc blocks:
```
/**
   * Add two numbers.
   * @param {number} a
   * @param {number} b
   * @returns {number}
   */
function add(a, b) {
    return a + b;
}
```
or
```
/**
* Add two numbers.
* @param {number} a
* @param {number} b
* @returns {number}
*/
function add(a, b) {
    return a + b;
}
```