### PR TITLE
Add support for reporting individual lines of jsdoc infraction

### DIFF
--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -36,10 +36,8 @@ const curryUtils = (functionNode, jsdoc, tagNamePreference, additionalTagNames, 
   return utils;
 };
 
-export const parseComment = (commentNode) => {
+export const parseComment = (commentNode, indent) => {
   // Preserve JSDoc block start/end indentation.
-  const indent = _.repeat(' ', commentNode.loc.start.column);
-
   return commentParser(indent + '/*' + commentNode.value + indent + '*/', {
     // @see https://github.com/yavorskiy/comment-parser/issues/21
     parsers: [
@@ -73,14 +71,29 @@ export default (iterator) => {
 
       const indent = _.repeat(' ', jsdocNode.loc.start.column);
 
-      const jsdoc = parseComment(jsdocNode);
+      const jsdoc = parseComment(jsdocNode, indent);
 
-      const report = (message, fixer = null) => {
+      const report = (message, fixer = null, jsdocLine = null) => {
+        let loc;
+
+        if (jsdocLine) {
+          const lineNumber = jsdocNode.loc.start.line + jsdocLine.line;
+
+          loc = {
+            end: {line: lineNumber},
+            start: {line: lineNumber}
+          };
+        }
         if (fixer === null) {
-          context.report(jsdocNode, message);
+          context.report({
+            loc,
+            message,
+            node: jsdocNode
+          });
         } else {
           context.report({
             fix: fixer,
+            loc,
             message,
             node: jsdocNode
           });


### PR DESCRIPTION
Fixes (at least in part): https://github.com/gajus/eslint-plugin-jsdoc/issues/48

I've always been a (little) annoyed that the jsdoc eslint warnings are noted at the top of the comment block rather than on the impacted lines. This allows rules to be able to opt into this by passing in a parsed comment line.

I'm unsure how to test this, based on the complexity of the functions. I can demonstrate this working in a forthcoming PR, however.

I consider this change to be semver MINOR.