### PR TITLE
 feat: Update supported jsdoc tags (fixes #163)

### DIFF
--- a/.README/rules/check-tag-names.md
+++ b/.README/rules/check-tag-names.md
@@ -8,6 +8,7 @@ Valid [JSDoc 3 Block Tags](http://usejsdoc.org/#block-tags) are:
 abstract
 access
 alias
+async
 augments
 author
 borrows
@@ -28,6 +29,7 @@ external
 file
 fires
 function
+generator
 global
 hideconstructor
 ignore
@@ -48,6 +50,7 @@ module
 name
 namespace
 override
+package
 param
 private
 property
@@ -68,6 +71,7 @@ type
 typedef
 variation
 version
+yields
 ```
 
 |||

--- a/README.md
+++ b/README.md
@@ -674,6 +674,7 @@ Valid [JSDoc 3 Block Tags](http://usejsdoc.org/#block-tags) are:
 abstract
 access
 alias
+async
 augments
 author
 borrows
@@ -694,6 +695,7 @@ external
 file
 fires
 function
+generator
 global
 hideconstructor
 ignore
@@ -714,6 +716,7 @@ module
 name
 namespace
 override
+package
 param
 private
 property
@@ -734,6 +737,7 @@ type
 typedef
 variation
 version
+yields
 ```
 
 |||

--- a/src/tagNames.js
+++ b/src/tagNames.js
@@ -45,6 +45,7 @@ export default {
     'func',
     'method'
   ],
+  generator: [],
   global: [],
   hideconstructor: [],
   ignore: [],
@@ -67,6 +68,7 @@ export default {
   name: [],
   namespace: [],
   override: [],
+  package: [],
   param: [
     'arg',
     'argument'
@@ -95,5 +97,8 @@ export default {
   type: [],
   typedef: [],
   variation: [],
-  version: []
+  version: [],
+  yields: [
+    'yield'
+  ]
 };


### PR DESCRIPTION
Added `@generator`, `@package` and `@yields`, which are listed in http://usejsdoc.org/ .