### PR TITLE
Makes "Check Returns" ignore abstract methods.

### DIFF
--- a/src/rules/requireReturnsCheck.js
+++ b/src/rules/requireReturnsCheck.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import iterateJsdoc from '../iterateJsdoc';
 
 export default iterateJsdoc(({
@@ -7,18 +6,6 @@ export default iterateJsdoc(({
   functionNode,
   utils
 }) => {
-  const targetTagName = utils.getPreferredTagName('returns');
-
-  const jsdocTags = _.filter(jsdoc.tags, {
-    tag: targetTagName
-  });
-
-  const sourcecode = utils.getFunctionSourceCode();
-
-  const voidReturn = jsdocTags.findIndex((vundef) => {
-    return ['undefined', 'void'].indexOf(vundef.type) !== -1;
-  }) === -1;
-
   // Implicit return like `() => foo` is ok
   if (functionNode.type === 'ArrowFunctionExpression' && functionNode.expression) {
     return;
@@ -29,7 +16,42 @@ export default iterateJsdoc(({
     return;
   }
 
-  if (JSON.stringify(jsdocTags) !== '[]' && voidReturn && sourcecode.indexOf('return') < 1) {
+  const targetTagName = utils.getPreferredTagName('returns');
+
+  // We can skip in case there are no tags defined...
+  if (typeof jsdoc.tags === 'undefined') {
+    return;
+  }
+
+  const jsdocTags = jsdoc.tags.filter((item) => {
+    return item.tag === targetTagName;
+  });
+
+  if (jsdocTags.length === 0) {
+    return;
+  }
+
+  if (jsdocTags.length > 1) {
+    report('Found more than one @' + targetTagName + ' declaration.');
+
+    return;
+  }
+
+  // An abstract function is by definition incomplete
+  // so it is perfectly fine if the return is missing
+  // a subclass may inherits the doc an implements the
+  // missing return.
+  const isAbstract = jsdoc.tags.some((item) => {
+    return item.tag === utils.getPreferredTagName('abstract');
+  });
+
+  if (isAbstract) {
+    return;
+  }
+
+  const sourcecode = utils.getFunctionSourceCode();
+
+  if (sourcecode.indexOf('return') === -1) {
     report('Present JSDoc @' + targetTagName + ' declaration but not available return expression in function.');
   }
 });

--- a/test/rules/assertions/requireReturnsCheck.js
+++ b/test/rules/assertions/requireReturnsCheck.js
@@ -52,6 +52,24 @@ export default {
           message: 'Present JSDoc @returns declaration but not available return expression in function.'
         }
       ]
+    },
+    {
+      code: `
+          /**
+           * @returns {undefined} Foo.
+           * @returns {String} Foo.
+           */
+          function quux () {
+
+            return foo;
+          }
+        `,
+      errors: [
+        {
+          line: 2,
+          message: 'Found more than one @returns declaration.'
+        }
+      ]
     }
   ],
   valid: [
@@ -126,6 +144,17 @@ export default {
       parserOptions: {
         ecmaVersion: 8
       }
+    },
+    {
+      code: `
+          /** 
+           * @returns Foo.
+           * @abstract
+           */
+          function quux () {
+            throw new Error('must be implemented by subclass!');
+          }
+      `
     }
   ]
 };


### PR DESCRIPTION
Abstract methods are typically completely documented as their children inherit their documentation by default. But their implementation is normally a single thow statement.

A perfect example can be found in the JSDoc Documentation:
http://usejsdoc.org/tags-abstract.html

The current eslint-plugin-jsdoc implementation fails in this case. It complains about a missing return statement. 

I also reordered the code and removed code which looks to me obsolete. I could not think of any example where the check for undefined or void code could kick into action. There is also no unit test which would cover this branch.

Futhermore I added a test which ensures at most one returns parameter is specified. 