### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "http://gajus.com"
   },
   "dependencies": {
-    "comment-parser": "^0.4.2",
+    "comment-parser": "^0.5.0",
     "jsdoctypeparser": "^2.0.0-alpha-8",
     "lodash": "^4.17.4"
   },
@@ -18,13 +18,14 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.26.0",
     "chai": "^4.1.2",
-    "eslint": "^4.19.1",
-    "eslint-config-canonical": "^9.3.1",
+    "eslint": "^5.4.0",
+    "eslint-config-canonical": "^12.0.0",
     "gitdown": "^2.5.1",
     "glob": "^7.1.2",
-    "globby": "^6.1.0",
-    "mocha": "^3.5.3",
-    "semantic-release": "^8.0.3"
+    "globby": "^8.0.1",
+    "marked": "^0.4.0",
+    "mocha": "^5.2.0",
+    "semantic-release": "^15.9.9"
   },
   "engines": {
     "node": ">=4"

--- a/src/bin/readme-assertions.js
+++ b/src/bin/readme-assertions.js
@@ -13,8 +13,8 @@ const trimCode = (code) => {
 
   const indentSize = indendation ? indendation[0].length : 0;
 
-  lines = _.map(lines, (line, i) => {
-    if (i === 0) {
+  lines = _.map(lines, (line, index) => {
+    if (index === 0) {
       return line;
     }
 
@@ -75,11 +75,10 @@ const updateDocuments = (assertions) => {
 
     if (!ruleAssertions) {
       throw new Error('No assertions available for rule "' + ruleName + '".');
-
-      return assertionsBlock;
     }
 
-    return 'The following patterns are considered problems:\n\n```js\n' + ruleAssertions.invalid.join('\n\n') + '\n```\n\nThe following patterns are not considered problems:\n\n```js\n' + ruleAssertions.valid.join('\n\n') + '\n```\n';
+    return 'The following patterns are considered problems:\n\n```js\n' + ruleAssertions.invalid.join('\n\n') +
+      '\n```\n\nThe following patterns are not considered problems:\n\n```js\n' + ruleAssertions.valid.join('\n\n') + '\n```\n';
   });
 
   fs.writeFileSync(readmeDocumentPath, documentBody);

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -41,7 +41,8 @@ const validateParameterNamesDeep = (targetTagName : string, jsdocParameterNames 
       const pathRootNodeName = jsdocParameterName.slice(0, jsdocParameterName.indexOf('.'));
 
       if (pathRootNodeName !== lastRealParameter) {
-        report('@' + targetTagName + ' path declaration ("' + jsdocParameterName + '") root node name ("' + pathRootNodeName + '") does not match previous real parameter name ("' + lastRealParameter + '").');
+        report('@' + targetTagName + ' path declaration ("' + jsdocParameterName + '") root node name ("' +
+          pathRootNodeName + '") does not match previous real parameter name ("' + lastRealParameter + '").');
 
         return true;
       }

--- a/src/rules/checkTypes.js
+++ b/src/rules/checkTypes.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import {parse, traverse, publish} from 'jsdoctypeparser';
-import iterateJsdoc from './../iterateJsdoc';
+import iterateJsdoc from '../iterateJsdoc';
 
 let targetTags = [
   'class',

--- a/test/jsdocUtils.js
+++ b/test/jsdocUtils.js
@@ -3,7 +3,7 @@
 import {
   expect
 } from 'chai';
-import jsdocUtils from './../src/jsdocUtils';
+import jsdocUtils from '../src/jsdocUtils';
 
 describe('jsdocUtils', () => {
   describe('getPreferredTagName()', () => {


### PR DESCRIPTION
Super minor thing, just keeping on the update treadmill (all but one are devDeps). None are in range of the existing semver looseness. Added `marked` to resolve a peer dep warning (in dev).

An argument could certainly be made for keeping eslint at the version [I've found is actually the minimum peer version](https://github.com/gajus/eslint-plugin-jsdoc/pull/80). Maintainer's choice, will update if asked.

I consider this update to be semver PATCH (or MINOR).