### PR TITLE
feat: add support for @template tag (fixes #165)

### DIFF
--- a/src/tagNames.js
+++ b/src/tagNames.js
@@ -85,6 +85,7 @@ export default {
   since: [],
   static: [],
   summary: [],
+  template: [],
   this: [],
   throws: [
     'exception'


### PR DESCRIPTION
Though this tag is not defined in jsdoc itself, it is used
by closure compiler and typescript.