### PR TITLE
Added a type parser and two new rules for types in JSdoc comments

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -28,6 +28,7 @@ This table maps the rules between `eslint-plugin-jsdoc` and `jscs-jsdoc`.
 | [`require-returns-description`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-returns-description) | [`requireReturnDescription`](https://github.com/jscs-dev/jscs-jsdoc#requirereturndescription) |
 | [`require-returns-type`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-returns-type) | [`requireReturnTypes`](https://github.com/jscs-dev/jscs-jsdoc#requirereturntypes) |
 | [`valid-types`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-valid-types) | N/A |
+| [`no-undefined-types`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-no-undefined-types) | N/A |
 | N/A | [`checkReturnTypes`](https://github.com/jscs-dev/jscs-jsdoc#checkreturntypes) |
 | N/A | [`checkRedundantParams`](https://github.com/jscs-dev/jscs-jsdoc#checkredundantparams) |
 | N/A | [`checkReturnTypes`](https://github.com/jscs-dev/jscs-jsdoc#checkreturntypes) |
@@ -70,6 +71,7 @@ Finally, enable all of the rules that you would like to use.
         "jsdoc/check-tag-names": 1,
         "jsdoc/check-types": 1,
         "jsdoc/newline-after-description": 1,
+        "jsdoc/no-undefined-types": 1,
         "jsdoc/require-description-complete-sentence": 1,
         "jsdoc/require-example": 1,
         "jsdoc/require-hyphen-before-param-description": 1,
@@ -128,6 +130,7 @@ Use `settings.jsdoc.additionalTagNames` to configure additional, allowed JSDoc t
 {"gitdown": "include", "file": "./rules/check-tag-names.md"}
 {"gitdown": "include", "file": "./rules/check-types.md"}
 {"gitdown": "include", "file": "./rules/newline-after-description.md"}
+{"gitdown": "include", "file": "./rules/no-undefined-types.md"}
 {"gitdown": "include", "file": "./rules/require-description-complete-sentence.md"}
 {"gitdown": "include", "file": "./rules/require-example.md"}
 {"gitdown": "include", "file": "./rules/require-hyphen-before-param-description.md"}

--- a/.README/README.md
+++ b/.README/README.md
@@ -27,6 +27,7 @@ This table maps the rules between `eslint-plugin-jsdoc` and `jscs-jsdoc`.
 | [`require-param-type`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-param-type) | [`requireParamTypes`](https://github.com/jscs-dev/jscs-jsdoc#requireparamtypes) |
 | [`require-returns-description`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-returns-description) | [`requireReturnDescription`](https://github.com/jscs-dev/jscs-jsdoc#requirereturndescription) |
 | [`require-returns-type`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-returns-type) | [`requireReturnTypes`](https://github.com/jscs-dev/jscs-jsdoc#requirereturntypes) |
+| [`valid-types`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-valid-types) | N/A |
 | N/A | [`checkReturnTypes`](https://github.com/jscs-dev/jscs-jsdoc#checkreturntypes) |
 | N/A | [`checkRedundantParams`](https://github.com/jscs-dev/jscs-jsdoc#checkredundantparams) |
 | N/A | [`checkReturnTypes`](https://github.com/jscs-dev/jscs-jsdoc#checkreturntypes) |
@@ -77,7 +78,8 @@ Finally, enable all of the rules that you would like to use.
         "jsdoc/require-param-name": 1,
         "jsdoc/require-param-type": 1,
         "jsdoc/require-returns-description": 1,
-        "jsdoc/require-returns-type": 1
+        "jsdoc/require-returns-type": 1,
+        "jsdoc/valid-types": 1
     }
 }
 ```
@@ -135,3 +137,4 @@ Use `settings.jsdoc.additionalTagNames` to configure additional, allowed JSDoc t
 {"gitdown": "include", "file": "./rules/require-param-type.md"}
 {"gitdown": "include", "file": "./rules/require-returns-description.md"}
 {"gitdown": "include", "file": "./rules/require-returns-type.md"}
+{"gitdown": "include", "file": "./rules/valid-types.md"}

--- a/.README/rules/no-undefined-types.md
+++ b/.README/rules/no-undefined-types.md
@@ -1,0 +1,13 @@
+### `no-undefined-types`
+
+Checks that types in jsdoc comments are defined. This can be used to check unimported types.
+
+When enabling this rule, types in jsdoc comments will resolve as used variables, i.e. will not be marked as unused by `no-unused-vars`.
+
+
+|||
+|---|---|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Tags|`param`, `returns`|
+
+<!-- assertions noUndefinedTypes -->

--- a/.README/rules/valid-types.md
+++ b/.README/rules/valid-types.md
@@ -1,0 +1,10 @@
+### `valid-types`
+
+Requires all types to be valid JSDoc or Closure compiler types without syntax errors.
+
+|||
+|---|---|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Tags|`param`, `returns`|
+
+<!-- assertions validTypes -->

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.26.0",
     "chai": "^4.1.2",
-    "eslint": "^4.7.2",
+    "eslint": "^4.19.1",
     "eslint-config-canonical": "^9.3.1",
     "gitdown": "^2.5.1",
     "globby": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "dependencies": {
     "comment-parser": "^0.4.2",
+    "jsdoctypeparser": "^2.0.0-alpha-8",
     "lodash": "^4.17.4"
   },
   "description": "JSDoc linting rules for ESLint.",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
+/* eslint-disable import/max-dependencies */
 import checkParamNames from './rules/checkParamNames';
 import checkTagNames from './rules/checkTagNames';
 import checkTypes from './rules/checkTypes';
 import newlineAfterDescription from './rules/newlineAfterDescription';
+import noUndefinedTypes from './rules/noUndefinedTypes';
 import requireDescriptionCompleteSentence from './rules/requireDescriptionCompleteSentence';
 import requireExample from './rules/requireExample';
 import requireHyphenBeforeParamDescription from './rules/requireHyphenBeforeParamDescription';
@@ -21,6 +23,7 @@ export default {
         'jsdoc/check-tag-names': 'warn',
         'jsdoc/check-types': 'warn',
         'jsdoc/newline-after-description': 'warn',
+        'jsdoc/no-undefined-types': 'warn',
         'jsdoc/require-description-complete-sentence': 'off',
         'jsdoc/require-example': 'off',
         'jsdoc/require-hyphen-before-param-description': 'off',
@@ -39,6 +42,7 @@ export default {
     'check-tag-names': checkTagNames,
     'check-types': checkTypes,
     'newline-after-description': newlineAfterDescription,
+    'no-undefined-types': noUndefinedTypes,
     'require-description-complete-sentence': requireDescriptionCompleteSentence,
     'require-example': requireExample,
     'require-hyphen-before-param-description': requireHyphenBeforeParamDescription,
@@ -55,6 +59,7 @@ export default {
     'check-tag-names': 'off',
     'check-types': 'off',
     'newline-after-description': 'off',
+    'no-undefined-types': 'off',
     'require-description-complete-sentence': 'off',
     'require-example': 'off',
     'require-hyphen-before-param-description': 'off',

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import requireParamDescription from './rules/requireParamDescription';
 import requireParamType from './rules/requireParamType';
 import requireReturnsDescription from './rules/requireReturnsDescription';
 import requireReturnsType from './rules/requireReturnsType';
+import validTypes from './rules/validTypes';
 
 export default {
   configs: {
@@ -28,7 +29,8 @@ export default {
         'jsdoc/require-param-name': 'warn',
         'jsdoc/require-param-type': 'warn',
         'jsdoc/require-returns-description': 'warn',
-        'jsdoc/require-returns-type': 'warn'
+        'jsdoc/require-returns-type': 'warn',
+        'jsdoc/valid-types': 'warn'
       }
     }
   },
@@ -45,7 +47,8 @@ export default {
     'require-param-name': requireParamName,
     'require-param-type': requireParamType,
     'require-returns-description': requireReturnsDescription,
-    'require-returns-type': requireReturnsType
+    'require-returns-type': requireReturnsType,
+    'valid-types': validTypes
   },
   rulesConfig: {
     'check-param-names': 'off',
@@ -60,6 +63,7 @@ export default {
     'require-param-name': 'off',
     'require-param-type': 'off',
     'require-returns-description': 'off',
-    'require-returns-type': 'off'
+    'require-returns-type': 'off',
+    'valid-types': 'off'
   }
 };

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -1,0 +1,32 @@
+import _ from 'lodash';
+import {parse as parseType, traverse} from 'jsdoctypeparser';
+import iterateJsdoc from '../iterateJsdoc';
+
+const extraTypes = ['string', 'number', 'boolean', 'any'];
+
+export default iterateJsdoc(({
+  context,
+  jsdoc,
+  report,
+  sourceCode
+}) => {
+  const scopeManager = sourceCode.scopeManager;
+  const globalScope = scopeManager.isModule() ? scopeManager.globalScope.childScopes[0] : scopeManager.globalScope;
+  const definedTypes = globalScope.variables.map((variable) => {
+    return variable.name;
+  }).concat(extraTypes);
+
+  _.forEach(jsdoc.tags, (tag) => {
+    const parsedType = parseType(tag.type);
+
+    traverse(parsedType, (node) => {
+      if (node.type === 'NAME') {
+        if (!_.includes(definedTypes, node.name)) {
+          report('The type \'' + node.name + '\' is undefined.');
+        } else if (!_.includes(extraTypes, node.name)) {
+          context.markVariableAsUsed(node.name);
+        }
+      }
+    });
+  });
+});

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -1,0 +1,22 @@
+import _ from 'lodash';
+import iterateJsdoc from '../iterateJsdoc';
+import {parse} from 'jsdoctypeparser';
+
+export default iterateJsdoc(({
+  jsdoc,
+  jsdocNode,
+  sourceCode,
+  report
+}) => {
+  _.forEach(jsdoc.tags, (tag) => {
+    if (tag.type) {
+      try {
+        parse(tag.type);
+      } catch (error) {
+        if (error.name === 'SyntaxError') {
+          report('Syntax error in type: ' + tag.type);
+        }
+      }
+    }
+  });
+});

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -1,11 +1,9 @@
 import _ from 'lodash';
-import iterateJsdoc from '../iterateJsdoc';
 import {parse} from 'jsdoctypeparser';
+import iterateJsdoc from '../iterateJsdoc';
 
 export default iterateJsdoc(({
   jsdoc,
-  jsdocNode,
-  sourceCode,
   report
 }) => {
   _.forEach(jsdoc.tags, (tag) => {

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -47,6 +47,58 @@ export default {
 
           }
       `
+    },
+    {
+      code: `
+          /**
+           * @param {(Number|string|Boolean)=} foo
+           */
+          function quux (foo, bar, baz) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "Number".'
+        },
+        {
+          message: 'Invalid JSDoc @param "foo" type "Boolean".'
+        }
+      ],
+      output: `
+          /**
+           * @param {(number|string|boolean)=} foo
+           */
+          function quux (foo, bar, baz) {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @param {Array<Number|String>} foo
+           */
+          function quux (foo, bar, baz) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "Number".'
+        },
+        {
+          message: 'Invalid JSDoc @param "foo" type "String".'
+        }
+      ],
+      output: `
+          /**
+           * @param {Array<number|string>} foo
+           */
+          function quux (foo, bar, baz) {
+
+          }
+      `
     }
   ],
   valid: [
@@ -68,6 +120,16 @@ export default {
            * @arg {number} foo
            * @arg {Bar} bar
            * @arg {*} baz
+           */
+          function quux (foo, bar, baz) {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @param {(number|string|boolean)=} foo
            */
           function quux (foo, bar, baz) {
 

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -91,6 +91,21 @@ export default {
       globals: {
         HisType: true
       }
+    },
+    {
+      code: `
+        /**
+         * @typedef {Object} hello
+         * @property {string} a - a.
+         */
+
+        /**
+         * @param {hello} foo
+         */
+        function quux(foo) {
+          
+        }
+      `
     }
   ]
 };

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -1,0 +1,97 @@
+/* eslint-disable no-restricted-syntax */
+
+export default {
+  invalid: [
+    {
+      code: `
+          /**
+           * @param {strnig} foo - Bar.
+           */
+          function quux(foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'The type \'strnig\' is undefined.'
+        }
+      ],
+      rules: {
+        'no-undef': 'error'
+      }
+    }
+  ],
+  valid: [
+    {
+      code: `
+          /**
+           * @param {string} foo - Bar.
+           */
+          function quux(foo) {
+
+          }
+      `
+    },
+    {
+      code: `
+          class MyClass {}
+
+          /**
+           * @param {MyClass} foo - Bar.
+           */
+          function quux(foo) {
+            console.log(foo);
+          }
+
+          quux(0);
+      `,
+      rules: {
+        'no-unused-vars': 'error'
+      }
+    },
+    {
+      code: `
+        const MyType = require('my-library').MyType;
+
+        /**
+         * @param {MyType} foo - Bar.
+         */
+          function quux(foo) {
+
+        }
+      `
+    },
+    {
+      code: `
+        import {MyType} from 'my-library';
+
+        /**
+         * @param {MyType} foo - Bar.
+         */
+          function quux(foo) {
+
+        }
+      `,
+      parserOptions: {
+        sourceType: 'module'
+      }
+    },
+    {
+      code: `
+        /*global MyType*/
+
+        /**
+         * @param {MyType} foo - Bar.
+         * @param {HisType} bar - Foo.
+         */
+          function quux(foo, bar) {
+
+        }
+      `,
+      globals: {
+        HisType: true
+      }
+    }
+  ]
+};
+

--- a/test/rules/assertions/validTypes.js
+++ b/test/rules/assertions/validTypes.js
@@ -1,0 +1,53 @@
+/* eslint-disable no-restricted-syntax */
+
+export default {
+  invalid: [
+    {
+      code: `
+          /**
+           * @param {Array<string} foo
+           */
+          function quux() {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Syntax error in type: Array<string'
+        }
+      ]
+    }
+  ],
+  valid: [
+    {
+      code: `
+          /**
+           * @param {Array<string>} foo
+           */
+          function quux() {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @param {string} foo
+           */
+          function quux() {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @param foo
+           */
+          function quux() {
+            
+          }
+      `
+    }
+  ]
+};

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -11,6 +11,7 @@ _.forEach([
   'check-tag-names',
   'check-types',
   'newline-after-description',
+  'no-undefined-types',
   'require-description-complete-sentence',
   'require-example',
   'require-hyphen-before-param-description',
@@ -30,13 +31,13 @@ _.forEach([
   const assertions = require('./assertions/' + _.camelCase(ruleName));
 
   assertions.invalid = _.map(assertions.invalid, (assertion) => {
-    assertion.parserOptions = parserOptions;
+    assertion.parserOptions = _.defaultsDeep(assertion.parserOptions, parserOptions);
 
     return assertion;
   });
 
   assertions.valid = _.map(assertions.valid, (assertion) => {
-    assertion.parserOptions = parserOptions;
+    assertion.parserOptions = _.defaultsDeep(assertion.parserOptions, parserOptions);
 
     return assertion;
   });

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -19,7 +19,8 @@ _.forEach([
   'require-param-name',
   'require-param-type',
   'require-returns-description',
-  'require-returns-type'
+  'require-returns-type',
+  'valid-types'
 ], (ruleName) => {
   const parserOptions = {
     ecmaVersion: 6


### PR DESCRIPTION
## Solves

* #52 
* #44 

## Summary of changes:

* Added [Kuniwak/jsdoctypeparser](/Kuniwak/jsdoctypeparser) as a runtime dependency, for parsing types inside JSdoc tags.
* `check-types` now checks for inner types such as `Array<String>`. This is a **Breaking** change.
* Added rule `valid-types` that checks there are no syntax errors when parsing the type. example of error: `@param {Array<string} foo`
* Added rule `no-undefined-types` that checks all the types are defined in the scope, and marks types in JSdoc comments as used, so imports for types will not be marked as unused by `no-unused-vars`

**This is a breaking change**