### PR TITLE
docs: fix require-returns assertions

### DIFF
--- a/.README/rules/require-returns.md
+++ b/.README/rules/require-returns.md
@@ -7,4 +7,4 @@ Requires returns are documented.
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
 |Tags|`returns`|
 
-<!-- assertions requireParam -->
+<!-- assertions requireReturns -->


### PR DESCRIPTION
Currently displaying `requireParam` asserions