### PR TITLE
Peer (dev) deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "chai": "^4.2.0",
     "eslint": "^5.9.0",
     "eslint-config-canonical": "^14.0.0",
+    "eslint-plugin-node": "^8.0.0",
+    "eslint-plugin-standard": "^4.0.0",
     "gitdown": "^2.5.5",
     "glob": "^7.1.3",
     "globby": "^8.0.1",


### PR DESCRIPTION
- Add expected peer dependencies for eslint-config-standard (through eslint-config-canonical) (warnings showing during local install)