### PR TITLE
Change deprecated Mocha `compilers` flag to `require`

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "build": "rm -fr ./dist && NODE_ENV=production babel ./src --out-dir ./dist --copy-files --source-maps",
     "create-readme": "gitdown ./.README/README.md --output-file ./README.md && npm run add-assertions",
     "lint": "eslint ./src ./test",
-    "test": "mocha --recursive --compilers js:@babel/register"
+    "test": "mocha --recursive --require @babel/register"
   },
   "version": "1.0.0"
 }


### PR DESCRIPTION
- Testing (Update): Deprecated Mocha --compilers flag; see https://github.com/mochajs/mocha/wiki/compilers-deprecation