### PR TITLE
Optionally loosen `requireParam` when implements/augments/extends present on tag or parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1350,6 +1350,82 @@ function quux (foo) {
 
 }
 // Message: Missing JSDoc @param "foo" declaration.
+
+/**
+ * @implements
+ */
+function quux (foo) {
+
+}
+// Message: Missing JSDoc @param "foo" declaration.
+
+/**
+ * @augments
+ */
+function quux (foo) {
+
+}
+// Message: Missing JSDoc @param "foo" declaration.
+
+/**
+ * @extends
+ */
+function quux (foo) {
+
+}
+// Message: Missing JSDoc @param "foo" declaration.
+
+/**
+ * @override
+ */
+class A {
+  /**
+    *
+    */
+  quux (foo) {
+
+  }
+}
+// Message: Missing JSDoc @param "foo" declaration.
+
+/**
+ * @implements
+ */
+class A {
+  /**
+   *
+   */
+  quux (foo) {
+
+  }
+}
+// Message: Missing JSDoc @param "foo" declaration.
+
+/**
+ * @augments
+ */
+class A {
+  /**
+   *
+   */
+  quux (foo) {
+
+  }
+}
+// Message: Missing JSDoc @param "foo" declaration.
+
+/**
+ * @extends
+ */
+class A {
+  /**
+   *
+   */
+  quux (foo) {
+
+  }
+}
+// Message: Missing JSDoc @param "foo" declaration.
 ```
 
 The following patterns are not considered problems:
@@ -1392,6 +1468,154 @@ function quux (foo) {
 
 }
 // Settings: {"jsdoc":{"allowOverrideWithoutParam":true}}
+
+/**
+ * @implements
+ */
+function quux (foo) {
+
+}
+// Settings: {"jsdoc":{"allowImplementsWithoutParam":true}}
+
+/**
+ * @implements
+ * @param foo
+ */
+function quux (foo) {
+
+}
+
+/**
+ * @augments
+ */
+function quux (foo) {
+
+}
+// Settings: {"jsdoc":{"allowAugmentsExtendsWithoutParam":true}}
+
+/**
+ * @augments
+ * @param foo
+ */
+function quux (foo) {
+
+}
+
+/**
+ * @extends
+ */
+function quux (foo) {
+
+}
+// Settings: {"jsdoc":{"allowAugmentsExtendsWithoutParam":true}}
+
+/**
+ * @extends
+ * @param foo
+ */
+function quux (foo) {
+
+}
+
+/**
+ * @override
+ */
+class A {
+  /**
+  * @param foo
+  */
+  quux (foo) {
+
+  }
+}
+
+/**
+ * @override
+ */
+class A {
+  /**
+   *
+   */
+  quux (foo) {
+
+  }
+}
+// Settings: {"jsdoc":{"allowOverrideWithoutParam":true}}
+
+/**
+ * @implements
+ */
+class A {
+  /**
+   *
+   */
+  quux (foo) {
+
+  }
+}
+// Settings: {"jsdoc":{"allowImplementsWithoutParam":true}}
+
+/**
+ * @implements
+ */
+class A {
+  /**
+   * @param foo
+   */
+  quux (foo) {
+
+  }
+}
+
+/**
+ * @augments
+ */
+class A {
+  /**
+   *
+   */
+  quux (foo) {
+
+  }
+}
+// Settings: {"jsdoc":{"allowAugmentsExtendsWithoutParam":true}}
+
+/**
+ * @augments
+ */
+class A {
+  /**
+   * @param foo
+   */
+  quux (foo) {
+
+  }
+}
+
+/**
+ * @extends
+ */
+class A {
+  /**
+   *
+   */
+  quux (foo) {
+
+  }
+}
+// Settings: {"jsdoc":{"allowAugmentsExtendsWithoutParam":true}}
+
+/**
+ * @extends
+ */
+class A {
+  /**
+   * @param foo
+   */
+  quux (foo) {
+
+  }
+}
 ```
 
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -2,7 +2,11 @@ import _ from 'lodash';
 import commentParser from 'comment-parser';
 import jsdocUtils from './jsdocUtils';
 
