### PR TITLE
Add fixers to some rules

### DIFF
--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -64,7 +64,7 @@ export default (iterator) => {
       })[0] || {};
 
       const report = (message, fixer = null) => {
-        if(fixer === null) {
+        if (fixer === null) {
           context.report(jsdocNode, message);
         } else {
           context.report({
@@ -78,13 +78,13 @@ export default (iterator) => {
       const utils = curryUtils(functionNode, jsdoc, tagNamePreference, additionalTagNames);
 
       iterator({
-        sourceCode,
         context,
         functionNode,
+        indent,
         jsdoc,
         jsdocNode,
-        indent,
         report,
+        sourceCode,
         utils
       });
     };

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -67,14 +67,24 @@ export default (iterator) => {
         context.report(jsdocNode, message);
       };
 
+      const reportFix = (message, fixer) => {
+        context.report({
+          fix: fixer,
+          message,
+          node: jsdocNode
+        });
+      };
+
       const utils = curryUtils(functionNode, jsdoc, tagNamePreference, additionalTagNames);
 
       iterator({
+        sourceCode,
         context,
         functionNode,
         jsdoc,
         jsdocNode,
         report,
+        reportFix,
         utils
       });
     };

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -83,6 +83,7 @@ export default (iterator) => {
         functionNode,
         jsdoc,
         jsdocNode,
+        indent,
         report,
         utils
       });

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -63,16 +63,16 @@ export default (iterator) => {
         ]
       })[0] || {};
 
-      const report = (message) => {
-        context.report(jsdocNode, message);
-      };
-
-      const reportFix = (message, fixer) => {
-        context.report({
-          fix: fixer,
-          message,
-          node: jsdocNode
-        });
+      const report = (message, fixer = null) => {
+        if(fixer === null) {
+          context.report(jsdocNode, message);
+        } else {
+          context.report({
+            fix: fixer,
+            message,
+            node: jsdocNode
+          });
+        }
       };
 
       const utils = curryUtils(functionNode, jsdoc, tagNamePreference, additionalTagNames);
@@ -84,7 +84,6 @@ export default (iterator) => {
         jsdoc,
         jsdocNode,
         report,
-        reportFix,
         utils
       });
     };

