### PR TITLE
feat: add rule check syntax

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -16,6 +16,7 @@ This table maps the rules between `eslint-plugin-jsdoc` and `jscs-jsdoc`.
 | --- | --- |
 | [`check-examples`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-examples) | N/A |
 | [`check-param-names`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-param-names) | [`checkParamNames`](https://github.com/jscs-dev/jscs-jsdoc#checkparamnames) |
+| [`check-syntax`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-syntax) | N/A |
 | [`check-tag-names`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-tag-names) | N/A ~ [`checkAnnotations`](https://github.com/jscs-dev/jscs-jsdoc#checkannotations) |
 | [`check-types`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-types) | [`checkTypes`](https://github.com/jscs-dev/jscs-jsdoc#checktypes) |
 | [`newline-after-description`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-newline-after-description) | [`requireNewlineAfterDescription`](https://github.com/jscs-dev/jscs-jsdoc#requirenewlineafterdescription) and [`disallowNewlineAfterDescription`](https://github.com/jscs-dev/jscs-jsdoc#disallownewlineafterdescription) |
@@ -73,6 +74,7 @@ Finally, enable all of the rules that you would like to use.
     "rules": {
         "jsdoc/check-examples": 1,
         "jsdoc/check-param-names": 1,
+        "jsdoc/check-syntax": 1,
         "jsdoc/check-tag-names": 1,
         "jsdoc/check-types": 1,
         "jsdoc/newline-after-description": 1,
@@ -247,6 +249,7 @@ Finally, the following rule pertains to inline disable directives:
 
 {"gitdown": "include", "file": "./rules/check-examples.md"}
 {"gitdown": "include", "file": "./rules/check-param-names.md"}
+{"gitdown": "include", "file": "./rules/check-syntax.md"}
 {"gitdown": "include", "file": "./rules/check-tag-names.md"}
 {"gitdown": "include", "file": "./rules/check-types.md"}
 {"gitdown": "include", "file": "./rules/newline-after-description.md"}

--- a/.README/rules/check-syntax.md
+++ b/.README/rules/check-syntax.md
@@ -1,0 +1,10 @@
+### `check-syntax`
+
+Reports against Google Closure Compiler syntax.
+
+|||
+|---|---|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Tags|N/A|
+
+<!-- assertions checkSyntax -->

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ JSDoc linting rules for ESLint.
     * [Rules](#eslint-plugin-jsdoc-rules)
         * [`check-examples`](#eslint-plugin-jsdoc-rules-check-examples)
         * [`check-param-names`](#eslint-plugin-jsdoc-rules-check-param-names)
+        * [`check-syntax`](#eslint-plugin-jsdoc-rules-check-syntax)
         * [`check-tag-names`](#eslint-plugin-jsdoc-rules-check-tag-names)
         * [`check-types`](#eslint-plugin-jsdoc-rules-check-types)
         * [`newline-after-description`](#eslint-plugin-jsdoc-rules-newline-after-description)
@@ -47,6 +48,7 @@ This table maps the rules between `eslint-plugin-jsdoc` and `jscs-jsdoc`.
 | --- | --- |
 | [`check-examples`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-examples) | N/A |
 | [`check-param-names`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-param-names) | [`checkParamNames`](https://github.com/jscs-dev/jscs-jsdoc#checkparamnames) |
+| [`check-syntax`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-syntax) | N/A |
 | [`check-tag-names`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-tag-names) | N/A ~ [`checkAnnotations`](https://github.com/jscs-dev/jscs-jsdoc#checkannotations) |
 | [`check-types`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-types) | [`checkTypes`](https://github.com/jscs-dev/jscs-jsdoc#checktypes) |
 | [`newline-after-description`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-newline-after-description) | [`requireNewlineAfterDescription`](https://github.com/jscs-dev/jscs-jsdoc#requirenewlineafterdescription) and [`disallowNewlineAfterDescription`](https://github.com/jscs-dev/jscs-jsdoc#disallownewlineafterdescription) |
@@ -106,6 +108,7 @@ Finally, enable all of the rules that you would like to use.
     "rules": {
         "jsdoc/check-examples": 1,
         "jsdoc/check-param-names": 1,
+        "jsdoc/check-syntax": 1,
         "jsdoc/check-tag-names": 1,
         "jsdoc/check-types": 1,
         "jsdoc/newline-after-description": 1,
@@ -662,6 +665,40 @@ function quux ({
 `{a, b}` is an [`ObjectPattern`](https://github.com/estree/estree/blob/master/es2015.md#objectpattern) AST type and does not have a name. Therefore, the associated parameter in JSDoc block can have any name.
 
 Likewise for the pattern `[a, b]` which is an [`ArrayPattern`](https://github.com/estree/estree/blob/master/es2015.md#arraypattern).
+
+<a name="eslint-plugin-jsdoc-rules-check-syntax"></a>
+### <code>check-syntax</code>
+
+Reports against Google Closure Compiler syntax.
+
+|||
+|---|---|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Tags|N/A|
+
+The following patterns are considered problems:
+
+````js
+/**
+ * @param {string=} foo
+ */
+function quux (foo) {
+
+}
+// Message: Syntax should not be Google Closure Compiler style.
+````
+
+The following patterns are not considered problems:
+
+````js
+/**
+ * @param {string} [foo]
+ */
+function quux (foo) {
+
+}
+````
+
 
 <a name="eslint-plugin-jsdoc-rules-check-tag-names"></a>
 ### <code>check-tag-names</code>

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/max-dependencies */
 import checkExamples from './rules/checkExamples';
 import checkParamNames from './rules/checkParamNames';
+import checkSyntax from './rules/checkSyntax';
 import checkTagNames from './rules/checkTagNames';
 import checkTypes from './rules/checkTypes';
 import newlineAfterDescription from './rules/newlineAfterDescription';
@@ -25,6 +26,7 @@ export default {
       rules: {
         'jsdoc/check-examples': 'off',
         'jsdoc/check-param-names': 'warn',
+        'jsdoc/check-syntax': 'off',
         'jsdoc/check-tag-names': 'warn',
         'jsdoc/check-types': 'warn',
         'jsdoc/newline-after-description': 'warn',
@@ -48,6 +50,7 @@ export default {
   rules: {
     'check-examples': checkExamples,
     'check-param-names': checkParamNames,
+    'check-syntax': checkSyntax,
     'check-tag-names': checkTagNames,
     'check-types': checkTypes,
     'newline-after-description': newlineAfterDescription,

--- a/src/rules/checkSyntax.js
+++ b/src/rules/checkSyntax.js
@@ -1,0 +1,17 @@
+import iterateJsdoc from '../iterateJsdoc';
+
+export default iterateJsdoc(({
+  jsdoc,
+  report
+}) => {
+  if (!jsdoc.tags.length) {
+    return;
+  }
+
+  for (const tag of jsdoc.tags) {
+    if (tag.type.slice(-1) === '=') {
+      report('Syntax should not be Google Closure Compiler style.');
+      break;
+    }
+  }
+});

--- a/test/rules/assertions/checkSyntax.js
+++ b/test/rules/assertions/checkSyntax.js
@@ -1,0 +1,31 @@
+export default {
+  invalid: [
+    {
+      code: `
+          /**
+           * @param {string=} foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Syntax should not be Google Closure Compiler style.'
+        }
+      ]
+    }
+  ],
+  valid: [
+    {
+      code: `
+          /**
+           * @param {string} [foo]
+           */
+          function quux (foo) {
+
+          }
+      `
+    }
+  ]
+};

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -9,6 +9,7 @@ const ruleTester = new RuleTester();
 _.forEach([
   'check-examples',
   'check-param-names',
+  'check-syntax',
   'check-tag-names',
   'check-types',
   'newline-after-description',


### PR DESCRIPTION
Reports against Google Closure Compiler syntax.

Only checks for `optional` style at the moment. Would be good to expand upon in the future / add optionals for `always-google-closure`, etc.