-const curryUtils = (functionNode, jsdoc, tagNamePreference, additionalTagNames, allowOverrideWithoutParam) => {
+const curryUtils = (
+  functionNode, jsdoc, tagNamePreference, additionalTagNames,
+  allowOverrideWithoutParam, allowImplementsWithoutParam,
+  allowAugmentsExtendsWithoutParam
+) => {
   const utils = {};
 
   utils.getFunctionParameterNames = () => {
@@ -33,6 +37,14 @@ const curryUtils = (functionNode, jsdoc, tagNamePreference, additionalTagNames, 
     return allowOverrideWithoutParam;
   };
 
+  utils.isImplementsAllowedWithoutParam = () => {
+    return allowImplementsWithoutParam;
+  };
+
+  utils.isAugmentsExtendsAllowedWithoutParam = () => {
+    return allowAugmentsExtendsWithoutParam;
+  };
+
   return utils;
 };
 
@@ -61,6 +73,8 @@ export default (iterator) => {
     const tagNamePreference = _.get(context, 'settings.jsdoc.tagNamePreference') || {};
     const additionalTagNames = _.get(context, 'settings.jsdoc.additionalTagNames') || {};
     const allowOverrideWithoutParam = Boolean(_.get(context, 'settings.jsdoc.allowOverrideWithoutParam'));
+    const allowImplementsWithoutParam = Boolean(_.get(context, 'settings.jsdoc.allowImplementsWithoutParam'));
+    const allowAugmentsExtendsWithoutParam = Boolean(_.get(context, 'settings.jsdoc.allowAugmentsExtendsWithoutParam'));
 
     const checkJsdoc = (functionNode) => {
       const jsdocNode = sourceCode.getJSDocComment(functionNode);
@@ -100,7 +114,11 @@ export default (iterator) => {
         }
       };
 
-      const utils = curryUtils(functionNode, jsdoc, tagNamePreference, additionalTagNames, allowOverrideWithoutParam);
+      const utils = curryUtils(
+        functionNode, jsdoc, tagNamePreference, additionalTagNames,
+        allowOverrideWithoutParam, allowImplementsWithoutParam,
+        allowAugmentsExtendsWithoutParam
+      );
 
       iterator({
         context,

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import iterateJsdoc from '../iterateJsdoc';
 
+// eslint-disable-next-line complexity
 export default iterateJsdoc(({
   report,
   utils
@@ -15,19 +16,20 @@ export default iterateJsdoc(({
 
   // When settings.jsdoc.allowOverrideWithoutParam is true, override implies that all documentation is inherited.
   // See https://github.com/gajus/eslint-plugin-jsdoc/issues/73
-  if (utils.hasTag('override') && utils.isOverrideAllowedWithoutParam()) {
+  if ((utils.hasTag('override') || utils.classHasTag('override')) && utils.isOverrideAllowedWithoutParam()) {
     return;
   }
 
   // When settings.jsdoc.allowImplementsWithoutParam is true, implements implies that all documentation is inherited.
   // See https://github.com/gajus/eslint-plugin-jsdoc/issues/100
-  if (utils.hasTag('implements') && utils.isImplementsAllowedWithoutParam()) {
+  if ((utils.hasTag('implements') || utils.classHasTag('implements')) && utils.isImplementsAllowedWithoutParam()) {
     return;
   }
 
   // When settings.jsdoc.allowAugmentsExtendsWithoutParam is true, augments or extends implies that all documentation is inherited.
   // See https://github.com/gajus/eslint-plugin-jsdoc/issues/100
-  if ((utils.hasTag('augments') || utils.hasTag('extends')) && utils.isAugmentsExtendsAllowedWithoutParam()) {
+  if ((utils.hasTag('augments') || utils.hasTag('extends') ||
+    utils.classHasTag('augments') || utils.classHasTag('extends')) && utils.isAugmentsExtendsAllowedWithoutParam()) {
     return;
   }
 

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -19,6 +19,18 @@ export default iterateJsdoc(({
     return;
   }
 
+  // When settings.jsdoc.allowImplementsWithoutParam is true, implements implies that all documentation is inherited.
+  // See https://github.com/gajus/eslint-plugin-jsdoc/issues/100
+  if (utils.hasTag('implements') && utils.isImplementsAllowedWithoutParam()) {
+    return;
+  }
+
+  // When settings.jsdoc.allowAugmentsExtendsWithoutParam is true, augments or extends implies that all documentation is inherited.
+  // See https://github.com/gajus/eslint-plugin-jsdoc/issues/100
+  if ((utils.hasTag('augments') || utils.hasTag('extends')) && utils.isAugmentsExtendsAllowedWithoutParam()) {
+    return;
+  }
+
   _.some(functionParameterNames, (functionParameterName, index) => {
     const jsdocParameterName = jsdocParameterNames[index];
 

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -111,6 +111,86 @@ export default {
           message: 'Missing JSDoc @param "foo" declaration.'
         }
       ]
+    },
+    {
+      code: `
+          /**
+           * @override
+           */
+          class A {
+            /**
+              *
+              */
+            quux (foo) {
+
+            }
+          }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "foo" declaration.'
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * @implements
+           */
+          class A {
+            /**
+             *
+             */
+            quux (foo) {
+
+            }
+          }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "foo" declaration.'
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * @augments
+           */
+          class A {
+            /**
+             *
+             */
+            quux (foo) {
+
+            }
+          }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "foo" declaration.'
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * @extends
+           */
+          class A {
+            /**
+             *
+             */
+            quux (foo) {
+
+            }
+          }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "foo" declaration.'
+        }
+      ]
     }
   ],
   valid: [
@@ -252,6 +332,146 @@ export default {
            */
           function quux (foo) {
 
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @override
+           */
+          class A {
+            /**
+            * @param foo
+            */
+            quux (foo) {
+
+            }
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @override
+           */
+          class A {
+            /**
+             *
+             */
+            quux (foo) {
+
+            }
+          }
+      `,
+      settings: {
+        jsdoc: {
+          allowOverrideWithoutParam: true
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @implements
+           */
+          class A {
+            /**
+             *
+             */
+            quux (foo) {
+
+            }
+          }
+      `,
+      settings: {
+        jsdoc: {
+          allowImplementsWithoutParam: true
+        }
+      }
+    },
+    {
+      code: `
+        /**
+         * @implements
+         */
+        class A {
+          /**
+           * @param foo
+           */
+          quux (foo) {
+
+          }
+        }
+      `
+    },
+    {
+      code: `
+          /**
+           * @augments
+           */
+          class A {
+            /**
+             *
+             */
+            quux (foo) {
+
+            }
+          }
+      `,
+      settings: {
+        jsdoc: {
+          allowAugmentsExtendsWithoutParam: true
+        }
+      }
+    },
+    {
+      code: `
+        /**
+         * @augments
+         */
+        class A {
+          /**
+           * @param foo
+           */
+          quux (foo) {
+
+          }
+        }
+      `
+    },
+    {
+      code: `
+          /**
+           * @extends
+           */
+          class A {
+            /**
+             *
+             */
+            quux (foo) {
+
+            }
+          }
+      `,
+      settings: {
+        jsdoc: {
+          allowAugmentsExtendsWithoutParam: true
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @extends
+           */
+          class A {
+            /**
+             * @param foo
+             */
+            quux (foo) {
+
+            }
           }
       `
     }

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -66,6 +66,51 @@ export default {
           message: 'Missing JSDoc @param "foo" declaration.'
         }
       ]
+    },
+    {
+      code: `
+          /**
+           * @implements
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "foo" declaration.'
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * @augments
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "foo" declaration.'
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * @extends
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "foo" declaration.'
+        }
+      ]
     }
   ],
   valid: [
@@ -131,6 +176,84 @@ export default {
           allowOverrideWithoutParam: true
         }
       }
+    },
+    {
+      code: `
+          /**
+           * @implements
+           */
+          function quux (foo) {
+
+          }
+      `,
+      settings: {
+        jsdoc: {
+          allowImplementsWithoutParam: true
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @implements
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @augments
+           */
+          function quux (foo) {
+
+          }
+      `,
+      settings: {
+        jsdoc: {
+          allowAugmentsExtendsWithoutParam: true
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @augments
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @extends
+           */
+          function quux (foo) {
+
+          }
+      `,
+      settings: {
+        jsdoc: {
+          allowAugmentsExtendsWithoutParam: true
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @extends
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `
     }
   ]
 };


### PR DESCRIPTION
I wasn't sure whether to add them as settings rather than rule-specific options, but I followed your pattern.