### PR TITLE
Fixes the require-description-complete-sentence docs

### DIFF
--- a/.README/rules/require-description-complete-sentence.md
+++ b/.README/rules/require-description-complete-sentence.md
@@ -3,9 +3,9 @@
 Requires that block description and tag description are written in complete sentences, i.e.,
 
 * Description must start with an uppercase alphabetical character.
-* Paragraph must start with an uppercase alphabetical character.
+* Paragraphs must start with an uppercase alphabetical character.
 * Sentences must end with a period.
-* Every line that starts with a lowercase character must be preceded by a line ending the sentence.
+* Every line in a paragraph (except the first) which starts with an uppercase character must be preceded by a line ending with a period.
 
 |||
 |---|---|


### PR DESCRIPTION
Updates the documentation to match the [code](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/src/rules/requireDescriptionCompleteSentence.js#L82). Notably, the doc used to say "lowercase" while the code is looking for "uppercase".