### PR TITLE
fix: no-undefined-types crashing when jsdoc has no tags

### DIFF
--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -19,7 +19,7 @@ export default iterateJsdoc(({
     })
     .map(parseComment)
     .flatMap((doc) => {
-      return doc.tags.filter((tag) => {
+      return (doc.tags || []).filter((tag) => {
         return tag.tag === 'typedef';
       });
     })


### PR DESCRIPTION
I've manually built and ran it on a large code base, so this should be the last crash to fix. sorry for the hassle.