### PR TITLE
feat: Add "require-param-name" rule

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -23,6 +23,7 @@ This table maps the rules between `eslint-plugin-jsdoc` and `jscs-jsdoc`.
 | [`require-hyphen-before-param-description`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-hyphen-before-param-description) | [`requireHyphenBeforeDescription`](https://github.com/jscs-dev/jscs-jsdoc#requirehyphenbeforedescription) |
 | [`require-param`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-param) | [`checkParamExistence`](https://github.com/jscs-dev/jscs-jsdoc#checkparamexistence) |
 | [`require-param-description`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-param-description) | [`requireParamDescription`](https://github.com/jscs-dev/jscs-jsdoc#requireparamdescription) |
+| [`require-param-name`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-param-name) | N/A |
 | [`require-param-type`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-param-type) | [`requireParamTypes`](https://github.com/jscs-dev/jscs-jsdoc#requireparamtypes) |
 | [`require-returns-description`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-returns-description) | [`requireReturnDescription`](https://github.com/jscs-dev/jscs-jsdoc#requirereturndescription) |
 | [`require-returns-type`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-returns-type) | [`requireReturnTypes`](https://github.com/jscs-dev/jscs-jsdoc#requirereturntypes) |
@@ -73,6 +74,7 @@ Finally, enable all of the rules that you would like to use.
         "jsdoc/require-hyphen-before-param-description": 1,
         "jsdoc/require-param": 1,
         "jsdoc/require-param-description": 1,
+        "jsdoc/require-param-name": 1,
         "jsdoc/require-param-type": 1,
         "jsdoc/require-returns-description": 1,
         "jsdoc/require-returns-type": 1
@@ -129,6 +131,7 @@ Use `settings.jsdoc.additionalTagNames` to configure additional, allowed JSDoc t
 {"gitdown": "include", "file": "./rules/require-hyphen-before-param-description.md"}
 {"gitdown": "include", "file": "./rules/require-param.md"}
 {"gitdown": "include", "file": "./rules/require-param-description.md"}
+{"gitdown": "include", "file": "./rules/require-param-name.md"}
 {"gitdown": "include", "file": "./rules/require-param-type.md"}
 {"gitdown": "include", "file": "./rules/require-returns-description.md"}
 {"gitdown": "include", "file": "./rules/require-returns-type.md"}

--- a/.README/rules/require-param-name.md
+++ b/.README/rules/require-param-name.md
@@ -1,0 +1,14 @@
+### `require-param-name`
+
+Requires that all function parameters have name.
+
+> The `@param` tag requires you to specify the name of the parameter you are documenting. You can also include the parameter's type, enclosed in curly brackets, and a description of the parameter.
+>
+> [JSDoc](http://usejsdoc.org/tags-param.html#overview)
+
+|||
+|---|---|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Tags|`param`|
+
+<!-- assertions requireParamName -->

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ JSDoc linting rules for ESLint.
         * [`require-hyphen-before-param-description`](#eslint-plugin-jsdoc-rules-require-hyphen-before-param-description)
         * [`require-param`](#eslint-plugin-jsdoc-rules-require-param)
         * [`require-param-description`](#eslint-plugin-jsdoc-rules-require-param-description)
+        * [`require-param-name`](#eslint-plugin-jsdoc-rules-require-param-name)
         * [`require-param-type`](#eslint-plugin-jsdoc-rules-require-param-type)
         * [`require-returns-description`](#eslint-plugin-jsdoc-rules-require-returns-description)
         * [`require-returns-type`](#eslint-plugin-jsdoc-rules-require-returns-type)
@@ -45,6 +46,7 @@ This table maps the rules between `eslint-plugin-jsdoc` and `jscs-jsdoc`.
 | [`require-hyphen-before-param-description`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-hyphen-before-param-description) | [`requireHyphenBeforeDescription`](https://github.com/jscs-dev/jscs-jsdoc#requirehyphenbeforedescription) |
 | [`require-param`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-param) | [`checkParamExistence`](https://github.com/jscs-dev/jscs-jsdoc#checkparamexistence) |
 | [`require-param-description`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-param-description) | [`requireParamDescription`](https://github.com/jscs-dev/jscs-jsdoc#requireparamdescription) |
+| [`require-param-name`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-param-name) | N/A |
 | [`require-param-type`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-param-type) | [`requireParamTypes`](https://github.com/jscs-dev/jscs-jsdoc#requireparamtypes) |
 | [`require-returns-description`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-returns-description) | [`requireReturnDescription`](https://github.com/jscs-dev/jscs-jsdoc#requirereturndescription) |
 | [`require-returns-type`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-returns-type) | [`requireReturnTypes`](https://github.com/jscs-dev/jscs-jsdoc#requirereturntypes) |
@@ -97,6 +99,7 @@ Finally, enable all of the rules that you would like to use.
         "jsdoc/require-hyphen-before-param-description": 1,
         "jsdoc/require-param": 1,
         "jsdoc/require-param-description": 1,
+        "jsdoc/require-param-name": 1,
         "jsdoc/require-param-type": 1,
         "jsdoc/require-returns-description": 1,
         "jsdoc/require-returns-type": 1
@@ -475,7 +478,7 @@ function quux (foo) {
 
 }
 
-/** 
+/**
  * @abstract
  * @access
  * @alias
@@ -563,9 +566,9 @@ RegExp
 <a name="eslint-plugin-jsdoc-rules-check-types-why-not-capital-case-everything"></a>
 #### Why not capital case everything?
 
-Why are `boolean`, `number` and `string` exempt from starting with a capital letter? Let's take `string` as an example. In Javascript, everything is an object. The string Object has prototypes for string functions such as `.toUpperCase()`. 
+Why are `boolean`, `number` and `string` exempt from starting with a capital letter? Let's take `string` as an example. In Javascript, everything is an object. The string Object has prototypes for string functions such as `.toUpperCase()`.
 
-Fortunately we don't have to write `new String()` everywhere in our code. Javascript will automatically wrap string primitives into string Objects when we're applying a string function to a string primitive. This way the memory footprint is a tiny little bit smaller, and the [GC](https://en.wikipedia.org/wiki/Garbage_collection_(computer_science)) has less work to do. 
+Fortunately we don't have to write `new String()` everywhere in our code. Javascript will automatically wrap string primitives into string Objects when we're applying a string function to a string primitive. This way the memory footprint is a tiny little bit smaller, and the [GC](https://en.wikipedia.org/wiki/Garbage_collection_(computer_science)) has less work to do.
 
 So in a sense, there two types of strings in Javascript; `{string}` literals, also called primitives and `{String}` Objects. We use the primitives because it's easier to write and uses less memory. `{String}` and `{string}` are technically both valid, but they are not the same.
 
@@ -757,6 +760,14 @@ function quux () {
 // Message: Paragraph must start with an uppercase character.
 
 /**
+ * тест.
+ */
+function quux () {
+
+}
+// Message: Description must start with an uppercase character.
+
+/**
  * Foo
  */
 function quux () {
@@ -823,6 +834,13 @@ function quux () {
  * Foo.
  *
  * Bar.
+ */
+function quux () {
+
+}
+
+/**
+ * Тест.
  */
 function quux () {
 
@@ -1050,6 +1068,59 @@ function quux (foo) {
 
 /**
  * @param foo Foo.
+ */
+function quux (foo) {
+
+}
+```
+
+
+<a name="eslint-plugin-jsdoc-rules-require-param-name"></a>
+### <code>require-param-name</code>
+
+Requires that all function parameters have name.
+
+> The `@param` tag requires you to specify the name of the parameter you are documenting. You can also include the parameter's type, enclosed in curly brackets, and a description of the parameter.
+>
+> [JSDoc](http://usejsdoc.org/tags-param.html#overview)
+
+|||
+|---|---|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Tags|`param`|
+
+The following patterns are considered problems:
+
+```js
+/**
+ * @param
+ */
+function quux (foo) {
+
+}
+// Message: There must be an identifier after @param type.
+
+/**
+ * @param {string}
+ */
+function quux (foo) {
+
+}
+// Message: There must be an identifier after @param tag.
+```
+
+The following patterns are not considered problems:
+
+```js
+/**
+ * @param foo
+ */
+function quux (foo) {
+
+}
+
+/**
+ * @param {string} foo
  */
 function quux (foo) {
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import newlineAfterDescription from './rules/newlineAfterDescription';
 import requireDescriptionCompleteSentence from './rules/requireDescriptionCompleteSentence';
 import requireExample from './rules/requireExample';
 import requireHyphenBeforeParamDescription from './rules/requireHyphenBeforeParamDescription';
+import requireParamName from './rules/requireParamName';
 import requireParam from './rules/requireParam';
 import requireParamDescription from './rules/requireParamDescription';
 import requireParamType from './rules/requireParamType';
@@ -22,6 +23,7 @@ export default {
     'require-hyphen-before-param-description': requireHyphenBeforeParamDescription,
     'require-param': requireParam,
     'require-param-description': requireParamDescription,
+    'require-param-name': requireParamName,
     'require-param-type': requireParamType,
     'require-returns-description': requireReturnsDescription,
     'require-returns-type': requireReturnsType
@@ -36,6 +38,7 @@ export default {
     'require-hyphen-before-param-description': 0,
     'require-param': 0,
     'require-param-description': 0,
+    'require-param-name': 0,
     'require-param-type': 0,
     'require-returns-description': 0,
     'require-returns-type': 0

--- a/src/rules/requireParamName.js
+++ b/src/rules/requireParamName.js
@@ -1,0 +1,20 @@
+import _ from 'lodash';
+import iterateJsdoc from '../iterateJsdoc';
+
+export default iterateJsdoc(({
+  jsdoc,
+  report,
+  utils
+}) => {
+  const targetTagName = utils.getPreferredTagName('param');
+
+  const jsdocParameters = _.filter(jsdoc.tags, {
+    tag: targetTagName
+  });
+
+  _.forEach(jsdocParameters, (jsdocParameter) => {
+    if (jsdocParameter.tag && jsdocParameter.name === '') {
+      report('There must be an identifier after @param ' + (jsdocParameter.type === '' ? 'type' : 'tag') + '.');
+    }
+  });
+});

--- a/test/rules/assertions/requireParamName.js
+++ b/test/rules/assertions/requireParamName.js
@@ -1,0 +1,58 @@
+/* eslint-disable no-restricted-syntax */
+
+export default {
+  invalid: [
+    {
+      code: `
+          /**
+           * @param
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'There must be an identifier after @param type.'
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * @param {string}
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'There must be an identifier after @param tag.'
+        }
+      ]
+    }
+  ],
+  valid: [
+    {
+      code: `
+          /**
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @param {string} foo
+           */
+          function quux (foo) {
+
+          }
+      `
+    }
+  ]
+};

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -16,6 +16,7 @@ _.forEach([
   'require-hyphen-before-param-description',
   'require-param',
   'require-param-description',
+  'require-param-name',
   'require-param-type',
   'require-returns-description',
   'require-returns-type'


### PR DESCRIPTION
Hello, @gajus,

My team uses [Ramda](http://ramdajs.com), as a functional library. Unfortunately, we forget to write the Identifier's of the @param tag, because the code is the following:

```js
const getSections = R.propOr([], 'sections');
```

In most cases JSDoc looks like:

```js
/*
 * @param {Object}
 * @retrurns {Object[]}
 */
const getSections = R.propOr([], 'sections');
```

We want in the near future to move to TypeScript. But now we use it for code validation based on JSDoc comments and TypeScript think that we have not correct JSDoc (he's right).

Valid JSDoc:

```js
/*
 * @param {Object} document
 * @retrurns {Object[]}
 */
const getSections = R.propOr([], 'sections');
```

Well, with this rule we can rectify this situation.