### PR TITLE
Improvements for RequireDescriptionCompleteSentence

### DIFF
--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -102,7 +102,7 @@ export default iterateJsdoc(({
   }
 
   const tags = _.filter(jsdoc.tags, (tag) => {
-    return _.includes(['param', 'returns'], tag.tag);
+    return _.includes(['param', 'arg', 'argument', 'returns', 'return'], tag.tag);
   });
 
   _.some(tags, (tag) => {

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -6,13 +6,21 @@ const extractParagraphs = (text) => {
 };
 
 const extractSentences = (text) => {
-  return text.split(/[.?!:](?:\s+|$)/).filter((sentence) => {
+  return text
+
+    // Remove all {} tags.
+    .replace(/\{[\s\S]*?\}\s*/g, '')
+    .split(/[.?!:](?:\s+|$)/)
+
     // Ignore sentences with only whitespaces.
-    return !/^\s*$/.test(sentence);
-  }).map((sentence) => {
+    .filter((sentence) => {
+      return !/^\s*$/.test(sentence);
+    })
+
     // Re-add the dot.
-    return sentence + '.';
-  });
+    .map((sentence) => {
+      return sentence + '.';
+    });
 };
 
 const isNewLinePrecededByAPeriod = (text) => {

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -6,7 +6,7 @@ const extractParagraphs = (text) => {
 };
 
 const extractSentences = (text) => {
-  return text.split(/\.\s+|\.$/).filter((sentence) => {
+  return text.split(/[.?!:](?:\s+|$)/).filter((sentence) => {
     // Ignore sentences with only whitespaces.
     return !/^\s*$/.test(sentence);
   }).map((sentence) => {
@@ -52,7 +52,7 @@ const validateDescription = (description, report, jsdocNode, sourceCode) => {
     const fix = (fixer) => {
       let text = sourceCode.getText(jsdocNode);
 
-      if (!_.endsWith(paragraph, '.')) {
+      if (!/[.:?!]$/.test(paragraph)) {
         const line = _.last(paragraph.split('\n'));
 
         text = text.replace(line, line + '.');
@@ -75,7 +75,7 @@ const validateDescription = (description, report, jsdocNode, sourceCode) => {
       report('Sentence should start with an uppercase character.', fix);
     }
 
-    if (!/\.$/.test(paragraph)) {
+    if (!/[.!?]$/.test(paragraph)) {
       report('Sentence must end with a period.', fix);
 
       return true;

--- a/test/rules/assertions/requireDescriptionCompleteSentence.js
+++ b/test/rules/assertions/requireDescriptionCompleteSentence.js
@@ -174,6 +174,32 @@ export default {
     {
       code: `
           /**
+           * {@see Foo.bar} buz
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Sentence should start with an uppercase character.'
+        },
+        {
+          message: 'Sentence must end with a period.'
+        }
+      ],
+      output: `
+          /**
+           * {@see Foo.bar} Buz.
+           */
+          function quux (foo) {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
            * Foo.
            *
            * @returns {number} foo
@@ -413,7 +439,7 @@ export default {
     {
       code: `
           /**
-           * Foo. {@see Math.sin}
+           * Foo. {@see Math.sin}.
            */
           function quux () {
 

--- a/test/rules/assertions/requireDescriptionCompleteSentence.js
+++ b/test/rules/assertions/requireDescriptionCompleteSentence.js
@@ -260,6 +260,78 @@ export default {
 
           }
       `
+    },
+    {
+      code: `
+          /**
+           * @arg {number} foo - Foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Sentence must end with a period.'
+        }
+      ],
+      output: `
+          /**
+           * @arg {number} foo - Foo.
+           */
+          function quux (foo) {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @argument {number} foo - Foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Sentence must end with a period.'
+        }
+      ],
+      output: `
+          /**
+           * @argument {number} foo - Foo.
+           */
+          function quux (foo) {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @return {number} foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Sentence should start with an uppercase character.'
+        },
+        {
+          message: 'Sentence must end with a period.'
+        }
+      ],
+      output: `
+          /**
+           * @return {number} Foo.
+           */
+          function quux (foo) {
+
+          }
+      `
     }
   ],
   valid: [

--- a/test/rules/assertions/requireDescriptionCompleteSentence.js
+++ b/test/rules/assertions/requireDescriptionCompleteSentence.js
@@ -409,6 +409,32 @@ export default {
 
           }
       `
+    },
+    {
+      code: `
+          /**
+           * Foo. {@see Math.sin}
+           */
+          function quux () {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * Foo?
+           * 
+           * Bar!
+           * 
+           * Baz:
+           *   1. Foo.
+           *   2. Bar.
+           */
+          function quux () {
+
+          }
+      `
     }
   ]
 };


### PR DESCRIPTION
This pull request introduces the following fixes/enhancements:

1. Added support for `@return`, `@arg` and `@argument` which are synonyms of `@returns`, `@param`.

2. Account for `?`, `!` and `:` as punctuation marks that end the sentence. See #16 .

3. Ignored all `{}` tags inside description. e.g. `{@see Class.Function}`.