--- a/src/rules/checkTypes.js
+++ b/src/rules/checkTypes.js
@@ -42,6 +42,8 @@ const strictNativeTypes = [
 
 export default iterateJsdoc(({
   jsdoc,
+  jsdocNode,
+  sourceCode,
   report
 }) => {
   const jsdocTags = _.filter(jsdoc.tags, (tag) => {
@@ -51,7 +53,9 @@ export default iterateJsdoc(({
   _.forEach(jsdocTags, (jsdocTag) => {
     _.some(strictNativeTypes, (strictNativeType) => {
       if (strictNativeType.toLowerCase() === jsdocTag.type.toLowerCase() && strictNativeType !== jsdocTag.type) {
-        report('Invalid JSDoc @' + jsdocTag.tag + ' "' + jsdocTag.name + '" type "' + jsdocTag.type + '".');
+        report('Invalid JSDoc @' + jsdocTag.tag + ' "' + jsdocTag.name + '" type "' + jsdocTag.type + '".', (fixer) => {
+          return fixer.replaceText(jsdocNode, sourceCode.getText(jsdocNode).replace('{' + jsdocTag.type + '}', '{' + strictNativeType + '}'));
+        });
 
         return true;
       }

--- a/src/rules/checkTypes.js
+++ b/src/rules/checkTypes.js
@@ -53,9 +53,11 @@ export default iterateJsdoc(({
   _.forEach(jsdocTags, (jsdocTag) => {
     _.some(strictNativeTypes, (strictNativeType) => {
       if (strictNativeType.toLowerCase() === jsdocTag.type.toLowerCase() && strictNativeType !== jsdocTag.type) {
-        report('Invalid JSDoc @' + jsdocTag.tag + ' "' + jsdocTag.name + '" type "' + jsdocTag.type + '".', (fixer) => {
+        const fix = (fixer) => {
           return fixer.replaceText(jsdocNode, sourceCode.getText(jsdocNode).replace('{' + jsdocTag.type + '}', '{' + strictNativeType + '}'));
-        });
+        };
+
+        report('Invalid JSDoc @' + jsdocTag.tag + ' "' + jsdocTag.name + '" type "' + jsdocTag.type + '".', fix);
 
         return true;
       }

--- a/src/rules/newlineAfterDescription.js
+++ b/src/rules/newlineAfterDescription.js
@@ -31,7 +31,7 @@ export default iterateJsdoc(({
       report('There must be a newline after the description of the JSDoc block.', (fixer) => {
         const sourceLines = sourceCode.getText(jsdocNode).split('\n');
         const lastDescriptionLine = _.findLastIndex(sourceLines, (line) => {
-          return _.includes(line, _.last(jsdoc.description.split('\n')))
+          return _.includes(line, _.last(jsdoc.description.split('\n')));
         });
 
         // Add the new line
@@ -44,14 +44,13 @@ export default iterateJsdoc(({
     report('There must be no newline after the description of the JSDoc block.', (fixer) => {
       const sourceLines = sourceCode.getText(jsdocNode).split('\n');
       const lastDescriptionLine = _.findLastIndex(sourceLines, (line) => {
-        return _.includes(line, _.last(jsdoc.description.split('\n')))
+        return _.includes(line, _.last(jsdoc.description.split('\n')));
       });
 
       // Remove the extra line
       sourceLines.splice(lastDescriptionLine + 1, 1);
 
-      return fixer.replaceText(jsdocNode, sourceLines.join('\n'));      
-      
+      return fixer.replaceText(jsdocNode, sourceLines.join('\n'));
     });
   }
 });

--- a/src/rules/newlineAfterDescription.js
+++ b/src/rules/newlineAfterDescription.js
@@ -4,7 +4,10 @@ import iterateJsdoc from '../iterateJsdoc';
 export default iterateJsdoc(({
   jsdoc,
   report,
-  context
+  context,
+  jsdocNode,
+  sourceCode,
+  indent
 }) => {
   let always;
 
@@ -25,9 +28,30 @@ export default iterateJsdoc(({
 
   if (always) {
     if (!descriptionEndsWithANewline) {
-      report('There must be a newline after the description of the JSDoc block.');
+      report('There must be a newline after the description of the JSDoc block.', (fixer) => {
+        const sourceLines = sourceCode.getText(jsdocNode).split('\n');
+        const lastDescriptionLine = _.findLastIndex(sourceLines, (line) => {
+          return _.includes(line, _.last(jsdoc.description.split('\n')))
+        });
+
+        // Add the new line
+        sourceLines.splice(lastDescriptionLine + 1, 0, indent + ' * ');
+
+        return fixer.replaceText(jsdocNode, sourceLines.join('\n'));
+      });
     }
   } else if (descriptionEndsWithANewline) {
-    report('There must be no newline after the description of the JSDoc block.');
+    report('There must be no newline after the description of the JSDoc block.', (fixer) => {
+      const sourceLines = sourceCode.getText(jsdocNode).split('\n');
+      const lastDescriptionLine = _.findLastIndex(sourceLines, (line) => {
+        return _.includes(line, _.last(jsdoc.description.split('\n')))
+      });
+
+      // Remove the extra line
+      sourceLines.splice(lastDescriptionLine + 1, 1);
+
+      return fixer.replaceText(jsdocNode, sourceLines.join('\n'));      
+      
+    });
   }
 });

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -7,11 +7,13 @@ const extractParagraphs = (text) => {
 
 const extractSentences = (text) => {
   return text.split(/\.\s*/).filter((sentence) => {
-    return ! /^\s*$/.test(sentence); // Ignore sentences with only whitespaces.
-  }).map((sentence) =>{
-    return sentence + '.'; // Re-add the dot.
+    // Ignore sentences with only whitespaces.
+    return !/^\s*$/.test(sentence);
+  }).map((sentence) => {
+    // Re-add the dot.
+    return sentence + '.';
   });
-}
+};
 
 const isNewLinePrecededByAPeriod = (text) => {
   let lastLineEndsSentence;
@@ -35,7 +37,7 @@ const isCapitalized = (str) => {
 
 const capitalize = (str) => {
   return str.charAt(0).toUpperCase() + str.slice(1);
-}
+};
 
 const validateDescription = (description, report, jsdocNode, sourceCode) => {
   if (!description) {
@@ -44,25 +46,31 @@ const validateDescription = (description, report, jsdocNode, sourceCode) => {
 
   const paragraphs = extractParagraphs(description);
 
-  return _.some(paragraphs, (paragraph, index) => {
-
+  return _.some(paragraphs, (paragraph) => {
     const sentences = extractSentences(paragraph);
 
-    if(_.some(sentences, (sentence, index) => {return !isCapitalized(sentence)})) {
+    if (_.some(sentences, (sentence) => {
+      return !isCapitalized(sentence);
+    })) {
       report('Sentence should start with an uppercase character.', (fixer) => {
         let text = sourceCode.getText(jsdocNode);
-        for (let sentence of sentences.filter((s) => {return !isCapitalized(s)})) {
+
+        for (const sentence of sentences.filter((sentence_) => {
+          return !isCapitalized(sentence_);
+        })) {
           const beginning = sentence.split(/\n/)[0];
+
           text = text.replace(beginning, capitalize(beginning));
         }
+
         return fixer.replaceText(jsdocNode, text);
       });
     }
 
     if (!/\.$/.test(paragraph)) {
       report('Sentence must end with a period.', (fixer) => {
-        let line = _.last(paragraph.split('\n'));
-        let replacement = sourceCode.getText(jsdocNode).replace(line, line + '.');
+        const line = _.last(paragraph.split('\n'));
+        const replacement = sourceCode.getText(jsdocNode).replace(line, line + '.');
 
         return fixer.replaceText(jsdocNode, replacement);
       });
@@ -81,10 +89,10 @@ const validateDescription = (description, report, jsdocNode, sourceCode) => {
 };
 
 export default iterateJsdoc(({
-  sourceCode,  
+  sourceCode,
   jsdoc,
   report,
-  jsdocNode,
+  jsdocNode
 }) => {
   if (validateDescription(jsdoc.description, report, jsdocNode, sourceCode)) {
     return;

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -37,13 +37,6 @@ const capitalize = (str) => {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
-const fixUpperCase = (fixer, paragraph, jsdocNode, sourceCode) => {
-  let line = paragraph.split('\n')[0];
-  let replacement = sourceCode.getText(jsdocNode).replace(line, capitalize(line));
-  
-  return fixer.replaceText(jsdocNode, replacement);
-}
-
 const validateDescription = (description, report, jsdocNode, sourceCode) => {
   if (!description) {
     return false;

--- a/src/rules/requireHyphenBeforeParamDescription.js
+++ b/src/rules/requireHyphenBeforeParamDescription.js
@@ -2,8 +2,10 @@ import _ from 'lodash';
 import iterateJsdoc from '../iterateJsdoc';
 
 export default iterateJsdoc(({
+  sourceCode,
   jsdoc,
-  report
+  reportFix,
+  jsdocNode
 }) => {
   const jsdocTags = _.filter(jsdoc.tags, {
     tag: 'param'
@@ -11,7 +13,11 @@ export default iterateJsdoc(({
 
   _.forEach(jsdocTags, (jsdocTag) => {
     if (jsdocTag.description && !_.startsWith(jsdocTag.description, '-')) {
-      report('There must be a hyphen before @param description.');
+      reportFix('There must be a hyphen before @param description.', (fixer) => {
+        let replacement = sourceCode.getText(jsdocNode).replace(jsdocTag.description, '- ' + jsdocTag.description);
+
+        return fixer.replaceText(jsdocNode, replacement);
+      });
     }
   });
 });

--- a/src/rules/requireHyphenBeforeParamDescription.js
+++ b/src/rules/requireHyphenBeforeParamDescription.js
@@ -14,7 +14,7 @@ export default iterateJsdoc(({
   _.forEach(jsdocTags, (jsdocTag) => {
     if (jsdocTag.description && !_.startsWith(jsdocTag.description, '-')) {
       report('There must be a hyphen before @param description.', (fixer) => {
-        let replacement = sourceCode.getText(jsdocNode).replace(jsdocTag.description, '- ' + jsdocTag.description);
+        const replacement = sourceCode.getText(jsdocNode).replace(jsdocTag.description, '- ' + jsdocTag.description);
 
         return fixer.replaceText(jsdocNode, replacement);
       });

--- a/src/rules/requireHyphenBeforeParamDescription.js
+++ b/src/rules/requireHyphenBeforeParamDescription.js
@@ -4,7 +4,7 @@ import iterateJsdoc from '../iterateJsdoc';
 export default iterateJsdoc(({
   sourceCode,
   jsdoc,
-  reportFix,
+  report,
   jsdocNode
 }) => {
   const jsdocTags = _.filter(jsdoc.tags, {
@@ -13,7 +13,7 @@ export default iterateJsdoc(({
 
   _.forEach(jsdocTags, (jsdocTag) => {
     if (jsdocTag.description && !_.startsWith(jsdocTag.description, '-')) {
-      reportFix('There must be a hyphen before @param description.', (fixer) => {
+      report('There must be a hyphen before @param description.', (fixer) => {
         let replacement = sourceCode.getText(jsdocNode).replace(jsdocTag.description, '- ' + jsdocTag.description);
 
         return fixer.replaceText(jsdocNode, replacement);

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -15,7 +15,15 @@ export default {
         {
           message: 'Invalid JSDoc @param "foo" type "Number".'
         }
-      ]
+      ],
+      output: `
+          /**
+           * @param {number} foo
+           */
+          function quux (foo) {
+
+          }
+      `
     },
     {
       code: `
@@ -29,8 +37,16 @@ export default {
       errors: [
         {
           message: 'Invalid JSDoc @arg "foo" type "Number".'
-        }
-      ]
+        },
+      ],
+      output:  `
+          /**
+           * @arg {number} foo
+           */
+          function quux (foo) {
+
+          }
+      `
     }
   ],
   valid: [

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -37,9 +37,9 @@ export default {
       errors: [
         {
           message: 'Invalid JSDoc @arg "foo" type "Number".'
-        },
+        }
       ],
-      output:  `
+      output: `
           /**
            * @arg {number} foo
            */

--- a/test/rules/assertions/newlineAfterDescription.js
+++ b/test/rules/assertions/newlineAfterDescription.js
@@ -21,7 +21,19 @@ export default {
       ],
       options: [
         'always'
-      ]
+      ],
+      output: `
+          /**
+           * Foo.
+           *
+           * Foo.
+           * 
+           * @foo
+           */
+          function quux () {
+
+          }
+      `
     },
     {
       code: `
@@ -43,7 +55,18 @@ export default {
       ],
       options: [
         'never'
-      ]
+      ],
+      output: `
+          /**
+           * Bar.
+           *
+           * Bar.
+           * @bar
+           */
+          function quux () {
+
+          }
+      `
     }
   ],
   valid: [

--- a/test/rules/assertions/requireDescriptionCompleteSentence.js
+++ b/test/rules/assertions/requireDescriptionCompleteSentence.js
@@ -13,7 +13,7 @@ export default {
       `,
       errors: [
         {
-          message: 'Description must start with an uppercase character.'
+          message: 'Sentence should start with an uppercase character.'
         }
       ],
       output: `
@@ -38,7 +38,7 @@ export default {
       `,
       errors: [
         {
-          message: 'Paragraph must start with an uppercase character.'
+          message: 'Sentence should start with an uppercase character.'
         }
       ], 
       output: `
@@ -63,7 +63,7 @@ export default {
       `,
       errors: [
         {
-          message: 'Description must start with an uppercase character.'
+          message: 'Sentence should start with an uppercase character.'
         }
       ],
       output: `
@@ -127,7 +127,7 @@ export default {
       `,
       errors: [
         {
-          message: 'Description must start with an uppercase character.'
+          message: 'Sentence should start with an uppercase character.'
         }
       ],
       output: `
@@ -154,7 +154,7 @@ export default {
       `,
       errors: [
         {
-          message: 'Description must start with an uppercase character.'
+          message: 'Sentence should start with an uppercase character.'
         }
       ],
       output: `
@@ -164,6 +164,40 @@ export default {
            * @returns Foo.
            */
           function quux (foo) {
+
+          }
+      `
+    },
+    
+    {
+      code: `
+          /**
+           * lorem ipsum dolor sit amet, consectetur adipiscing elit. pellentesque elit diam, 
+           * iaculis eu dignissim sed, ultrices sed nisi. nulla at ligula auctor, consectetur neque sed,
+           * tincidunt nibh. vivamus sit amet vulputate ligula. vivamus interdum elementum nisl,
+           * vitae rutrum tortor semper ut. morbi porta ante vitae dictum fermentum.
+           * proin ut nulla at quam convallis gravida in id elit. sed dolor mauris, blandit quis ante at, 
+           * consequat auctor magna. duis pharetra purus in porttitor mollis.
+           */
+          function longDescription (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Sentence should start with an uppercase character.'
+        }
+      ],
+      output: `
+          /**
+           * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elit diam, 
+           * iaculis eu dignissim sed, ultrices sed nisi. Nulla at ligula auctor, consectetur neque sed,
+           * tincidunt nibh. Vivamus sit amet vulputate ligula. Vivamus interdum elementum nisl,
+           * vitae rutrum tortor semper ut. Morbi porta ante vitae dictum fermentum.
+           * Proin ut nulla at quam convallis gravida in id elit. Sed dolor mauris, blandit quis ante at, 
+           * consequat auctor magna. Duis pharetra purus in porttitor mollis.
+           */
+          function longDescription (foo) {
 
           }
       `

--- a/test/rules/assertions/requireDescriptionCompleteSentence.js
+++ b/test/rules/assertions/requireDescriptionCompleteSentence.js
@@ -15,7 +15,15 @@ export default {
         {
           message: 'Description must start with an uppercase character.'
         }
-      ]
+      ],
+      output: `
+          /**
+           * Foo.
+           */
+          function quux () {
+
+          }
+      `
     },
     {
       code: `
@@ -32,7 +40,17 @@ export default {
         {
           message: 'Paragraph must start with an uppercase character.'
         }
-      ]
+      ], 
+      output: `
+          /**
+           * Foo.
+           *
+           * Foo.
+           */
+          function quux () {
+
+          }
+      `
     },
     {
       code: `
@@ -47,7 +65,15 @@ export default {
         {
           message: 'Description must start with an uppercase character.'
         }
-      ]
+      ],
+      output: `
+          /**
+           * Тест.
+           */
+          function quux () {
+
+          }
+      `
     },
     {
       code: `
@@ -62,7 +88,15 @@ export default {
         {
           message: 'Sentence must end with a period.'
         }
-      ]
+      ],
+      output: `
+          /**
+           * Foo.
+           */
+          function quux () {
+
+          }
+      `
     },
     {
       code: `
@@ -95,7 +129,17 @@ export default {
         {
           message: 'Description must start with an uppercase character.'
         }
-      ]
+      ],
+      output: `
+          /**
+           * Foo.
+           *
+           * @param foo Foo.
+           */
+          function quux (foo) {
+
+          }
+      `
     },
     {
       code: `
@@ -112,7 +156,17 @@ export default {
         {
           message: 'Description must start with an uppercase character.'
         }
-      ]
+      ],
+      output: `
+          /**
+           * Foo.
+           *
+           * @returns Foo.
+           */
+          function quux (foo) {
+
+          }
+      `
     }
   ],
   valid: [

--- a/test/rules/assertions/requireDescriptionCompleteSentence.js
+++ b/test/rules/assertions/requireDescriptionCompleteSentence.js
@@ -40,7 +40,7 @@ export default {
         {
           message: 'Sentence should start with an uppercase character.'
         }
-      ], 
+      ],
       output: `
           /**
            * Foo.
@@ -168,7 +168,6 @@ export default {
           }
       `
     },
-    
     {
       code: `
           /**

--- a/test/rules/assertions/requireHyphenBeforeParamDescription.js
+++ b/test/rules/assertions/requireHyphenBeforeParamDescription.js
@@ -15,7 +15,15 @@ export default {
         {
           message: 'There must be a hyphen before @param description.'
         }
-      ]
+      ],
+      output: `
+          /**
+           * @param foo - Foo.
+           */
+          function quux () {
+
+          }
+      `
     }
   ],
   valid: [


### PR DESCRIPTION
This pull request introduces two major changes:

* Fixers. The following rules are now fixable with `--fix`. This is Issue #53 
    * check-types
    * newline-after-description
    * require-description-complete-sentence
    * require-hyphen-before-param-description
* require-description-complete-sentence now checks that after a period there's an upper case letter. Before, it only checked the beginning of paragraphs.

All this new behavior is tested.