### PR TITLE
feat: make require-returns-description accept void functions (fixes #157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2146,6 +2146,20 @@ function quux () {
 function quux () {
 
 }
+
+/**
+ * @returns {undefined}
+ */
+function quux () {
+
+}
+
+/**
+ * @returns {void}
+ */
+function quux () {
+
+}
 ````
 
 
@@ -2358,6 +2372,13 @@ function quux (bar) {
  * @returns Array
  */
 const quux = (bar) => bar.filter(({ corge }) => corge())
+
+/**
+ * @inheritdoc
+ */
+function quux (foo) {
+  return "test"
+}
 ````
 
 

--- a/src/rules/requireReturnsDescription.js
+++ b/src/rules/requireReturnsDescription.js
@@ -13,6 +13,12 @@ export default iterateJsdoc(({
   });
 
   _.forEach(jsdocTags, (jsdocTag) => {
+    const type = jsdocTag.type && jsdocTag.type.trim();
+
+    if (type === 'void' || type === 'undefined') {
+      return;
+    }
+
     if (!jsdocTag.description) {
       report('Missing JSDoc @' + targetTagName + ' description.', null, jsdocTag);
     }

--- a/test/rules/assertions/requireReturnsDescription.js
+++ b/test/rules/assertions/requireReturnsDescription.js
@@ -60,6 +60,26 @@ export default {
 
           }
       `
+    },
+    {
+      code: `
+          /**
+           * @returns {undefined}
+           */
+          function quux () {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns {void}
+           */
+          function quux () {
+
+          }
+      `
     }
   ]
 };


### PR DESCRIPTION
Fixes  #157 .

If the return type is `{void}` or `{undefined}`, return description is not required.