### PR TITLE
Add an `allowOverrideWithoutParam` setting for `jsdoc/require-param`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ JSDoc linting rules for ESLint.
     * [Settings](#eslint-plugin-jsdoc-settings)
         * [Alias Preference](#eslint-plugin-jsdoc-settings-alias-preference)
         * [Additional Tag Names](#eslint-plugin-jsdoc-settings-additional-tag-names)
+        * [Allow `@override` Without Accompanying `@param` Tags](#eslint-plugin-jsdoc-settings-allow-override-without-param)
     * [Rules](#eslint-plugin-jsdoc-rules)
         * [`check-param-names`](#eslint-plugin-jsdoc-rules-check-param-names)
         * [`check-tag-names`](#eslint-plugin-jsdoc-rules-check-tag-names)
@@ -143,6 +144,22 @@ Use `settings.jsdoc.additionalTagNames` to configure additional, allowed JSDoc t
             "additionalTagNames": {
                 "customTags": ["define", "extends", "record"]
             }
+        }
+    }
+}
+```
+
+<a name="eslint-plugin-jsdoc-settings-allow-override-without-param"></a>
+### Allow `@override` Without Accompanying `@param` Tags
+
+Use `settings.jsdoc.allowOverrideWithoutParam` to indicate whether the `@override` tag can be used without accompanying `@param` tag(s). The default value is `false`. The format of the configuration is as follows:
+
+```json
+{
+    "rules": {},
+    "settings": {
+        "jsdoc": {
+            "allowOverrideWithoutParam": true
         }
     }
 }
@@ -998,6 +1015,14 @@ function quux (foo, bar) {
 
 }
 // Message: Missing JSDoc @param "bar" declaration.
+
+/**
+ * @override
+ */
+function quux (foo) {
+
+}
+// Message: Missing JSDoc @arg "foo" declaration.
 ```
 
 The following patterns are not considered problems:
@@ -1023,6 +1048,22 @@ function quux (foo) {
 function quux (foo) {
 
 }
+
+/**
+ * @override
+ * @param foo
+ */
+function quux (foo) {
+
+}
+
+/**
+ * @override
+ */
+function quux (foo) {
+
+}
+// Settings: { "allowOverrideWithoutParam": true }
 ```
 
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import commentParser from 'comment-parser';
 import jsdocUtils from './jsdocUtils';
 
-const curryUtils = (functionNode, jsdoc, tagNamePreference, additionalTagNames) => {
+const curryUtils = (functionNode, jsdoc, tagNamePreference, additionalTagNames, allowOverrideWithoutParam) => {
   const utils = {};
 
   utils.getFunctionParameterNames = () => {
@@ -27,6 +27,10 @@ const curryUtils = (functionNode, jsdoc, tagNamePreference, additionalTagNames) 
 
   utils.hasTag = (name) => {
     return jsdocUtils.hasTag(jsdoc, name);
+  };
+
+  utils.isOverrideAllowedWithoutParam = () => {
+    return allowOverrideWithoutParam;
   };
 
   return utils;
@@ -58,6 +62,7 @@ export default (iterator) => {
     const sourceCode = context.getSourceCode();
     const tagNamePreference = _.get(context, 'settings.jsdoc.tagNamePreference') || {};
     const additionalTagNames = _.get(context, 'settings.jsdoc.additionalTagNames') || {};
+    const allowOverrideWithoutParam = Boolean(_.get(context, 'settings.jsdoc.allowOverrideWithoutParam'));
 
     const checkJsdoc = (functionNode) => {
       const jsdocNode = sourceCode.getJSDocComment(functionNode);
@@ -82,7 +87,7 @@ export default (iterator) => {
         }
       };
 
-      const utils = curryUtils(functionNode, jsdoc, tagNamePreference, additionalTagNames);
+      const utils = curryUtils(functionNode, jsdoc, tagNamePreference, additionalTagNames, allowOverrideWithoutParam);
 
       iterator({
         context,

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -13,6 +13,12 @@ export default iterateJsdoc(({
     return;
   }
 
+  // When settings.jsdoc.allowOverrideWithoutParam is true, override implies that all documentation is inherited.
+  // See https://github.com/gajus/eslint-plugin-jsdoc/issues/73
+  if (utils.hasTag('override') && utils.isOverrideAllowedWithoutParam()) {
+    return;
+  }
+
   _.some(functionParameterNames, (functionParameterName, index) => {
     const jsdocParameterName = jsdocParameterNames[index];
 

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -53,6 +53,21 @@ export default {
           message: 'Missing JSDoc @param "bar" declaration.'
         }
       ]
+    },
+    {
+      code: `
+          /**
+           * @override
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "foo" declaration.'
+        }
+      ]
     }
   ],
   valid: [
@@ -90,6 +105,32 @@ export default {
           tagNamePreference: {
             param: 'arg'
           }
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @override
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @override
+           */
+          function quux (foo) {
+
+          }
+      `,
+      settings: {
+        jsdoc: {
+          allowOverrideWithoutParam: true
         }
       }
     }


### PR DESCRIPTION
This PR adds a new boolean setting called `allowOverrideWithoutParam` with a default value of `false`. 

- When the setting is `true`, the `@override` tag can be used without any accompanying `@param` tag(s).
- When the setting is omitted (or explicitly set to `false`), the original behavior remains, and `jsdoc/require-param` will flag an error when it finds an `@override` tag without the correct accompanying `@param` tags.

This was required due to the recommendations of the [Google JS style guide](https://google.github.io/styleguide/jsguide.html) ([here](https://google.github.io/styleguide/jsguide.html#features-functions-parameters), [here](https://google.github.io/styleguide/jsguide.html#jsdoc-method-and-function-comments), and [here](https://google.github.io/styleguide/jsguide.html#appendices-notes-about-standard-closure-compiler-annotations)). See #73 and https://github.com/ampproject/amphtml/issues/15297 for more context.

Fixes #73
Fixes #20 
Follow up to #24 
