### PR TITLE
Detect implicit return and fix nested return false positive. Closes #148

### DIFF
--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -14,7 +14,30 @@ export default iterateJsdoc(({
 
   const sourcecode = utils.getFunctionSourceCode();
 
-  if (JSON.stringify(jsdocTags) === '[]' && sourcecode.indexOf('return') >= 1) {
+  // build a one-liner to test against
+  const flattenedSource = sourcecode.replace(/\r?\n|\r|\s/g, '');
+
+  const startsWithReturn = '(\\)\\s?\\{return)';
+
+  const endsWithReturn = '(return.*\\})';
+
+  const implicitReturn = '(\\s?=>\\s?\\b.*)';
+
+  const implicitObjectReturn = '(\\s?=>\\s?\\(\\{)';
+
+  const matcher = new RegExp([
+    startsWithReturn,
+    endsWithReturn,
+    implicitObjectReturn,
+    implicitReturn
+  ].join('|'), 'gim');
+
+  const positiveTest = (flattenedSource.match(matcher) || []).length > 0;
+
+  const negativeTest = (flattenedSource.match(/(\{.*\{.*return)/gim) || []).length > 0 &&
+    (flattenedSource.match(/(return)/gim) || []).length < 2;
+
+  if (JSON.stringify(jsdocTags) === '[]' && positiveTest && !negativeTest) {
     report('Missing JSDoc @' + targetTagName + ' declaration.');
   }
 });

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -22,6 +22,50 @@ export default {
           /**
            *
            */
+          const foo = () => ({
+            bar: 'baz'
+          })
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.'
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          const foo = bar=>({ bar })
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.'
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          const foo = bar => bar.baz()
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.'
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           *
+           */
           function quux (foo) {
 
             return foo;
@@ -61,6 +105,38 @@ export default {
            */
           function quux () {
           }
+      `
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (bar) {
+            bar.filter(baz => {
+              return baz.corge();
+            })
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns Array
+           */
+          function quux (bar) {
+            return bar.filter(baz => {
+              return baz.corge();
+            })
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns Array
+           */
+          const quux = (bar) => bar.filter(({ corge }) => corge())
       `
     }
   ]


### PR DESCRIPTION
Ok so I got this working. There was no real way to do this without installing an AST parser/generator. So, I ended up implementing the checks via Regex on the function's source code.

Not sure what everyone thinks of this but it does work. I added a bunch more test cases as well. Everything passes.