### PR TITLE
`check-examples` rule

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -14,6 +14,7 @@ This table maps the rules between `eslint-plugin-jsdoc` and `jscs-jsdoc`.
 
 | `eslint-plugin-jsdoc` | `jscs-jsdoc` |
 | --- | --- |
+| [`check-examples`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-examples) | N/A |
 | [`check-param-names`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-param-names) | [`checkParamNames`](https://github.com/jscs-dev/jscs-jsdoc#checkparamnames) |
 | [`check-tag-names`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-tag-names) | N/A ~ [`checkAnnotations`](https://github.com/jscs-dev/jscs-jsdoc#checkannotations) |
 | [`check-types`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-types) | [`checkTypes`](https://github.com/jscs-dev/jscs-jsdoc#checktypes) |
@@ -68,6 +69,7 @@ Finally, enable all of the rules that you would like to use.
 ```json
 {
     "rules": {
+        "jsdoc/check-examples": 1,
         "jsdoc/check-param-names": 1,
         "jsdoc/check-tag-names": 1,
         "jsdoc/check-types": 1,
@@ -108,7 +110,6 @@ Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a
 }
 ```
 
-
 ### Additional Tag Names
 
 Use `settings.jsdoc.additionalTagNames` to configure additional, allowed JSDoc tags. The format of the configuration is as follows:
@@ -141,8 +142,83 @@ Use `settings.jsdoc.allowOverrideWithoutParam` to indicate whether the `@overrid
 }
 ```
 
+### Settings to Configure `check-examples`
+
+The settings below all impact the `check-examples` rule and default to
+no-op/false except for `eslintrcForExamples` which defaults to `true`.
+
+JSDoc specs use of an optional `<caption>` element at the beginning of
+`@example`. The following setting requires its use.
+
+* `settings.jsdoc.captionRequired` - Require `<caption>` at beginning
+  of any `@example`
+
+JSDoc does not specify a formal means for delimiting code blocks within
+`@example` (it uses generic syntax highlighting techniques for its own
+syntax highlighting). The following settings determine whether a given
+`@example` tag will have the `check-examples` checks applied to it:
+
+* `settings.jsdoc.exampleCodeRegex` - Regex which whitelists lintable
+  examples. If a parenthetical group is used, the first one will be used,
+  so you may wish to use `(?:...)` groups where you do not wish the
+  first such group treated as one to include. If no parenthetical group
+  exists or matches, the whole matching expression will be used.
+  An example might be ````"^```(?:js|javascript)([\\s\\S]*)```$"````
+  to only match explicitly fenced JavaScript blocks.
+* `settings.jsdoc.rejectExampleCodeRegex` - Regex blacklist which rejects
+  non-lintable examples (has priority over `exampleCodeRegex`). An example
+  might be ```"^`"``` to avoid linting fenced blocks which may indicate
+  a non-JavaScript language.
+
+If neither is in use, all examples will be matched. Note also that even if
+`settings.jsdoc.captionRequired` is not set, any initial `<caption>`
+will be stripped out before doing the regex matching.
+
+The following settings determine which individual ESLint rules will be
+applied to the JavaScript found within the `@example` tags (as determined
+to be applicable by the above regex settings). They are ordered by
+decreasing precedence:
+
+* `settings.jsdoc.noDefaultExampleRules` - Setting to `true` will disable the
+  default rules which are expected to be troublesome for most documentation
+  use. See the section below for the specific default rules.
+* `settings.jsdoc.matchingFileName` - Setting for a dummy file name to trigger
+  specific rules defined in one's config; usable with ESLint `.eslintrc.*`
+  `overrides` -> `files` globs, to apply a desired subset of rules with
+  `@example` (besides allowing for rules specific to examples, this setting
+  can be useful for enabling reuse of the same rules within `@example` as
+  with JavaScript Markdown lintable by
+  [other plugins](https://github.com/eslint/eslint-plugin-markdown), e.g.,
+  if one sets `matchingFileName` to `dummy.md` so that `@example` rules will
+  follow one's Markdown rules).
+* `settings.jsdoc.configFile` - A config file. Corresponds to `-c`.
+* `settings.jsdoc.eslintrcForExamples` - Defaults to `true` in adding rules
+  based on an `.eslintrc.*` file. Setting to `false` corresponds to
+  `--no-eslintrc`.
+* `settings.jsdoc.baseConfig` - An object of rules with the same schema
+  as `.eslintrc.*` for defaults
+
+#### Rules Disabled by Default Unless `noDefaultExampleRules` is Set to `true`
+
+* `eol-last` - Insisting that a newline "always" be at the end is less likely
+  to be desired in sample code as with the code file convention
+* `no-console` - Unlikely to have inadvertent temporary debugging within
+  examples
+* `no-undef` - Many variables in examples will be `undefined`.
+* `no-unused-vars` - It is common to define variables for clarity without always
+  using them within examples.
+* `padded-blocks` - It can generally look nicer to pad a little even if one's
+  code follows more stringency as far as block padding.
+* `import/no-unresolved` - One wouldn't generally expect example paths to
+  resolve relative to the current JavaScript file as one would with real code.
+* `import/unambiguous` - Snippets in examples are likely too short to always
+  include full import/export info
+* `node/no-missing-import` - See `import/no-unresolved`
+* `node/no-missing-require` -  See `import/no-unresolved`
+
 ## Rules
 
+{"gitdown": "include", "file": "./rules/check-examples.md"}
 {"gitdown": "include", "file": "./rules/check-param-names.md"}
 {"gitdown": "include", "file": "./rules/check-tag-names.md"}
 {"gitdown": "include", "file": "./rules/check-types.md"}

--- a/.README/rules/check-examples.md
+++ b/.README/rules/check-examples.md
@@ -1,0 +1,26 @@
+### `check-examples`
+
+Ensures that (JavaScript) examples within JSDoc adhere to ESLint rules.
+
+Works in conjunction with the following settings:
+
+* `captionRequired`
+* `exampleCodeRegex`
+* `rejectExampleCodeRegex`
+* `noDefaultExampleRules`
+* `matchingFileName`
+* `configFile`
+* `eslintrcForExamples` - Defaults to `true`
+* `baseConfig`
+
+Inline ESLint config within `@example` JavaScript is allowed, though the
+disabling of ESLint directives which are not needed by the resolved rules
+will be reported as with the ESLint `--report-unused-disable-directives`
+command.
+
+|||
+|---|---|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Tags|`param`|
+
+<!-- assertions checkExamples -->

--- a/README.md
+++ b/README.md
@@ -195,9 +195,16 @@ syntax highlighting). The following settings determine whether a given
 `@example` tag will have the `check-examples` checks applied to it:
 
 * `settings.jsdoc.exampleCodeRegex` - Regex which whitelists lintable
-  examples
+  examples. If a parenthetical group is used, the first one will be used,
+  so you may wish to use `(?:...)` groups where you do not wish the
+  first such group treated as one to include. If no parenthetical group
+  exists or matches, the whole matching expression will be used.
+  An example might be ````"^```(?:js|javascript)([\\s\\S]*)```$"````
+  to only match explicitly fenced JavaScript blocks.
 * `settings.jsdoc.rejectExampleCodeRegex` - Regex blacklist which rejects
-  non-lintable examples (has priority over `exampleCodeRegex`)
+  non-lintable examples (has priority over `exampleCodeRegex`). An example
+  might be ```"^`"``` to avoid linting fenced blocks which may indicate
+  a non-JavaScript language.
 
 If neither is in use, all examples will be matched. Note also that even if
 `settings.jsdoc.captionRequired` is not set, any initial `<caption>`

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 /* eslint-disable import/max-dependencies */
+import checkExamples from './rules/checkExamples';
 import checkParamNames from './rules/checkParamNames';
 import checkTagNames from './rules/checkTagNames';
 import checkTypes from './rules/checkTypes';
@@ -20,6 +21,7 @@ export default {
   configs: {
     recommended: {
       rules: {
+        'jsdoc/check-examples': 'off',
         'jsdoc/check-param-names': 'warn',
         'jsdoc/check-tag-names': 'warn',
         'jsdoc/check-types': 'warn',
@@ -40,6 +42,7 @@ export default {
     }
   },
   rules: {
+    'check-examples': checkExamples,
     'check-param-names': checkParamNames,
     'check-tag-names': checkTagNames,
     'check-types': checkTypes,

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -25,7 +25,15 @@ const curryUtils = (
   functionNode,
   jsdoc,
   tagNamePreference,
+  exampleCodeRegex,
+  rejectExampleCodeRegex,
   additionalTagNames,
+  baseConfig,
+  configFile,
+  captionRequired,
+  matchingFileName,
+  eslintrcForExamples,
+  noDefaultExampleRules,
   allowOverrideWithoutParam,
   allowImplementsWithoutParam,
   allowAugmentsExtendsWithoutParam,
@@ -50,12 +58,44 @@ const curryUtils = (
     return jsdocUtils.getPreferredTagName(name, tagNamePreference);
   };
 
+  utils.getExampleCodeRegex = () => {
+    return exampleCodeRegex;
+  };
+
+  utils.getRejectExampleCodeRegex = () => {
+    return rejectExampleCodeRegex;
+  };
+
+  utils.getMatchingFileName = () => {
+    return matchingFileName;
+  };
+
   utils.isValidTag = (name) => {
     return jsdocUtils.isValidTag(name, additionalTagNames);
   };
 
   utils.hasTag = (name) => {
     return jsdocUtils.hasTag(jsdoc, name);
+  };
+
+  utils.useEslintrcForExamples = () => {
+    return eslintrcForExamples;
+  };
+
+  utils.hasNoDefaultExampleRules = () => {
+    return noDefaultExampleRules;
+  };
+
+  utils.getBaseConfig = () => {
+    return baseConfig;
+  };
+
+  utils.getConfigFile = () => {
+    return configFile;
+  };
+
+  utils.isCaptionRequired = () => {
+    return captionRequired;
   };
 
   utils.isOverrideAllowedWithoutParam = () => {
@@ -101,7 +141,15 @@ export default (iterator) => {
   return (context) => {
     const sourceCode = context.getSourceCode();
     const tagNamePreference = _.get(context, 'settings.jsdoc.tagNamePreference') || {};
+    const exampleCodeRegex = _.get(context, 'settings.jsdoc.exampleCodeRegex') || null;
+    const rejectExampleCodeRegex = _.get(context, 'settings.jsdoc.rejectExampleCodeRegex') || null;
+    const matchingFileName = _.get(context, 'settings.jsdoc.matchingFileName') || null;
     const additionalTagNames = _.get(context, 'settings.jsdoc.additionalTagNames') || {};
+    const baseConfig = _.get(context, 'settings.jsdoc.baseConfig') || {};
+    const configFile = _.get(context, 'settings.jsdoc.configFile');
+    const eslintrcForExamples = _.get(context, 'settings.jsdoc.eslintrcForExamples') !== false;
+    const captionRequired = Boolean(_.get(context, 'settings.jsdoc.captionRequired'));
+    const noDefaultExampleRules = Boolean(_.get(context, 'settings.jsdoc.noDefaultExampleRules'));
     const allowOverrideWithoutParam = Boolean(_.get(context, 'settings.jsdoc.allowOverrideWithoutParam'));
     const allowImplementsWithoutParam = Boolean(_.get(context, 'settings.jsdoc.allowImplementsWithoutParam'));
     const allowAugmentsExtendsWithoutParam = Boolean(_.get(context, 'settings.jsdoc.allowAugmentsExtendsWithoutParam'));
@@ -119,16 +167,22 @@ export default (iterator) => {
 
       const jsdoc = parseComment(jsdocNode, indent);
 
-      const report = (message, fixer = null, jsdocLine = null) => {
+      const report = (message, fixer = null, jsdocLoc = null) => {
         let loc;
 
-        if (jsdocLine) {
-          const lineNumber = jsdocNode.loc.start.line + jsdocLine.line;
+        if (jsdocLoc) {
+          const lineNumber = jsdocNode.loc.start.line + jsdocLoc.line;
 
           loc = {
             end: {line: lineNumber},
             start: {line: lineNumber}
           };
+          if (jsdocLoc.column) {
+            const colNumber = jsdocNode.loc.start.column + jsdocLoc.column;
+
+            loc.end.column = colNumber;
+            loc.start.column = colNumber;
+          }
         }
         if (fixer === null) {
           context.report({
@@ -150,7 +204,15 @@ export default (iterator) => {
         functionNode,
         jsdoc,
         tagNamePreference,
+        exampleCodeRegex,
+        rejectExampleCodeRegex,
         additionalTagNames,
+        baseConfig,
+        configFile,
+        captionRequired,
+        matchingFileName,
+        eslintrcForExamples,
+        noDefaultExampleRules,
         allowOverrideWithoutParam,
         allowImplementsWithoutParam,
         allowAugmentsExtendsWithoutParam,

--- a/src/rules/checkExamples.js
+++ b/src/rules/checkExamples.js
@@ -1,0 +1,197 @@
+import _ from 'lodash';
+import {CLIEngine, Linter} from 'eslint';
+import iterateJsdoc from '../iterateJsdoc';
+
+const zeroBasedLineIndexAdjust = -1;
+const likelyNestedJSDocIndentSpace = 1;
+const preTagSpaceLength = 1;
+const hasCaptionRegex = /^\s*<caption>.*?<\/caption>/;
+
+const escapeStringRegexp = (str) => {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+};
+const countChars = (str, ch) => {
+  return (str.match(new RegExp(escapeStringRegexp(ch), 'g')) || []).length;
+};
+
+export default iterateJsdoc(({
+  jsdoc,
+  report,
+  utils
+}) => {
+  let exampleCodeRegex = utils.getExampleCodeRegex();
+  let rejectExampleCodeRegex = utils.getRejectExampleCodeRegex();
+  const noDefaultExampleRules = utils.hasNoDefaultExampleRules();
+  const eslintrcForExamples = utils.useEslintrcForExamples();
+  const filename = utils.getMatchingFileName();
+  const baseConfig = utils.getBaseConfig();
+  const configFile = utils.getConfigFile();
+
+  // Make these configurable?
+  const reportUnusedDisableDirectives = true;
+  const allowInlineConfig = true;
+  const rulePaths = [];
+
+  const rules = noDefaultExampleRules ? undefined : {
+    // "always" newline rule at end unlikely in sample code
+    'eol-last': 0,
+
+    // Wouldn't generally expect example paths to resolve relative to JS file
+    'import/no-unresolved': 0,
+
+    // Snippets likely too short to always include import/export info
+    'import/unambiguous': 0,
+
+    // Unlikely to have inadvertent debugging within examples
+    'no-console': 0,
+
+    // Many variables in examples will be `undefined`
+    'no-undef': 0,
+
+    // Common to define variables for clarity without always using them
+    'no-unused-vars': 0,
+
+    // See import/no-unresolved
+    'node/no-missing-import': 0,
+    'node/no-missing-require': 0,
+
+    // Can generally look nicer to pad a little even if code imposes more stringency
+    'padded-blocks': 0
+  };
+
+  exampleCodeRegex = exampleCodeRegex && new RegExp(exampleCodeRegex, '');
+  rejectExampleCodeRegex = rejectExampleCodeRegex && new RegExp(rejectExampleCodeRegex, '');
+
+  _.forEach(jsdoc.tags, (tag) => { // eslint-disable-line complexity
+    if (tag.tag !== 'example') {
+      return;
+    }
+
+    // If a space is present, we should ignore it
+    const initialTag = tag.source.match(/^@example ?/);
+    const initialTagLength = initialTag[0].length;
+    const firstLinePrefixLength = preTagSpaceLength + initialTagLength;
+
+    let source = tag.source.slice(initialTagLength);
+    const match = source.match(hasCaptionRegex);
+
+    if (utils.isCaptionRequired() && !match) {
+      report('Caption is expected for examples.', null, tag);
+    }
+
+    // If we allow newlines in hasCaptionRegex, we should add to line count
+    source = source.replace(hasCaptionRegex, '');
+
+    if (exampleCodeRegex && !exampleCodeRegex.test(source) ||
+      rejectExampleCodeRegex && rejectExampleCodeRegex.test(source)
+    ) {
+      return;
+    }
+
+    let nonJSPrefacingLines = 0;
+    let nonJSPrefacingCols = 0;
+
+    if (exampleCodeRegex) {
+      const idx = source.search(exampleCodeRegex);
+
+      // Strip out anything preceding user regex match (can affect line numbering)
+      let preMatchLines = 0;
+
+      const preMatch = source.slice(0, idx);
+
+      preMatchLines = countChars(preMatch, '\n');
+
+      nonJSPrefacingLines = preMatchLines;
+
+      const colDelta = preMatchLines ?
+        preMatch.slice(preMatch.lastIndexOf('\n') + 1).length - initialTagLength :
+        preMatch.length;
+
+      // Get rid of text preceding user regex match (even if it leaves valid JS, it
+      //   could cause us to count newlines twice)
+      source = source.slice(idx);
+
+      source = source.replace(exampleCodeRegex, (n0, n1) => {
+        if (!n1) {
+          return n0;
+        }
+
+        const index = n0.indexOf(n1);
+        const nonJSPreface = n0.slice(0, index);
+        const nonJSPrefaceLineCount = countChars(nonJSPreface, '\n');
+
+        nonJSPrefacingLines += nonJSPrefaceLineCount;
+
+        // Ignore `preMatch` delta if newlines here
+        if (nonJSPrefaceLineCount) {
+          const charsInLastLine = nonJSPreface.slice(nonJSPreface.lastIndexOf('\n') + 1).length;
+
+          nonJSPrefacingCols += charsInLastLine - initialTagLength;
+        } else {
+          nonJSPrefacingCols += colDelta + nonJSPreface.length;
+        }
+
+        return n1;
+      });
+    }
+
+    // Programmatic ESLint API: https://eslint.org/docs/developer-guide/nodejs-api
+    const cli = new CLIEngine({
+      allowInlineConfig,
+      baseConfig,
+      configFile,
+      reportUnusedDisableDirectives,
+      rulePaths,
+      rules,
+      useEslintrc: eslintrcForExamples
+    });
+
+    let messages;
+
+    if (filename) {
+      const config = cli.getConfigForFile(filename);
+      const linter = new Linter();
+
+      const linterRules = [...cli.getRules().entries()].reduce((obj, [key, val]) => {
+        obj[key] = val;
+
+        return obj;
+      }, {});
+
+      linter.defineRules(linterRules);
+
+      messages = linter.verify(source, config, {
+        filename,
+        reportUnusedDisableDirectives
+      });
+    } else {
+      ({results: [{messages}]} =
+        cli.executeOnText(source));
+    }
+
+    // NOTE: `tag.line` can be 0 if of form `/** @tag ... */`
+    const codeStartLine = tag.line + nonJSPrefacingLines;
+    const codeStartCol = likelyNestedJSDocIndentSpace;
+
+    messages.forEach(({message, line, column, severity, ruleId}) => {
+      const startLine = codeStartLine + line + zeroBasedLineIndexAdjust;
+      const startCol = codeStartCol + (
+
+        // This might not work for line 0, but line 0 is unlikely for examples
+        line <= 1 ? nonJSPrefacingCols + firstLinePrefixLength : preTagSpaceLength
+      ) + column;
+
+      // Could perhaps make fixable
+      report(
+        '@example ' + (severity === 2 ? 'error' : 'warning') +
+          (ruleId ? ' (' + ruleId + ')' : '') + ': ' +
+          message,
+        null,
+        {
+          column: startCol,
+          line: startLine
+        }
+      );
+    });
+  });
+});

--- a/test/rules/assertions/checkExamples.js
+++ b/test/rules/assertions/checkExamples.js
@@ -1,0 +1,318 @@
+/* eslint-disable no-restricted-syntax */
+
+export default {
+  invalid: [
+    {
+      code: `
+          /**
+           * @example alert('hello')
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: '@example error (no-alert): Unexpected alert.'
+        },
+        {
+          message: '@example error (semi): Missing semicolon.'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          baseConfig: {
+            rules: {
+              'no-alert': 2,
+              semi: ['error', 'always']
+            }
+          },
+          eslintrcForExamples: false
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @example \`\`\`js
+           alert('hello');
+           \`\`\`
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        '@example error (semi): Extra semicolon.'
+      ],
+      settings: {
+        jsdoc: {
+          baseConfig: {
+            rules: {
+              semi: ['error', 'never']
+            }
+          },
+          eslintrcForExamples: false,
+          exampleCodeRegex: '```js([\\s\\S]*)```'
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @example
+           * \`\`\`js alert('hello'); \`\`\`
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        '@example error (semi): Extra semicolon.'
+      ],
+      settings: {
+        jsdoc: {
+          baseConfig: {
+            rules: {
+              semi: ['error', 'never']
+            }
+          },
+          eslintrcForExamples: false,
+          exampleCodeRegex: '```js ([\\s\\S]*)```'
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @example \`\`\`
+           * js alert('hello'); \`\`\`
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        '@example error (semi): Extra semicolon.'
+      ],
+      settings: {
+        jsdoc: {
+          baseConfig: {
+            rules: {
+              semi: ['error', 'never']
+            }
+          },
+          eslintrcForExamples: false,
+          exampleCodeRegex: '```\njs ([\\s\\S]*)```'
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @example <b>Not JavaScript</b>
+           */
+          function quux () {
+
+          }
+          /**
+           * @example quux2();
+           */
+          function quux2 () {
+
+          }
+      `,
+      errors: [
+        '@example error (semi): Extra semicolon.'
+      ],
+      settings: {
+        jsdoc: {
+          baseConfig: {
+            rules: {
+              semi: ['error', 'never']
+            }
+          },
+          eslintrcForExamples: false,
+          rejectExampleCodeRegex: '^\\s*<.*>$'
+        }
+      }
+    },
+
+    {
+      code: `
+          /**
+           * @example
+           * quux(); // does something useful
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        '@example error (no-undef): \'quux\' is not defined.'
+      ],
+      settings: {
+        jsdoc: {
+          baseConfig: {
+            rules: {
+              'no-undef': ['error']
+            }
+          },
+          eslintrcForExamples: false,
+          noDefaultExampleRules: true
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @example <caption>Valid usage</caption>
+           * quux(); // does something useful
+           *
+           * @example
+           * quux('random unwanted arg'); // results in an error
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        'Caption is expected for examples.'
+      ],
+      settings: {
+        jsdoc: {
+          captionRequired: true,
+          eslintrcForExamples: false
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @example  quux();
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        '@example error (indent): Expected indentation of 0 spaces but found 1.'
+      ],
+      settings: {
+        jsdoc: {
+          baseConfig: {
+            rules: {
+              indent: ['error']
+            }
+          },
+          eslintrcForExamples: false,
+          noDefaultExampleRules: false
+        }
+      }
+    }
+  ],
+  valid: [
+    {
+      code: `
+          /**
+           * @example \`\`\`js
+           alert('hello');
+           \`\`\`
+           */
+          function quux () {
+
+          }
+      `,
+      settings: {
+        jsdoc: {
+          baseConfig: {
+            rules: {
+              semi: ['error', 'always']
+            }
+          },
+          eslintrcForExamples: false,
+          exampleCodeRegex: '```js([\\s\\S]*)```'
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @example
+           * // arbitrary example content
+           */
+          function quux () {
+
+          }
+      `,
+      settings: {
+        jsdoc: {
+          eslintrcForExamples: false
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @example
+           * quux(); // does something useful
+           */
+          function quux () {
+
+          }
+      `,
+      settings: {
+        jsdoc: {
+          baseConfig: {
+            rules: {
+              'no-undef': ['error']
+            }
+          },
+          eslintrcForExamples: false,
+          noDefaultExampleRules: false
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @example quux();
+           */
+          function quux () {
+
+          }
+      `,
+      settings: {
+        jsdoc: {
+          baseConfig: {
+            rules: {
+              indent: ['error']
+            }
+          },
+          eslintrcForExamples: false,
+          noDefaultExampleRules: false
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @example <caption>Valid usage</caption>
+           * quux(); // does something useful
+           *
+           * @example <caption>Invalid usage</caption>
+           * quux('random unwanted arg'); // results in an error
+           */
+          function quux () {
+
+          }
+      `,
+      settings: {
+        jsdoc: {
+          captionRequired: true,
+          eslintrcForExamples: false
+        }
+      }
+    }
+  ]
+};

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -7,6 +7,7 @@ import config from '../../src';
 const ruleTester = new RuleTester();
 
 _.forEach([
+  'check-examples',
   'check-param-names',
   'check-tag-names',
   'check-types',


### PR DESCRIPTION
- feat: Add `check-examples` rule to lint JavaScript within `@example` (fixes #101);
    with settings to:
    1. require JSDoc-spec'd `<caption>` at beginning of `@example`
    2. regex settings to whitelist and blacklist lintable examples
    3. setting for a dummy file name to trigger specific rules defined in one's
         config; usable with ESLint `overrides`->`files` globs, to apply a desired
         subset of rules with `@example` (besides allowing for rules specific to
         examples, can be useful for using same rules within `@example` as
         with JavaScript Markdown lintable by other plugins)
    4. Other settings for specifying config (base config object or an `.eslintrc`
         config file; checks normal `.eslintrc` by default unless
         `eslintrcForExamples` setting is set to `false`)
    5. Provides some defaults for suppressing reporting of rules which are
         likely to be troublesome in example files unless
         `noDefaultExampleRules` setting is `true`
- Report column (for checkExamples and any that report it)

Regarding your [comment](https://github.com/gajus/eslint-plugin-jsdoc/issues/101#issuecomment-434608259) about being open to a PR but the need being esoteric, in my opinion, this could actually be the single most important doc item to lint for, in order to ensure the examples indicated for users of the library do not have inadvertent bugs.

Thanks!