### PR TITLE
RequireReturns Rule does not honor inheritdoc tag.

### DIFF
--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -6,6 +6,14 @@ export default iterateJsdoc(({
   report,
   utils
 }) => {
+  // inheritdoc implies that all documentation is inherited
+  // see http://usejsdoc.org/tags-inheritdoc.html
+  //
+  // As we do not know the parent method, we cannot perform any checks.
+  if (utils.hasTag('inheritdoc')) {
+    return;
+  }
+
   const targetTagName = utils.getPreferredTagName('returns');
 
   const jsdocTags = _.filter(jsdoc.tags, {

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -138,6 +138,16 @@ export default {
            */
           const quux = (bar) => bar.filter(({ corge }) => corge())
       `
+    },
+    {
+      code: `
+          /**
+           * @inheritdoc
+           */
+          function quux (foo) {
+            return "test"
+          }
+      `
     }
   ]
 };


### PR DESCRIPTION
Currently the requireReturns Rule indicates false positives in case you use the inherit documentation.

In a perfect world the inherited documentation should be checked. But the requireReturns Rule has no information about the inheritance. So disabling the Rule in case a jsdoc comment with a inherit tag was found seems to be the only viable solution. 

This pull request fixes #153.