### PR TITLE
Upgrade eslint peer dep to actually required minimum

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "main": "./dist/index.js",
   "name": "eslint-plugin-jsdoc",
   "peerDependencies": {
-    "eslint": ">=0.8.0"
+    "eslint": ">=4.14.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes: https://github.com/gajus/eslint-plugin-jsdoc/issues/79

Through just a little brute forcing, I was able to find the required minimum version, which I'm bumping here in the peerdep.

As a result of this being the effective case right now, only "fixing" the package manager expectations, I'd like to consider this a semver MINOR.