### PR TITLE
Set line locations when reporting violations

### DIFF
--- a/src/rules/checkTagNames.js
+++ b/src/rules/checkTagNames.js
@@ -11,10 +11,10 @@ export default iterateJsdoc(({
       const preferredTagName = utils.getPreferredTagName(jsdocTag.tag);
 
       if (preferredTagName !== jsdocTag.tag) {
-        report('Invalid JSDoc tag (preference). Replace "' + jsdocTag.tag + '" JSDoc tag with "' + preferredTagName + '".');
+        report('Invalid JSDoc tag (preference). Replace "' + jsdocTag.tag + '" JSDoc tag with "' + preferredTagName + '".', null, jsdocTag);
       }
     } else {
-      report('Invalid JSDoc tag name "' + jsdocTag.tag + '".');
+      report('Invalid JSDoc tag name "' + jsdocTag.tag + '".', null, jsdocTag);
     }
   });
 });

--- a/src/rules/checkTypes.js
+++ b/src/rules/checkTypes.js
@@ -80,7 +80,7 @@ export default iterateJsdoc(({
           return fixer.replaceText(jsdocNode, sourceCode.getText(jsdocNode).replace('{' + jsdocTag.type + '}', '{' + fixedType + '}'));
         };
 
-        report('Invalid JSDoc @' + jsdocTag.tag + ' "' + jsdocTag.name + '" type "' + invalidType + '".', fix);
+        report('Invalid JSDoc @' + jsdocTag.tag + ' "' + jsdocTag.name + '" type "' + invalidType + '".', fix, jsdocTag);
       });
     }
   });

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -52,7 +52,7 @@ export default iterateJsdoc(({
     traverse(parsedType, (node) => {
       if (node.type === 'NAME') {
         if (!_.includes(definedTypes, node.name)) {
-          report('The type \'' + node.name + '\' is undefined.');
+          report('The type \'' + node.name + '\' is undefined.', null, tag);
         } else if (!_.includes(extraTypes, node.name)) {
           context.markVariableAsUsed(node.name);
         }

--- a/src/rules/requireHyphenBeforeParamDescription.js
+++ b/src/rules/requireHyphenBeforeParamDescription.js
@@ -17,7 +17,7 @@ export default iterateJsdoc(({
         const replacement = sourceCode.getText(jsdocNode).replace(jsdocTag.description, '- ' + jsdocTag.description);
 
         return fixer.replaceText(jsdocNode, replacement);
-      });
+      }, jsdocTag);
     }
   });
 });

--- a/src/rules/requireParamDescription.js
+++ b/src/rules/requireParamDescription.js
@@ -14,7 +14,7 @@ export default iterateJsdoc(({
 
   _.forEach(jsdocParameters, (jsdocParameter) => {
     if (!jsdocParameter.description) {
-      report('Missing JSDoc @' + targetTagName + ' "' + jsdocParameter.name + '" description.');
+      report('Missing JSDoc @' + targetTagName + ' "' + jsdocParameter.name + '" description.', null, jsdocParameter);
     }
   });
 });

--- a/src/rules/requireParamName.js
+++ b/src/rules/requireParamName.js
@@ -14,7 +14,7 @@ export default iterateJsdoc(({
 
   _.forEach(jsdocParameters, (jsdocParameter) => {
     if (jsdocParameter.tag && jsdocParameter.name === '') {
-      report('There must be an identifier after @param ' + (jsdocParameter.type === '' ? 'type' : 'tag') + '.');
+      report('There must be an identifier after @param ' + (jsdocParameter.type === '' ? 'type' : 'tag') + '.', null, jsdocParameter);
     }
   });
 });

--- a/src/rules/requireParamType.js
+++ b/src/rules/requireParamType.js
@@ -14,7 +14,7 @@ export default iterateJsdoc(({
 
   _.forEach(jsdocParameters, (jsdocParameter) => {
     if (!jsdocParameter.type) {
-      report('Missing JSDoc @' + targetTagName + ' "' + jsdocParameter.name + '" type.');
+      report('Missing JSDoc @' + targetTagName + ' "' + jsdocParameter.name + '" type.', null, jsdocParameter);
     }
   });
 });

--- a/src/rules/requireReturnsDescription.js
+++ b/src/rules/requireReturnsDescription.js
@@ -14,7 +14,7 @@ export default iterateJsdoc(({
 
   _.forEach(jsdocTags, (jsdocTag) => {
     if (!jsdocTag.description) {
-      report('Missing JSDoc @' + targetTagName + ' description.');
+      report('Missing JSDoc @' + targetTagName + ' description.', null, jsdocTag);
     }
   });
 });

--- a/src/rules/requireReturnsType.js
+++ b/src/rules/requireReturnsType.js
@@ -14,7 +14,7 @@ export default iterateJsdoc(({
 
   _.forEach(jsdocTags, (jsdocTag) => {
     if (!jsdocTag.type) {
-      report('Missing JSDoc @' + targetTagName + ' type.');
+      report('Missing JSDoc @' + targetTagName + ' type.', null, jsdocTag);
     }
   });
 });

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -12,7 +12,7 @@ export default iterateJsdoc(({
         parse(tag.type);
       } catch (error) {
         if (error.name === 'SyntaxError') {
-          report('Syntax error in type: ' + tag.type);
+          report('Syntax error in type: ' + tag.type, null, tag);
         }
       }
     }

--- a/test/rules/assertions/checkTagNames.js
+++ b/test/rules/assertions/checkTagNames.js
@@ -18,6 +18,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Invalid JSDoc tag name "Param".'
         }
       ]
@@ -33,6 +34,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Invalid JSDoc tag name "foo".'
         }
       ]
@@ -48,6 +50,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Invalid JSDoc tag (preference). Replace "arg" JSDoc tag with "param".'
         }
       ]
