### PR TITLE
Test typeof and import types from Typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -1016,7 +1016,7 @@ function quux (foo) {
 }
 // Settings: {"jsdoc":{"additionalTagNames":{"customTags":["baz","bar"]}}}
 
-/**
+/** 
  * @abstract
  * @access
  * @alias
@@ -1104,9 +1104,9 @@ RegExp
 <a name="eslint-plugin-jsdoc-rules-check-types-why-not-capital-case-everything"></a>
 #### Why not capital case everything?
 
-Why are `boolean`, `number` and `string` exempt from starting with a capital letter? Let's take `string` as an example. In Javascript, everything is an object. The string Object has prototypes for string functions such as `.toUpperCase()`.
+Why are `boolean`, `number` and `string` exempt from starting with a capital letter? Let's take `string` as an example. In Javascript, everything is an object. The string Object has prototypes for string functions such as `.toUpperCase()`. 
 
-Fortunately we don't have to write `new String()` everywhere in our code. Javascript will automatically wrap string primitives into string Objects when we're applying a string function to a string primitive. This way the memory footprint is a tiny little bit smaller, and the [GC](https://en.wikipedia.org/wiki/Garbage_collection_(computer_science)) has less work to do.
+Fortunately we don't have to write `new String()` everywhere in our code. Javascript will automatically wrap string primitives into string Objects when we're applying a string function to a string primitive. This way the memory footprint is a tiny little bit smaller, and the [GC](https://en.wikipedia.org/wiki/Garbage_collection_(computer_science)) has less work to do. 
 
 So in a sense, there two types of strings in Javascript; `{string}` literals, also called primitives and `{String}` Objects. We use the primitives because it's easier to write and uses less memory. `{String}` and `{string}` are technically both valid, but they are not the same.
 
@@ -2464,7 +2464,6 @@ The following patterns are considered problems:
  */
 function quux (foo) {
 
-  return foo;
 }
 // Message: Present JSDoc @returns declaration but not available return expression in function.
 
