### PR TITLE
package.json linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
     "name": "Gajus Kuizinas",
     "url": "http://gajus.com"
   },
+  "contributors": [
+    "Brett Zamir"
+  ],
   "dependencies": {
     "comment-parser": "^0.5.0",
     "jsdoctypeparser": "^2.0.0-alpha-8",
@@ -49,6 +52,8 @@
   "peerDependencies": {
     "eslint": ">=4.14.0"
   },
+  "homepage": "https://github.com/gajus/eslint-plugin-jsdoc",
+  "bugs": "https://github.com/gajus/eslint-plugin-jsdoc/issues",
   "repository": {
     "type": "git",
     "url": "https://github.com/gajus/eslint-plugin-jsdoc"


### PR DESCRIPTION
- Linting (package.json): Add linter-recommended contributors, homepage, bugs (used on npmjs.com)

I'm not itching to get myself added as a contributor, but the linter linter-package-json-validator flags it as a recommended field. It probably helps though to advertise more contributors. If nothing else, it would be nice to have it as an empty array so it can stop flagging things...