### PR TITLE
Fix crash on invalid JSDoc class comment

### DIFF
--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -76,11 +76,13 @@ const curryUtils = (
 
     if (greatGrandParentValue === 'class') {
       const classJsdocNode = sourceCode.getJSDocComment(greatGrandParent);
-      const indent = _.repeat(' ', classJsdocNode.loc.start.column);
-      const classJsdoc = parseComment(classJsdocNode, indent);
+      if (classJsdocNode) {
+        const indent = _.repeat(' ', classJsdocNode.loc.start.column);
+        const classJsdoc = parseComment(classJsdocNode, indent);
 
-      if (jsdocUtils.hasTag(classJsdoc, tagName)) {
-        return true;
+        if (jsdocUtils.hasTag(classJsdoc, tagName)) {
+          return true;
+        }
       }
     }
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -76,6 +76,7 @@ const curryUtils = (
 
     if (greatGrandParentValue === 'class') {
       const classJsdocNode = sourceCode.getJSDocComment(greatGrandParent);
+      
       if (classJsdocNode) {
         const indent = _.repeat(' ', classJsdocNode.loc.start.column);
         const classJsdoc = parseComment(classJsdocNode, indent);

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -76,7 +76,7 @@ const curryUtils = (
 
     if (greatGrandParentValue === 'class') {
       const classJsdocNode = sourceCode.getJSDocComment(greatGrandParent);
-      
+
       if (classJsdocNode) {
         const indent = _.repeat(' ', classJsdocNode.loc.start.column);
         const classJsdoc = parseComment(classJsdocNode, indent);


### PR DESCRIPTION
`sourceCode.getJSDocComment` can return `null` here in case of incomplete or malformed JSDoc comment and this will result in ESLint crash