### PR TITLE
Docs for `allowImplementsWithoutParam` and `allowAugmentsExtendsWithoutParam` and updating `allowOverrideWithoutParam`

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -128,14 +128,27 @@ Use `settings.jsdoc.additionalTagNames` to configure additional, allowed JSDoc t
 
 ### Allow `@override` Without Accompanying `@param` Tags
 
-Use `settings.jsdoc.allowOverrideWithoutParam` to indicate whether the `@override` tag can be used without accompanying `@param` tag(s). The default value is `false`. The format of the configuration is as follows:
+Use any of the following settings to override `require-param` and allow
+`@param` to be omitted when the specified tags are present on the JSDoc
+comment or the parent class comment. The default value for each is `false`.
+
+* `settings.jsdoc.allowOverrideWithoutParam` - Enables behavior with
+  `@override` tag
+* `settings.jsdoc.allowImplementsWithoutParam` - Enables behavior with
+  `@implements` tag
+* `settings.jsdoc.allowAugmentsExtendsWithoutParam` - Enables behavior with
+  `@augments` tag or its synonym `@extends`
+
+The format of the configuration is as follows:
 
 ```json
 {
     "rules": {},
     "settings": {
         "jsdoc": {
-            "allowOverrideWithoutParam": true
+            "allowOverrideWithoutParam": true,
+            "allowImplementsWithoutParam": true,
+            "allowAugmentsExtendsWithoutParam": true
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -161,14 +161,27 @@ Use `settings.jsdoc.additionalTagNames` to configure additional, allowed JSDoc t
 <a name="eslint-plugin-jsdoc-settings-allow-override-without-accompanying-param-tags"></a>
 ### Allow <code>@override</code> Without Accompanying <code>@param</code> Tags
 
-Use `settings.jsdoc.allowOverrideWithoutParam` to indicate whether the `@override` tag can be used without accompanying `@param` tag(s). The default value is `false`. The format of the configuration is as follows:
+Use any of the following settings to override `require-param` and allow
+`@param` to be omitted when the specified tags are present on the JSDoc
+comment or the parent class comment. The default value for each is `false`.
+
+* `settings.jsdoc.allowOverrideWithoutParam` - Enables behavior with
+  `@override` tag
+* `settings.jsdoc.allowImplementsWithoutParam` - Enables behavior with
+  `@implements` tag
+* `settings.jsdoc.allowAugmentsExtendsWithoutParam` - Enables behavior with
+  `@augments` tag or its synonym `@extends`
+
+The format of the configuration is as follows:
 
 ```json
 {
     "rules": {},
     "settings": {
         "jsdoc": {
-            "allowOverrideWithoutParam": true
+            "allowOverrideWithoutParam": true,
+            "allowImplementsWithoutParam": true,
+            "allowAugmentsExtendsWithoutParam": true
         }
     }
 }


### PR DESCRIPTION
- Add docs missing for `allowImplementsWithoutParam` and `allowAugmentsExtendsWithoutParam`, and include them with `allowOverrideWithoutParam` (to save space and to mention that they all operate if present on the parent class comment block or the same comment block)