### PR TITLE
[WIP] Improvement: Check param names at depth (destructure)

### DIFF
--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -1,26 +1,32 @@
 import _ from 'lodash';
 import tagNames from './tagNames';
 
+const getFunctionParameterName = (param : Object) : string => {
+  if (_.has(param, 'name')) {
+    return param.name;
+  }
+
+  if (_.has(param, 'left.name')) {
+    return param.left.name;
+  }
+
+  if (param.type === 'ObjectPattern' || _.get(param, 'left.type') === 'ObjectPattern') {
+    return '<ObjectPattern>';
+  }
+
+  if (param.type === 'RestElement') {
+    return param.argument.name;
+  }
+
+  if (param.type === 'ObjectPattern' || param.type === 'Property') {
+    return param.key.name;
+  }
+
+  throw new Error('Unsupported function signature format.');
+};
+
 const getFunctionParameterNames = (functionNode : Object) : Array<string> => {
-  return _.map(functionNode.params, (param) => {
-    if (_.has(param, 'name')) {
-      return param.name;
-    }
-
-    if (_.has(param, 'left.name')) {
-      return param.left.name;
-    }
-
-    if (param.type === 'ObjectPattern' || _.get(param, 'left.type') === 'ObjectPattern') {
-      return '<ObjectPattern>';
-    }
-
-    if (param.type === 'RestElement') {
-      return param.argument.name;
-    }
-
-    throw new Error('Unsupported function signature format.');
-  });
+  return _.map(functionNode.params, getFunctionParameterName);
 };
 
 /**
@@ -83,6 +89,7 @@ const hasTag = (jsdoc : Object, targetTagName : string) : boolean => {
 };
 
 export default {
+  getFunctionParameterName,
   getFunctionParameterNames,
   getJsdocParameterNames,
   getJsdocParameterNamesDeep,

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -1,72 +1,110 @@
 import _ from 'lodash';
 import iterateJsdoc from '../iterateJsdoc';
+import { getFunctionParameterName } from '../jsdocUtils';
 
-const validateParameterNames = (targetTagName : string, functionParameterNames : Array<string>, jsdocParameterNames : Array<string>, report : Function) => {
-  return _.some(jsdocParameterNames, (jsdocParameterName, index) => {
-    const functionParameterName = functionParameterNames[index];
-
-    if (!functionParameterName) {
-      report('@' + targetTagName + ' "' + jsdocParameterName + '" does not match an existing function parameter.');
-
-      return true;
+function getTreeItemByPath(tree : Array<Object>, path : string = '') {
+  let currentTree = tree || [];
+  const currentPath = [];
+  let finalItem;
+  const pathParts = path.split('.');
+  pathParts.forEach((pathItem) => {
+    currentPath.push(pathItem);
+    for (let i = 0; i < currentTree.length; ++ i) {
+      const item = currentTree[i];
+      if (item.name === path) {
+        finalItem = item;
+      }
+      if (item.name === currentPath.join('.')) {
+        currentTree = item.children;
+        break;
+      }
     }
-
-    if (functionParameterName === '<ObjectPattern>') {
-      return false;
-    }
-
-    if (functionParameterName !== jsdocParameterName) {
-      report('Expected @' + targetTagName + ' names to be "' + functionParameterNames.join(', ') + '". Got "' + jsdocParameterNames.join(', ') + '".');
-
-      return true;
-    }
-
-    return false;
   });
+  return finalItem;
+}
+
+function parsePathName(path : string) {
+  const pathParts = path.split('.');
+  const name = pathParts.pop();
+  const basePath = pathParts.join('.');
+
+  return { name, basePath };
+}
+
+// Function capable of parsing different AST items including function definitions and destructured objects
+function getIterableNames(functionASTItem) {
+  switch (functionASTItem.type) {
+    case 'ArrowFunctionExpression':
+    case 'FunctionDeclaration':
+    case 'FunctionExpression':
+      return functionASTItem.params;
+    case 'ObjectPattern':
+      return functionASTItem.properties;
+    default:
+      return [];
+  }
+}
+
+const validateParameterNames = (targetTagName : string, report : Function) => {
+  return function validateParameterNamesBound(functionNode: Object, nestedParams : Array<string>, pathPrefix : string) {
+    const iterableParameters = getIterableNames(functionNode);
+    iterableParameters.forEach((functionParameter, index) => {
+      if (!nestedParams[index]) {
+        // Doesn't seem to be the job of this rule
+        // report(`@${targetTagName} "${functionParameterName}" does not have corresponding definition.`);
+        return;
+      }
+      const jsdocParameterName = nestedParams[index].name;
+      const jsdocParameterPath = jsdocParameterName;
+      const functionParameterName = getFunctionParameterName(functionParameter);
+      const functionParameterPath = pathPrefix ? `${pathPrefix}.${functionParameterName}` : functionParameterName;
+
+      if (functionParameterName === '<ObjectPattern>') {
+        validateParameterNamesBound(functionParameter, nestedParams[index].children, jsdocParameterPath);
+        return;
+      }
+
+      if (functionParameterPath !== jsdocParameterPath) {
+        report(`Expected @${targetTagName} name to be "${functionParameterPath}". Got "${jsdocParameterPath}".`, null, nestedParams[index]);
+      }
+    });
+    if (nestedParams.length > iterableParameters.length) {
+      for (let i = iterableParameters.length; i < nestedParams.length; i++) {
+        report(`@${targetTagName} "${nestedParams[i].name}" does not match an existing function parameter.`, null, nestedParams[i]);
+      }
+    }
+  };
 };
 
-const validateParameterNamesDeep = (targetTagName : string, jsdocParameterNames : Array<string>, report : Function) => {
-  let lastRealParameter;
+const nestParametersWithValidation = (targetTagName : string, jsdocTags: Array<Object> = [], report : Function) => {
+  const errorPrefix = `@${targetTagName} path declaration`;
 
-  return _.some(jsdocParameterNames, (jsdocParameterName) => {
-    const isPropertyPath = _.includes(jsdocParameterName, '.');
+  return jsdocTags.filter((item) => item.tag === targetTagName).reduce((acc, jsdocLine) => {
+    const isPropertyPath = jsdocLine.name.includes('.');
 
     if (isPropertyPath) {
-      if (!lastRealParameter) {
-        report('@' + targetTagName + ' path declaration ("' + jsdocParameterName + '") appears before any real parameter.');
+        const { basePath } = parsePathName(jsdocLine.name);
+        const parent = getTreeItemByPath(acc, basePath);
 
-        return true;
-      }
-
-      const pathRootNodeName = jsdocParameterName.slice(0, jsdocParameterName.indexOf('.'));
-
-      if (pathRootNodeName !== lastRealParameter) {
-        report('@' + targetTagName + ' path declaration ("' + jsdocParameterName + '") root node name ("' +
-          pathRootNodeName + '") does not match previous real parameter name ("' + lastRealParameter + '").');
-
-        return true;
-      }
+        if (parent) {
+          parent.children.push(Object.assign({}, jsdocLine, { children: [] }));
+        } else {
+          report(`${errorPrefix} "${jsdocLine.name}" requires previous definition of "${basePath}".`, null, jsdocLine);
+        }
     } else {
-      lastRealParameter = jsdocParameterName;
+      acc.push(Object.assign({}, jsdocLine, { children: [] }));
     }
-
-    return false;
-  });
+    return acc;
+  }, []);
 };
 
 export default iterateJsdoc(({
+  functionNode,
+  jsdoc,
   report,
   utils
 }) => {
-  const functionParameterNames = utils.getFunctionParameterNames();
-  const jsdocParameterNames = utils.getJsdocParameterNames();
-  const jsdocParameterNamesDeep = utils.getJsdocParameterNamesDeep();
   const targetTagName = utils.getPreferredTagName('param');
-  const isError = validateParameterNames(targetTagName, functionParameterNames, jsdocParameterNames, report);
-
-  if (isError) {
-    return;
-  }
-
-  validateParameterNamesDeep(targetTagName, jsdocParameterNamesDeep, report);
+  const nestedParams = nestParametersWithValidation(targetTagName, jsdoc.tags, report);
+  validateParameterNames(targetTagName, report)(functionNode, nestedParams);
 });

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -13,7 +13,7 @@ export default {
       `,
       errors: [
         {
-          message: 'Expected @param names to be "foo". Got "Foo".'
+          message: 'Expected @param name to be "foo". Got "Foo".'
         }
       ]
     },
@@ -28,7 +28,7 @@ export default {
       `,
       errors: [
         {
-          message: 'Expected @arg names to be "foo". Got "Foo".'
+          message: 'Expected @arg name to be "foo". Got "Foo".'
         }
       ],
       settings: {
@@ -50,7 +50,7 @@ export default {
       `,
       errors: [
         {
-          message: 'Expected @param names to be "foo". Got "Foo".'
+          message: 'Expected @param name to be "foo". Got "Foo".'
         }
       ]
     },
@@ -65,7 +65,7 @@ export default {
       `,
       errors: [
         {
-          message: '@param path declaration ("Foo.Bar") appears before any real parameter.'
+          message: '@param path declaration "Foo.Bar" requires previous definition of "Foo".'
         }
       ]
     },
@@ -81,7 +81,7 @@ export default {
       `,
       errors: [
         {
-          message: '@param path declaration ("Foo.Bar") root node name ("Foo") does not match previous real parameter name ("foo").'
+          message: '@param path declaration "Foo.Bar" requires previous definition of "Foo".'
         }
       ]
     },
@@ -98,7 +98,10 @@ export default {
       `,
       errors: [
         {
-          message: 'Expected @param names to be "bar, foo". Got "foo, bar".'
+          message: 'Expected @param name to be "bar". Got "foo".'
+        },
+        {
+          message: 'Expected @param name to be "foo". Got "bar".'
         }
       ]
     },
@@ -115,6 +118,39 @@ export default {
       errors: [
         {
           message: '@param "bar" does not match an existing function parameter.'
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * @param first
+           * @param baz
+           */
+          function quux ({foo, bar}) {
+
+          }
+      `,
+      errors: [
+        {
+          message: '@param "baz" does not match an existing function parameter.'
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * @param first
+           * @param first.foo
+           * @param first.baz
+           */
+          function quux ({foo, bar}) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Expected @param name to be "first.bar". Got "first.baz".'
         }
       ]
     }
@@ -203,6 +239,18 @@ export default {
 
           }
       `
