### PR TITLE
Fixed @examples with multiple lines breaking markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,8 +309,8 @@ function quux () {
 
 /**
  * @example ```js
- alert('hello');
- ```
+    alert('hello');
+    ```
  */
 function quux () {
 
@@ -391,8 +391,8 @@ The following patterns are not considered problems:
 ```js
 /**
  * @example ```js
- alert('hello');
- ```
+    alert('hello');
+    ```
  */
 function quux () {
 


### PR DESCRIPTION
The \``` in the `@example`s that are multiline broke the markdown for the readme. Indenting to 4 spaces makes markdown see the \``` as code and just indents it. 