### PR TITLE
fix: no-undefined-types crashing on type syntax error 

### DIFF
--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -35,7 +35,14 @@ export default iterateJsdoc(({
     .concat(typedefDeclarations);
 
   _.forEach(jsdoc.tags, (tag) => {
-    const parsedType = parseType(tag.type);
+    let parsedType;
+
+    try {
+      parsedType = parseType(tag.type);
+    } catch (error) {
+      // On syntax error, will be handled by valid-types.
+      return;
+    }
 
     traverse(parsedType, (node) => {
       if (node.type === 'NAME') {

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -106,6 +106,16 @@ export default {
           
         }
       `
+    },
+    {
+      code: `
+        /**
+         * @param {Array<syntaxError} foo
+         */
+        function quux(foo) {
+          
+        }
+      `
     }
   ]
 };


### PR DESCRIPTION
Crashed on, for example,

```javascript
/**
 * @param {Array<}
 */
```

Sorry for noticing this only after the release