@@ -2473,7 +2472,6 @@ function quux (foo) {
  */
 function quux (foo) {
 
-  return foo;
 }
 // Settings: {"jsdoc":{"tagNamePreference":{"returns":"return"}}}
 // Message: Present JSDoc @return declaration but not available return expression in function.
@@ -2483,6 +2481,16 @@ function quux (foo) {
  */
 const quux = () => {}
 // Message: Present JSDoc @returns declaration but not available return expression in function.
+
+/**
+ * @returns {undefined} Foo.
+ * @returns {String} Foo.
+ */
+function quux () {
+
+  return foo;
+}
+// Message: Found more than one @returns declaration.
 ````
 
 The following patterns are not considered problems:
@@ -2523,15 +2531,23 @@ function quux () {
  */
 const quux = () => foo;
 
-/**
+/** 
  * @returns {Promise<void>}
  */
 async function quux() {}
 
-/**
+/** 
  * @returns {Promise<void>}
  */
 async () => {}
+
+/** 
+ * @returns Foo.
+ * @abstract
+ */
+function quux () {
+  throw new Error('must be implemented by subclass!');
+}
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ function quux () {
 
 }
 // Settings: {"jsdoc":{"baseConfig":{"rules":{"no-undef":["error"]}},"eslintrcForExamples":false,"noDefaultExampleRules":true}}
-// Message: @example error (semi): Extra semicolon.
+// Message: @example error (no-undef): 'quux' is not defined.
 
 /**
  * @example <caption>Valid usage</caption>
@@ -1018,6 +1018,30 @@ function quux (foo, bar, baz) {
  */
 function quux (foo, bar, baz) {
 
+}
+
+/**
+ * @param {typeof bar} foo
+ */
+function qux(foo) {
+}
+
+/**
+ * @param {import('./foo').bar.baz} foo
+ */
+function qux(foo) {
+}
+
+/**
+ * @param {(x: number, y: string) => string} foo
+ */
+function qux(foo) {
+}
+
+/**
+ * @param {() => string} foo
+ */
+function qux(foo) {
 }
 ````
 
@@ -2215,298 +2239,36 @@ The following patterns are considered problems:
  */
 function quux (foo) {
 
+  return foo;
 }
-// Message: Missing JSDoc @param "foo" declaration.
+// Message: Missing JSDoc @returns declaration.
 
 /**
  *
  */
 function quux (foo) {
 
+  return foo;
 }
-// Settings: {"jsdoc":{"tagNamePreference":{"param":"arg"}}}
-// Message: Missing JSDoc @arg "foo" declaration.
-
-/**
- * @param foo
- */
-function quux (foo, bar) {
-
-}
-// Message: Missing JSDoc @param "bar" declaration.
-
-/**
- * @override
- */
-function quux (foo) {
-
-}
-// Message: Missing JSDoc @param "foo" declaration.
-
-/**
- * @implements
- */
-function quux (foo) {
-
-}
-// Message: Missing JSDoc @param "foo" declaration.
-
-/**
- * @augments
- */
-function quux (foo) {
-
-}
-// Message: Missing JSDoc @param "foo" declaration.
-
-/**
- * @extends
- */
-function quux (foo) {
-
-}
-// Message: Missing JSDoc @param "foo" declaration.
-
-/**
- * @override
- */
-class A {
-  /**
-    *
-    */
-  quux (foo) {
-
-  }
-}
-// Message: Missing JSDoc @param "foo" declaration.
-
-/**
- * @implements
- */
-class A {
-  /**
-   *
-   */
-  quux (foo) {
-
-  }
-}
-// Message: Missing JSDoc @param "foo" declaration.
-
-/**
- * @augments
- */
-class A {
-  /**
-   *
-   */
-  quux (foo) {
-
-  }
-}
-// Message: Missing JSDoc @param "foo" declaration.
-
-/**
- * @extends
- */
-class A {
-  /**
-   *
-   */
-  quux (foo) {
-
-  }
-}
-// Message: Missing JSDoc @param "foo" declaration.
+// Settings: {"jsdoc":{"tagNamePreference":{"returns":"return"}}}
+// Message: Missing JSDoc @return declaration.
 ````
 
 The following patterns are not considered problems:
 
 ````js
 /**
- * @param foo
+ * @returns Foo.
  */
-function quux (foo) {
+function quux () {
 
+  return foo;
 }
 
 /**
- * @inheritdoc
+ *
  */
-function quux (foo) {
-
-}
-
-/**
- * @arg foo
- */
-function quux (foo) {
-
-}
-// Settings: {"jsdoc":{"tagNamePreference":{"param":"arg"}}}
-
-/**
- * @override
- * @param foo
- */
-function quux (foo) {
-
-}
-
-/**
- * @override
- */
-function quux (foo) {
-
-}
-// Settings: {"jsdoc":{"allowOverrideWithoutParam":true}}
-
-/**
- * @implements
- */
-function quux (foo) {
-
-}
-// Settings: {"jsdoc":{"allowImplementsWithoutParam":true}}
-
-/**
- * @implements
- * @param foo
- */
-function quux (foo) {
-
-}
-
-/**
- * @augments
- */
-function quux (foo) {
-
-}
-// Settings: {"jsdoc":{"allowAugmentsExtendsWithoutParam":true}}
-
-/**
- * @augments
- * @param foo
- */
-function quux (foo) {
-
-}
-
-/**
- * @extends
- */
-function quux (foo) {
-
-}
-// Settings: {"jsdoc":{"allowAugmentsExtendsWithoutParam":true}}
-
-/**
- * @extends
- * @param foo
- */
-function quux (foo) {
-
-}
-
-/**
- * @override
- */
-class A {
-  /**
-  * @param foo
-  */
-  quux (foo) {
-
-  }
-}
-
-/**
- * @override
- */
-class A {
-  /**
-   *
-   */
-  quux (foo) {
-
-  }
-}
-// Settings: {"jsdoc":{"allowOverrideWithoutParam":true}}
-
-/**
- * @implements
- */
-class A {
-  /**
-   *
-   */
-  quux (foo) {
-
-  }
-}
-// Settings: {"jsdoc":{"allowImplementsWithoutParam":true}}
-
-/**
- * @implements
- */
-class A {
-  /**
-   * @param foo
-   */
-  quux (foo) {
-
-  }
-}
-
-/**
- * @augments
- */
-class A {
-  /**
-   *
-   */
-  quux (foo) {
-
-  }
-}
-// Settings: {"jsdoc":{"allowAugmentsExtendsWithoutParam":true}}
-
-/**
- * @augments
- */
-class A {
-  /**
-   * @param foo
-   */
-  quux (foo) {
-
-  }
-}
-
-/**
- * @extends
- */
-class A {
-  /**
-   *
-   */
-  quux (foo) {
-
-  }
-}
-// Settings: {"jsdoc":{"allowAugmentsExtendsWithoutParam":true}}
-
-/**
- * @extends
- */
-class A {
-  /**
-   * @param foo
-   */
-  quux (foo) {
-
-  }
+function quux () {
 }
 ````
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "comment-parser": "^0.5.1",
-    "jsdoctypeparser": "^2.0.0-alpha-8",
+    "jsdoctypeparser": "3.1.0",
     "lodash": "^4.17.11"
   },
   "description": "JSDoc linting rules for ESLint.",
@@ -58,7 +58,7 @@
     "build": "rm -fr ./dist && NODE_ENV=production babel ./src --out-dir ./dist --copy-files --source-maps",
     "create-readme": "gitdown ./.README/README.md --output-file ./README.md && npm run add-assertions",
     "lint": "eslint ./src ./test",
-    "test": "mocha --recursive --require @babel/register"
+    "test": "mocha --recursive --require @babel/register --reporter progress"
   },
   "version": "1.0.0"
 }

--- a/src/rules/checkIndentation.js
+++ b/src/rules/checkIndentation.js
@@ -7,6 +7,7 @@ export default iterateJsdoc(({
 }) => {
   const reg = new RegExp(/^[ \t]+\*[ \t]{2}/m);
   const text = sourceCode.getText(jsdocNode);
+
   if (reg.test(text)) {
     report('There must be no indentation.');
   }

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -175,6 +175,6 @@ export default {
           function qux(foo) {
           }
       `
-    },
+    }
   ]
 };

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -157,6 +157,6 @@ export default {
           function qux(foo) {
           }
       `
-    },
+    }
   ]
 };

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -157,6 +157,24 @@ export default {
           function qux(foo) {
           }
       `
-    }
+    },
+    {
+      code: `
+          /**
+           * @param {(x: number, y: string) => string} foo
+           */
+          function qux(foo) {
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @param {() => string} foo
+           */
+          function qux(foo) {
+          }
+      `
+    },
   ]
 };

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -139,6 +139,24 @@ export default {
 
           }
       `
-    }
+    },
+    {
+      code: `
+          /**
+           * @param {typeof bar} foo
+           */
+          function qux(foo) {
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @param {import('./foo').bar.baz} foo
+           */
+          function qux(foo) {
+          }
+      `
+    },
   ]
 };


### PR DESCRIPTION
This PR shows that #133 is fixed, and that #145 is starting to be addressed.

However, it depends on Kuniwak/jsdoctypeparser#51 being merged and a new version of that package being published.