+    },
+    {
+      code: `
+          /**
+           * @param first
+           * @param first.foo
+           * @param first.bar
+           */
+          function quux ({foo, bar}) {
+
+          }
+      `,
     }
   ]
 };


### PR DESCRIPTION
Fixes: https://github.com/gajus/eslint-plugin-jsdoc/issues/11
Prereq: https://github.com/gajus/eslint-plugin-jsdoc/pull/82

Meta: Certainly expect some conversation on this topic, not to be merged straight away. I am also still working on some edge cases.

This PR attempts to upgrade the "checkParamNames" rule to consider destructured props in a function argument, requiring the same level of jsdoc consistency that regular props require right now.

It accomplishes this by moving from the string versions of the jsdoc and function params to their most highly structured forms -- AST node for function params, and parsed array for jsdoc. We then build a pseudo AST for the latter, so that we can recurse into arbitrary depths of destructures.

One possible complaint at the moment would be that the AST building and the validation logic (and thus reporting) are comingled. It should be possible to separate these, but then there would need to be a step to compare the flat structure to the tree... seems not worth the effort.

I know there are currently issues with static definitions (though I don't know why...), and I haven't tested on greater depth or with combinations of destructures and either renames or defaults. All of which I'd consider requirements for this to land. Additionally, I would expect this to either need to hide behind an opt-in flag as a possible minor (though with this substantial of a rewrite, I can't guarantee perfect parity), OR a major release (still possibly flagged).