### PR TITLE
Allow for array value props to be defined

### DIFF
--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -38,7 +38,11 @@ const validateParameterNamesDeep = (targetTagName : string, jsdocParameterNames 
         return true;
       }
 
-      const pathRootNodeName = jsdocParameterName.slice(0, jsdocParameterName.indexOf('.'));
+      let pathRootNodeName = jsdocParameterName.slice(0, jsdocParameterName.indexOf('.'));
+
+      if (pathRootNodeName.endsWith('[]')) {
+        pathRootNodeName = pathRootNodeName.slice(0, -2);
+      }
 
       if (pathRootNodeName !== lastRealParameter) {
         report('@' + targetTagName + ' path declaration ("' + jsdocParameterName + '") root node name ("' +

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -211,6 +211,19 @@ export default {
 
           }
       `
+    },
+    {
+      code: `
+          /**
+           * Assign the project to a list of employees.
+           * @param {Object[]} employees - The employees who are responsible for the project.
+           * @param {string} employees[].name - The name of an employee.
+           * @param {string} employees[].department - The employee's department.
+           */
+          function assign (employees) {
+
+          };
+      `
     }
   ]
 };


### PR DESCRIPTION
Solves: #135.
This is by no means a perfect solution, but was a simple solution that wouldn't require considerable refactoring. This implementation allows for array value props to be defined.

A better solution would be one that checks that the `lastRealParameter` has the `Object[]` type.

Thank you for the excellent plugin! 👍 