### PR TITLE
feat: add rule check indentation

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -15,6 +15,7 @@ This table maps the rules between `eslint-plugin-jsdoc` and `jscs-jsdoc`.
 | `eslint-plugin-jsdoc` | `jscs-jsdoc` |
 | --- | --- |
 | [`check-examples`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-examples) | N/A |
+| [`check-indentation`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-indentation) | N/A |
 | [`check-param-names`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-param-names) | [`checkParamNames`](https://github.com/jscs-dev/jscs-jsdoc#checkparamnames) |
 | [`check-tag-names`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-tag-names) | N/A ~ [`checkAnnotations`](https://github.com/jscs-dev/jscs-jsdoc#checkannotations) |
 | [`check-types`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-types) | [`checkTypes`](https://github.com/jscs-dev/jscs-jsdoc#checktypes) |
@@ -72,6 +73,7 @@ Finally, enable all of the rules that you would like to use.
 {
     "rules": {
         "jsdoc/check-examples": 1,
+        "jsdoc/check-indentation": 1,
         "jsdoc/check-param-names": 1,
         "jsdoc/check-tag-names": 1,
         "jsdoc/check-types": 1,
@@ -246,6 +248,7 @@ Finally, the following rule pertains to inline disable directives:
 ## Rules
 
 {"gitdown": "include", "file": "./rules/check-examples.md"}
+{"gitdown": "include", "file": "./rules/check-indentation.md"}
 {"gitdown": "include", "file": "./rules/check-param-names.md"}
 {"gitdown": "include", "file": "./rules/check-tag-names.md"}
 {"gitdown": "include", "file": "./rules/check-types.md"}

--- a/.README/rules/check-indentation.md
+++ b/.README/rules/check-indentation.md
@@ -1,0 +1,10 @@
+### `check-indentation`
+
+Reports invalid padding inside JSDoc block.
+
+|||
+|---|---|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Tags|N/A|
+
+<!-- assertions checkIndentation -->

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ JSDoc linting rules for ESLint.
         * [Settings to Configure `check-examples`](#eslint-plugin-jsdoc-settings-settings-to-configure-check-examples)
     * [Rules](#eslint-plugin-jsdoc-rules)
         * [`check-examples`](#eslint-plugin-jsdoc-rules-check-examples)
+        * [`check-indentation`](#eslint-plugin-jsdoc-rules-check-indentation)
         * [`check-param-names`](#eslint-plugin-jsdoc-rules-check-param-names)
         * [`check-tag-names`](#eslint-plugin-jsdoc-rules-check-tag-names)
         * [`check-types`](#eslint-plugin-jsdoc-rules-check-types)
@@ -46,6 +47,7 @@ This table maps the rules between `eslint-plugin-jsdoc` and `jscs-jsdoc`.
 | `eslint-plugin-jsdoc` | `jscs-jsdoc` |
 | --- | --- |
 | [`check-examples`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-examples) | N/A |
+| [`check-indentation`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-indentation) | N/A |
 | [`check-param-names`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-param-names) | [`checkParamNames`](https://github.com/jscs-dev/jscs-jsdoc#checkparamnames) |
 | [`check-tag-names`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-tag-names) | N/A ~ [`checkAnnotations`](https://github.com/jscs-dev/jscs-jsdoc#checkannotations) |
 | [`check-types`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-types) | [`checkTypes`](https://github.com/jscs-dev/jscs-jsdoc#checktypes) |
@@ -105,6 +107,7 @@ Finally, enable all of the rules that you would like to use.
 {
     "rules": {
         "jsdoc/check-examples": 1,
+        "jsdoc/check-indentation": 1,
         "jsdoc/check-param-names": 1,
         "jsdoc/check-tag-names": 1,
         "jsdoc/check-types": 1,
@@ -482,6 +485,46 @@ function quux () {}
  */
 function quux () {}
 // Settings: {"jsdoc":{"allowInlineConfig":true,"baseConfig":{"rules":{"semi":["error","always"]}},"eslintrcForExamples":false,"noDefaultExampleRules":true}}
+````
+
+
+<a name="eslint-plugin-jsdoc-rules-check-indentation"></a>
+### <code>check-indentation</code>
+
+Reports invalid padding inside JSDoc block.
+
+|||
+|---|---|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Tags|N/A|
+
+The following patterns are considered problems:
+
+````js
+/**
+ * foo
+ *
+ * @param bar
+ *  baz
+ */
+function quux () {
+
+}
+// Message: There must be no indentation.
+````
+
+The following patterns are not considered problems:
+
+````js
+/**
+ * foo
+ *
+ * @param bar
+ * baz
+ */
+function quux () {
+
+}
 ````
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/max-dependencies */
 import checkExamples from './rules/checkExamples';
+import checkIndentation from './rules/checkIndentation';
 import checkParamNames from './rules/checkParamNames';
 import checkTagNames from './rules/checkTagNames';
 import checkTypes from './rules/checkTypes';
@@ -24,6 +25,7 @@ export default {
     recommended: {
       rules: {
         'jsdoc/check-examples': 'off',
+        'jsdoc/check-indentation': 'off',
         'jsdoc/check-param-names': 'warn',
         'jsdoc/check-tag-names': 'warn',
         'jsdoc/check-types': 'warn',
@@ -47,6 +49,7 @@ export default {
   },
   rules: {
     'check-examples': checkExamples,
+    'check-indentation': checkIndentation,
     'check-param-names': checkParamNames,
     'check-tag-names': checkTagNames,
     'check-types': checkTypes,

--- a/src/rules/checkIndentation.js
+++ b/src/rules/checkIndentation.js
@@ -1,0 +1,13 @@
+import iterateJsdoc from '../iterateJsdoc';
+
+export default iterateJsdoc(({
+  sourceCode,
+  jsdocNode,
+  report
+}) => {
+  const reg = new RegExp(/^[ \t]+\*[ \t]{2}/m);
+  const text = sourceCode.getText(jsdocNode);
+  if (reg.test(text)) {
+    report('There must be no indentation.');
+  }
+});

--- a/test/rules/assertions/checkIndentation.js
+++ b/test/rules/assertions/checkIndentation.js
@@ -1,0 +1,37 @@
+export default {
+  invalid: [
+    {
+      code: `
+          /**
+           * foo
+           *
+           * @param bar
+           *  baz
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'There must be no indentation.'
+        }
+      ]
+    }
+  ],
+  valid: [
+    {
+      code: `
+          /**
+           * foo
+           *
+           * @param bar
+           * baz
+           */
+          function quux () {
+
+          }
+      `
+    }
+  ]
+};

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -8,6 +8,7 @@ const ruleTester = new RuleTester();
 
 _.forEach([
   'check-examples',
+  'check-indentation',
   'check-param-names',
   'check-tag-names',
   'check-types',


### PR DESCRIPTION
Reports against extra indentation of eg; description blocks. Would be good to add optionals in the future to specify `allowed` and `max` levels of indentation.

Eg; Invalid:
```
    /**
     * Description line one
     *                     line two
     */
```