### PR TITLE
Fix: correct error message of `check-types` (fixes #103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -984,6 +984,15 @@ function quux (foo) {
 // Message: Invalid JSDoc @arg "foo" type "Number".
 
 /**
+ * @returns {Number} foo
+ * @throws {Number} foo
+ */
+function quux () {
+
+}
+// Message: Invalid JSDoc @returns type "Number".
+
+/**
  * @param {(Number|string|Boolean)=} foo
  */
 function quux (foo, bar, baz) {

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -10,7 +10,7 @@ const parseComment = (commentNode, indent) => {
       commentParser.PARSERS.parse_tag,
       commentParser.PARSERS.parse_type,
       (str, data) => {
-        if (_.includes(['return', 'returns'], data.tag)) {
+        if (_.includes(['return', 'returns', 'throws', 'exception'], data.tag)) {
           return null;
         }
 

--- a/src/rules/checkTypes.js
+++ b/src/rules/checkTypes.js
@@ -80,7 +80,9 @@ export default iterateJsdoc(({
           return fixer.replaceText(jsdocNode, sourceCode.getText(jsdocNode).replace('{' + jsdocTag.type + '}', '{' + fixedType + '}'));
         };
 
-        report('Invalid JSDoc @' + jsdocTag.tag + ' "' + jsdocTag.name + '" type "' + invalidType + '".', fix, jsdocTag);
+        const name = jsdocTag.name ? ' "' + jsdocTag.name + '"' : '';
+
+        report('Invalid JSDoc @' + jsdocTag.tag + name + ' type "' + invalidType + '".', fix, jsdocTag);
       });
     }
   });

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -51,6 +51,27 @@ export default {
     {
       code: `
           /**
+           * @returns {Number} foo
+           * @throws {Number} foo
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @returns type "Number".'
+        },
+        {
+          line: 4,
+          message: 'Invalid JSDoc @throws type "Number".'
+        }
+      ]
+    },
+    {
+      code: `
+          /**
            * @param {(Number|string|Boolean)=} foo
            */
           function quux (foo, bar, baz) {


### PR DESCRIPTION
Previously when the tag is `@returns` or `@throws`, the
error message was `Invalid JSDoc @returns "" type "Number" .`.
Now the empty quotes are removed.