@@ -63,6 +66,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Invalid JSDoc tag (preference). Replace "param" JSDoc tag with "arg".'
         }
       ],
@@ -85,6 +89,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Invalid JSDoc tag name "bar".'
         }
       ]
@@ -100,6 +105,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Invalid JSDoc tag name "baz".'
         }
       ],
@@ -123,6 +129,7 @@ export default {
         `,
       errors: [
         {
+          line: 4,
           message: 'Invalid JSDoc tag name "baz".'
         }
       ],

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -13,6 +13,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Invalid JSDoc @param "foo" type "Number".'
         }
       ],
@@ -36,6 +37,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Invalid JSDoc @arg "foo" type "Number".'
         }
       ],
@@ -59,9 +61,11 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Invalid JSDoc @param "foo" type "Number".'
         },
         {
+          line: 3,
           message: 'Invalid JSDoc @param "foo" type "Boolean".'
         }
       ],
@@ -85,9 +89,11 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Invalid JSDoc @param "foo" type "Number".'
         },
         {
+          line: 3,
           message: 'Invalid JSDoc @param "foo" type "String".'
         }
       ],

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -13,6 +13,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'The type \'strnig\' is undefined.'
         }
       ],

--- a/test/rules/assertions/requireHyphenBeforeParamDescription.js
+++ b/test/rules/assertions/requireHyphenBeforeParamDescription.js
@@ -13,6 +13,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'There must be a hyphen before @param description.'
         }
       ],

--- a/test/rules/assertions/requireParamDescription.js
+++ b/test/rules/assertions/requireParamDescription.js
@@ -13,6 +13,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Missing JSDoc @param "foo" description.'
         }
       ]
@@ -28,6 +29,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Missing JSDoc @arg "foo" description.'
         }
       ],

--- a/test/rules/assertions/requireParamName.js
+++ b/test/rules/assertions/requireParamName.js
@@ -13,6 +13,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'There must be an identifier after @param type.'
         }
       ]
@@ -28,6 +29,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'There must be an identifier after @param tag.'
         }
       ]

--- a/test/rules/assertions/requireParamType.js
+++ b/test/rules/assertions/requireParamType.js
@@ -13,6 +13,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Missing JSDoc @param "foo" type.'
         }
       ]
@@ -28,6 +29,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Missing JSDoc @arg "foo" type.'
         }
       ],

--- a/test/rules/assertions/requireReturnsDescription.js
+++ b/test/rules/assertions/requireReturnsDescription.js
@@ -13,6 +13,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Missing JSDoc @returns description.'
         }
       ]
@@ -28,6 +29,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Missing JSDoc @return description.'
         }
       ],

--- a/test/rules/assertions/requireReturnsType.js
+++ b/test/rules/assertions/requireReturnsType.js
@@ -13,6 +13,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Missing JSDoc @returns type.'
         }
       ]
@@ -28,6 +29,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Missing JSDoc @returns type.'
         }
       ]
@@ -43,6 +45,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Missing JSDoc @return type.'
         }
       ],

--- a/test/rules/assertions/validTypes.js
+++ b/test/rules/assertions/validTypes.js
@@ -13,6 +13,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Syntax error in type: Array<string'
         }
       ]


### PR DESCRIPTION
Follows up on https://github.com/gajus/eslint-plugin-jsdoc/pull/82

This attempts to update all rules to attribute errors directly to the offending line rather than to the whole jsdoc block. There are several rules where specific lines are unknown (like the absence of a thing), or hard to figure (the last line of a description, or will be addressed later (checkParamNames).

I committed by rule changed, just for completeness.

I would suggest this change is MINOR