### PR TITLE
Improve markdown links to use header tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,8 +309,8 @@ function quux () {
 
 /**
  * @example ```js
- alert('hello');
- ```
+    alert('hello');
+    ```
  */
 function quux () {
 
@@ -391,8 +391,8 @@ The following patterns are not considered problems:
 ```js
 /**
  * @example ```js
- alert('hello');
- ```
+    alert('hello');
+    ```
  */
 function quux () {
 

--- a/README.md
+++ b/README.md
@@ -7,33 +7,32 @@
 JSDoc linting rules for ESLint.
 
 * [eslint-plugin-jsdoc](#eslint-plugin-jsdoc)
-    * [Reference to jscs-jsdoc](#eslint-plugin-jsdoc-reference-to-jscs-jsdoc)
-    * [Installation](#eslint-plugin-jsdoc-installation)
-    * [Configuration](#eslint-plugin-jsdoc-configuration)
-    * [Settings](#eslint-plugin-jsdoc-settings)
-        * [Alias Preference](#eslint-plugin-jsdoc-settings-alias-preference)
-        * [Additional Tag Names](#eslint-plugin-jsdoc-settings-additional-tag-names)
-        * [Allow `@override` Without Accompanying `@param` Tags](#eslint-plugin-jsdoc-settings-allow-override-without-accompanying-param-tags)
-        * [Settings to Configure `check-examples`](#eslint-plugin-jsdoc-settings-settings-to-configure-check-examples)
-    * [Rules](#eslint-plugin-jsdoc-rules)
-        * [`check-examples`](#eslint-plugin-jsdoc-rules-check-examples)
-        * [`check-param-names`](#eslint-plugin-jsdoc-rules-check-param-names)
-        * [`check-tag-names`](#eslint-plugin-jsdoc-rules-check-tag-names)
-        * [`check-types`](#eslint-plugin-jsdoc-rules-check-types)
-        * [`newline-after-description`](#eslint-plugin-jsdoc-rules-newline-after-description)
-        * [`no-undefined-types`](#eslint-plugin-jsdoc-rules-no-undefined-types)
-        * [`require-description`](#eslint-plugin-jsdoc-rules-require-description)
-        * [`require-description-complete-sentence`](#eslint-plugin-jsdoc-rules-require-description-complete-sentence)
-        * [`require-example`](#eslint-plugin-jsdoc-rules-require-example)
-        * [`require-hyphen-before-param-description`](#eslint-plugin-jsdoc-rules-require-hyphen-before-param-description)
-        * [`require-param`](#eslint-plugin-jsdoc-rules-require-param)
-        * [`require-param-description`](#eslint-plugin-jsdoc-rules-require-param-description)
-        * [`require-param-name`](#eslint-plugin-jsdoc-rules-require-param-name)
-        * [`require-param-type`](#eslint-plugin-jsdoc-rules-require-param-type)
-        * [`require-returns-description`](#eslint-plugin-jsdoc-rules-require-returns-description)
-        * [`require-returns-type`](#eslint-plugin-jsdoc-rules-require-returns-type)
-        * [`valid-types`](#eslint-plugin-jsdoc-rules-valid-types)
-
+    * [Reference to jscs-jsdoc](#reference-to-jscs-jsdoc)
+    * [Installation](#installation)
+    * [Configuration](#configuration)
+    * [Settings](#settings)
+        * [Alias Preference](#alias-preference)
+        * [Additional Tag Names](#additional-tag-names)
+        * [Allow `@override` Without Accompanying `@param` Tags](#allow-override-without-accompanying-param-tags)
+        * [Settings to Configure `check-examples`](#settings-to-configure-check-examples)
+    * [Rules](#rules)
+        * [`check-examples`](#check-examples)
+        * [`check-param-names`](#check-param-names)
+        * [`check-tag-names`](#check-tag-names)
+        * [`check-types`](#check-types)
+        * [`newline-after-description`](#newline-after-description)
+        * [`no-undefined-types`](#no-undefined-types)
+        * [`require-description`](#require-description)
+        * [`require-description-complete-sentence`](#require-description-complete-sentence)
+        * [`require-example`](#require-example)
+        * [`require-hyphen-before-param-description`](#require-hyphen-before-param-description)
+        * [`require-param`](#require-param)
+        * [`require-param-description`](#require-param-description)
+        * [`require-param-name`](#require-param-name)
+        * [`require-param-type`](#require-param-type)
+        * [`require-returns-description`](#require-returns-description)
+        * [`require-returns-type`](#require-returns-type)
+        * [`valid-types`](#valid-types)
 
 
 ### Reference to jscs-jsdoc
@@ -66,7 +65,6 @@ This table maps the rules between `eslint-plugin-jsdoc` and `jscs-jsdoc`.
 | N/A | [`enforceExistence`](https://github.com/jscs-dev/jscs-jsdoc#enforceexistence) |
 | N/A | [`leadingUnderscoreAccess`](https://github.com/jscs-dev/jscs-jsdoc#leadingunderscoreaccess) |
 
-
 ## Installation
 
 Install [ESLint](https://www.github.com/eslint/eslint) either locally or globally.
@@ -80,7 +78,6 @@ If you have installed `ESLint` globally, you have to install JSDoc plugin global
 ```sh
 npm install eslint-plugin-jsdoc
 ```
-
 
 ## Configuration
 
@@ -120,9 +117,7 @@ Finally, enable all of the rules that you would like to use.
 }
 ```
 
-
 ## Settings
-
 
 ### Alias Preference
 
@@ -142,7 +137,6 @@ Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a
 }
 ```
 
-
 ### Additional Tag Names
 
 Use `settings.jsdoc.additionalTagNames` to configure additional, allowed JSDoc tags. The format of the configuration is as follows:
@@ -159,7 +153,6 @@ Use `settings.jsdoc.additionalTagNames` to configure additional, allowed JSDoc t
     }
 }
 ```
-
 
 ### Allow `@override` Without Accompanying `@param` Tags
 
@@ -188,7 +181,6 @@ The format of the configuration is as follows:
     }
 }
 ```
-
 
 ### Settings to Configure `check-examples`
 
@@ -246,7 +238,6 @@ decreasing precedence:
 * `settings.jsdoc.baseConfig` - An object of rules with the same schema
   as `.eslintrc.*` for defaults
 
-
 #### Rules Disabled by Default Unless `noDefaultExampleRules` is Set to `true`
 
 * `eol-last` - Insisting that a newline "always" be at the end is less likely
@@ -265,9 +256,7 @@ decreasing precedence:
 * `node/no-missing-import` - See `import/no-unresolved`
 * `node/no-missing-require` -  See `import/no-unresolved`
 
-
 ## Rules
-
 
 ### `check-examples`
 
@@ -437,8 +426,6 @@ function quux () {
 // Settings: {"jsdoc":{"captionRequired":true,"eslintrcForExamples":false}}
 ```
 
-
-
 ### `check-param-names`
 
 Ensures that parameter names in JSDoc match those in the function declaration.
@@ -585,7 +572,6 @@ function quux ([a, b] = []) {
 ```
 
 
-
 #### Deconstructing Function Parameter
 
 `eslint-plugin-jsdoc` does not validate names of parameters in function deconstruction, e.g.
@@ -605,7 +591,6 @@ function quux ({
 `{a, b}` is an [`ObjectPattern`](https://github.com/estree/estree/blob/master/es2015.md#objectpattern) AST type and does not have a name. Therefore, the associated parameter in JSDoc block can have any name.
 
 Likewise for the pattern `[a, b]` which is an [`ArrayPattern`](https://github.com/estree/estree/blob/master/es2015.md#arraypattern).
-
 
 ### `check-tag-names`
 
@@ -849,7 +834,6 @@ function quux (foo) {}
 ```
 
 
-
 ### `check-types`
 
 Reports invalid types.
@@ -865,7 +849,6 @@ Array
 Date
 RegExp
 ```
-
 
 #### Why not capital case everything?
 
@@ -968,7 +951,6 @@ function quux (foo, bar, baz) {
 ```
 
 
-
 ### `newline-after-description`
 
 Enforces a consistent padding of the block description.
@@ -1047,7 +1029,6 @@ function quux () {
 }
 // Options: ["never"]
 ```
-
 
 
 ### `no-undefined-types`
@@ -1146,7 +1127,6 @@ function quux(foo) {
 ```
 
 
-
 ### `require-description`
 
 Requires that all functions have a description.
@@ -1209,7 +1189,6 @@ function quux () {
 
 }
 ```
-
 
 
 ### `require-description-complete-sentence`
@@ -1476,7 +1455,6 @@ function quux () {
 ```
 
 
-
 ### `require-example`
 
 Requires that all functions have examples.
@@ -1541,7 +1519,6 @@ function quux () {
 ```
 
 
-
 ### `require-hyphen-before-param-description`
 
 Requires a hyphen before the `@param` description.
@@ -1573,7 +1550,6 @@ function quux () {
 
 }
 ```
-
 
 
 ### `require-param`
@@ -1889,7 +1865,6 @@ class A {
 ```
 
 
-
 ### `require-param-description`
 
 Requires that `@param` tag has `description` value.
@@ -1937,7 +1912,6 @@ function quux (foo) {
 
 }
 ```
-
 
 
 ### `require-param-name`
@@ -1992,7 +1966,6 @@ function quux (foo) {
 ```
 
 
-
 ### `require-param-type`
 
 Requires that `@param` tag has `type` value.
@@ -2040,7 +2013,6 @@ function quux (foo) {
 
 }
 ```
-
 
 
 ### `require-returns-description`
@@ -2092,7 +2064,6 @@ function quux () {
 ```
 
 
-
 ### `require-returns-type`
 
 Requires that `@returns` tag has `type` value.
@@ -2141,7 +2112,6 @@ function quux () {
 
 }
 ```
-
 
 
 ### `valid-types`

--- a/README.md
+++ b/README.md
@@ -41,23 +41,23 @@ This table maps the rules between `eslint-plugin-jsdoc` and `jscs-jsdoc`.
 
 | `eslint-plugin-jsdoc` | `jscs-jsdoc` |
 | --- | --- |
-| [`check-examples`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-examples) | N/A |
-| [`check-param-names`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-param-names) | [`checkParamNames`](https://github.com/jscs-dev/jscs-jsdoc#checkparamnames) |
-| [`check-tag-names`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-tag-names) | N/A ~ [`checkAnnotations`](https://github.com/jscs-dev/jscs-jsdoc#checkannotations) |
-| [`check-types`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-types) | [`checkTypes`](https://github.com/jscs-dev/jscs-jsdoc#checktypes) |
-| [`newline-after-description`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-newline-after-description) | [`requireNewlineAfterDescription`](https://github.com/jscs-dev/jscs-jsdoc#requirenewlineafterdescription) and [`disallowNewlineAfterDescription`](https://github.com/jscs-dev/jscs-jsdoc#disallownewlineafterdescription) |
-| [`require-description`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-description) | N/A |
-| [`require-description-complete-sentence`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-description-complete-sentence) | [`requireDescriptionCompleteSentence`](https://github.com/jscs-dev/jscs-jsdoc#requiredescriptioncompletesentence) |
-| [`require-example`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-example) | N/A |
-| [`require-hyphen-before-param-description`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-hyphen-before-param-description) | [`requireHyphenBeforeDescription`](https://github.com/jscs-dev/jscs-jsdoc#requirehyphenbeforedescription) |
-| [`require-param`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-param) | [`checkParamExistence`](https://github.com/jscs-dev/jscs-jsdoc#checkparamexistence) |
-| [`require-param-description`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-param-description) | [`requireParamDescription`](https://github.com/jscs-dev/jscs-jsdoc#requireparamdescription) |
-| [`require-param-name`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-param-name) | N/A |
-| [`require-param-type`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-param-type) | [`requireParamTypes`](https://github.com/jscs-dev/jscs-jsdoc#requireparamtypes) |
-| [`require-returns-description`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-returns-description) | [`requireReturnDescription`](https://github.com/jscs-dev/jscs-jsdoc#requirereturndescription) |
-| [`require-returns-type`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-returns-type) | [`requireReturnTypes`](https://github.com/jscs-dev/jscs-jsdoc#requirereturntypes) |
-| [`valid-types`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-valid-types) | N/A |
-| [`no-undefined-types`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-no-undefined-types) | N/A |
+| [`check-examples`](#check-examples) | N/A |
+| [`check-param-names`](#check-param-names) | [`checkParamNames`](https://github.com/jscs-dev/jscs-jsdoc#checkparamnames) |
+| [`check-tag-names`](#check-tag-names) | N/A ~ [`checkAnnotations`](https://github.com/jscs-dev/jscs-jsdoc#checkannotations) |
+| [`check-types`](#check-types) | [`checkTypes`](https://github.com/jscs-dev/jscs-jsdoc#checktypes) |
+| [`newline-after-description`](#newline-after-description) | [`requireNewlineAfterDescription`](https://github.com/jscs-dev/jscs-jsdoc#requirenewlineafterdescription) and [`disallowNewlineAfterDescription`](https://github.com/jscs-dev/jscs-jsdoc#disallownewlineafterdescription) |
+| [`require-description`](#require-description) | N/A |
+| [`require-description-complete-sentence`](#require-description-complete-sentence) | [`requireDescriptionCompleteSentence`](https://github.com/jscs-dev/jscs-jsdoc#requiredescriptioncompletesentence) |
+| [`require-example`](#require-example) | N/A |
+| [`require-hyphen-before-param-description`](#require-hyphen-before-param-description) | [`requireHyphenBeforeDescription`](https://github.com/jscs-dev/jscs-jsdoc#requirehyphenbeforedescription) |
+| [`require-param`](#require-param) | [`checkParamExistence`](https://github.com/jscs-dev/jscs-jsdoc#checkparamexistence) |
+| [`require-param-description`](#require-param-description) | [`requireParamDescription`](https://github.com/jscs-dev/jscs-jsdoc#requireparamdescription) |
+| [`require-param-name`](#require-param-name) | N/A |
+| [`require-param-type`](#require-param-type) | [`requireParamTypes`](https://github.com/jscs-dev/jscs-jsdoc#requireparamtypes) |
+| [`require-returns-description`](#require-returns-description) | [`requireReturnDescription`](https://github.com/jscs-dev/jscs-jsdoc#requirereturndescription) |
+| [`require-returns-type`](#require-returns-type) | [`requireReturnTypes`](https://github.com/jscs-dev/jscs-jsdoc#requirereturntypes) |
+| [`valid-types`](#valid-types) | N/A |
+| [`no-undefined-types`](#no-undefined-types) | N/A |
 | N/A | [`checkReturnTypes`](https://github.com/jscs-dev/jscs-jsdoc#checkreturntypes) |
 | N/A | [`checkRedundantParams`](https://github.com/jscs-dev/jscs-jsdoc#checkredundantparams) |
 | N/A | [`checkReturnTypes`](https://github.com/jscs-dev/jscs-jsdoc#checkreturntypes) |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<a name="eslint-plugin-jsdoc"></a>
 # eslint-plugin-jsdoc
 
 [![NPM version](http://img.shields.io/npm/v/eslint-plugin-jsdoc.svg?style=flat-square)](https://www.npmjs.org/package/eslint-plugin-jsdoc)
@@ -36,7 +35,7 @@ JSDoc linting rules for ESLint.
         * [`valid-types`](#eslint-plugin-jsdoc-rules-valid-types)
 
 
-<a name="eslint-plugin-jsdoc-reference-to-jscs-jsdoc"></a>
+
 ### Reference to jscs-jsdoc
 
 This table maps the rules between `eslint-plugin-jsdoc` and `jscs-jsdoc`.
@@ -67,7 +66,7 @@ This table maps the rules between `eslint-plugin-jsdoc` and `jscs-jsdoc`.
 | N/A | [`enforceExistence`](https://github.com/jscs-dev/jscs-jsdoc#enforceexistence) |
 | N/A | [`leadingUnderscoreAccess`](https://github.com/jscs-dev/jscs-jsdoc#leadingunderscoreaccess) |
 
-<a name="eslint-plugin-jsdoc-installation"></a>
+
 ## Installation
 
 Install [ESLint](https://www.github.com/eslint/eslint) either locally or globally.
@@ -82,7 +81,7 @@ If you have installed `ESLint` globally, you have to install JSDoc plugin global
 npm install eslint-plugin-jsdoc
 ```
 
-<a name="eslint-plugin-jsdoc-configuration"></a>
+
 ## Configuration
 
 Add `plugins` section and specify `eslint-plugin-jsdoc` as a plugin.
@@ -121,10 +120,10 @@ Finally, enable all of the rules that you would like to use.
 }
 ```
 
-<a name="eslint-plugin-jsdoc-settings"></a>
+
 ## Settings
 
-<a name="eslint-plugin-jsdoc-settings-alias-preference"></a>
+
 ### Alias Preference
 
 Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a JSDoc tag. The format of the configuration is: `<primary tag name>: <preferred alias name>`, e.g.
@@ -143,7 +142,7 @@ Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a
 }
 ```
 
-<a name="eslint-plugin-jsdoc-settings-additional-tag-names"></a>
+
 ### Additional Tag Names
 
 Use `settings.jsdoc.additionalTagNames` to configure additional, allowed JSDoc tags. The format of the configuration is as follows:
@@ -161,8 +160,8 @@ Use `settings.jsdoc.additionalTagNames` to configure additional, allowed JSDoc t
 }
 ```
 
-<a name="eslint-plugin-jsdoc-settings-allow-override-without-accompanying-param-tags"></a>
-### Allow <code>@override</code> Without Accompanying <code>@param</code> Tags
+
+### Allow `@override` Without Accompanying `@param` Tags
 
 Use any of the following settings to override `require-param` and allow
 `@param` to be omitted when the specified tags are present on the JSDoc
@@ -190,8 +189,8 @@ The format of the configuration is as follows:
 }
 ```
 
-<a name="eslint-plugin-jsdoc-settings-settings-to-configure-check-examples"></a>
-### Settings to Configure <code>check-examples</code>
+
+### Settings to Configure `check-examples`
 
 The settings below all impact the `check-examples` rule and default to
 no-op/false except for `eslintrcForExamples` which defaults to `true`.
@@ -247,8 +246,8 @@ decreasing precedence:
 * `settings.jsdoc.baseConfig` - An object of rules with the same schema
   as `.eslintrc.*` for defaults
 
-<a name="eslint-plugin-jsdoc-settings-settings-to-configure-check-examples-rules-disabled-by-default-unless-nodefaultexamplerules-is-set-to-true"></a>
-#### Rules Disabled by Default Unless <code>noDefaultExampleRules</code> is Set to <code>true</code>
+
+#### Rules Disabled by Default Unless `noDefaultExampleRules` is Set to `true`
 
 * `eol-last` - Insisting that a newline "always" be at the end is less likely
   to be desired in sample code as with the code file convention
@@ -266,11 +265,11 @@ decreasing precedence:
 * `node/no-missing-import` - See `import/no-unresolved`
 * `node/no-missing-require` -  See `import/no-unresolved`
 
-<a name="eslint-plugin-jsdoc-rules"></a>
+
 ## Rules
 
-<a name="eslint-plugin-jsdoc-rules-check-examples"></a>
-### <code>check-examples</code>
+
+### `check-examples`
 
 Ensures that (JavaScript) examples within JSDoc adhere to ESLint rules.
 
@@ -439,8 +438,8 @@ function quux () {
 ```
 
 
-<a name="eslint-plugin-jsdoc-rules-check-param-names"></a>
-### <code>check-param-names</code>
+
+### `check-param-names`
 
 Ensures that parameter names in JSDoc match those in the function declaration.
 
@@ -586,7 +585,7 @@ function quux ([a, b] = []) {
 ```
 
 
-<a name="eslint-plugin-jsdoc-rules-check-param-names-deconstructing-function-parameter"></a>
+
 #### Deconstructing Function Parameter
 
 `eslint-plugin-jsdoc` does not validate names of parameters in function deconstruction, e.g.
@@ -607,8 +606,8 @@ function quux ({
 
 Likewise for the pattern `[a, b]` which is an [`ArrayPattern`](https://github.com/estree/estree/blob/master/es2015.md#arraypattern).
 
-<a name="eslint-plugin-jsdoc-rules-check-tag-names"></a>
-### <code>check-tag-names</code>
+
+### `check-tag-names`
 
 Reports invalid block tag names.
 
@@ -850,8 +849,8 @@ function quux (foo) {}
 ```
 
 
-<a name="eslint-plugin-jsdoc-rules-check-types"></a>
-### <code>check-types</code>
+
+### `check-types`
 
 Reports invalid types.
 
@@ -867,7 +866,7 @@ Date
 RegExp
 ```
 
-<a name="eslint-plugin-jsdoc-rules-check-types-why-not-capital-case-everything"></a>
+
 #### Why not capital case everything?
 
 Why are `boolean`, `number` and `string` exempt from starting with a capital letter? Let's take `string` as an example. In Javascript, everything is an object. The string Object has prototypes for string functions such as `.toUpperCase()`.
@@ -969,8 +968,8 @@ function quux (foo, bar, baz) {
 ```
 
 
-<a name="eslint-plugin-jsdoc-rules-newline-after-description"></a>
-### <code>newline-after-description</code>
+
+### `newline-after-description`
 
 Enforces a consistent padding of the block description.
 
@@ -1050,8 +1049,8 @@ function quux () {
 ```
 
 
-<a name="eslint-plugin-jsdoc-rules-no-undefined-types"></a>
-### <code>no-undefined-types</code>
+
+### `no-undefined-types`
 
 Checks that types in jsdoc comments are defined. This can be used to check unimported types.
 
@@ -1147,8 +1146,8 @@ function quux(foo) {
 ```
 
 
-<a name="eslint-plugin-jsdoc-rules-require-description"></a>
-### <code>require-description</code>
+
+### `require-description`
 
 Requires that all functions have a description.
 
@@ -1212,8 +1211,8 @@ function quux () {
 ```
 
 
-<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence"></a>
-### <code>require-description-complete-sentence</code>
+
+### `require-description-complete-sentence`
 
 Requires that block description and tag description are written in complete sentences, i.e.,
 
@@ -1477,8 +1476,8 @@ function quux () {
 ```
 
 
-<a name="eslint-plugin-jsdoc-rules-require-example"></a>
-### <code>require-example</code>
+
+### `require-example`
 
 Requires that all functions have examples.
 
@@ -1542,8 +1541,8 @@ function quux () {
 ```
 
 
-<a name="eslint-plugin-jsdoc-rules-require-hyphen-before-param-description"></a>
-### <code>require-hyphen-before-param-description</code>
+
+### `require-hyphen-before-param-description`
 
 Requires a hyphen before the `@param` description.
 
@@ -1576,8 +1575,8 @@ function quux () {
 ```
 
 
-<a name="eslint-plugin-jsdoc-rules-require-param"></a>
-### <code>require-param</code>
+
+### `require-param`
 
 Requires that all function parameters are documented.
 
@@ -1890,8 +1889,8 @@ class A {
 ```
 
 
-<a name="eslint-plugin-jsdoc-rules-require-param-description"></a>
-### <code>require-param-description</code>
+
+### `require-param-description`
 
 Requires that `@param` tag has `description` value.
 
@@ -1940,8 +1939,8 @@ function quux (foo) {
 ```
 
 
-<a name="eslint-plugin-jsdoc-rules-require-param-name"></a>
-### <code>require-param-name</code>
+
+### `require-param-name`
 
 Requires that all function parameters have name.
 
@@ -1993,8 +1992,8 @@ function quux (foo) {
 ```
 
 
-<a name="eslint-plugin-jsdoc-rules-require-param-type"></a>
-### <code>require-param-type</code>
+
+### `require-param-type`
 
 Requires that `@param` tag has `type` value.
 
@@ -2043,8 +2042,8 @@ function quux (foo) {
 ```
 
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-description"></a>
-### <code>require-returns-description</code>
+
+### `require-returns-description`
 
 Requires that `@returns` tag has `description` value.
 
@@ -2093,8 +2092,8 @@ function quux () {
 ```
 
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-type"></a>
-### <code>require-returns-type</code>
+
+### `require-returns-type`
 
 Requires that `@returns` tag has `type` value.
 
@@ -2144,8 +2143,8 @@ function quux () {
 ```
 
 
-<a name="eslint-plugin-jsdoc-rules-valid-types"></a>
-### <code>valid-types</code>
+
+### `valid-types`
 
 Requires all types to be valid JSDoc or Closure compiler types without syntax errors.
 


### PR DESCRIPTION
The empty `<a>` tags aren't needed for anchors. 

https://stackoverflow.com/a/45508928/10559113 