### PR TITLE
Implement a requireJSDoc compatible rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ import requireReturnsCheck from './rules/requireReturnsCheck';
 import requireReturnsDescription from './rules/requireReturnsDescription';
 import requireReturnsType from './rules/requireReturnsType';
 import validTypes from './rules/validTypes';
+import requireJSDoc from './rules/requireJSDoc';
 
 export default {
   configs: {
@@ -33,6 +34,7 @@ export default {
         'jsdoc/require-description-complete-sentence': 'off',
         'jsdoc/require-example': 'off',
         'jsdoc/require-hyphen-before-param-description': 'off',
+        'jsdoc/require-jsdoc': 'warn',
         'jsdoc/require-param': 'warn',
         'jsdoc/require-param-description': 'warn',
         'jsdoc/require-param-name': 'warn',
@@ -56,6 +58,7 @@ export default {
     'require-description-complete-sentence': requireDescriptionCompleteSentence,
     'require-example': requireExample,
     'require-hyphen-before-param-description': requireHyphenBeforeParamDescription,
+    'require-jsdoc': requireJSDoc,
     'require-param': requireParam,
     'require-param-description': requireParamDescription,
     'require-param-name': requireParamName,

--- a/src/rules/requireJSDoc.js
+++ b/src/rules/requireJSDoc.js
@@ -5,7 +5,7 @@
 
 /* eslint-disable sort-keys */
 /* The meta information is well defined and has a fixed structure.
-   Sorting the keys does not destroys this natural structure and creates confusion. */
+   Sorting the keys destroys this natural structure. */
 
 const OPTIONS_SCHEMA = {
   type: 'object',

--- a/src/rules/requireJSDoc.js
+++ b/src/rules/requireJSDoc.js
@@ -3,91 +3,164 @@
 // Thus this method implements a compatible requireJSDoc rule.
 //
 
-export default (context) => {
-  const getOption = (key, fallback) => {
-    if (!context.options.length) {
-      return fallback;
+/* eslint-disable sort-keys */
+/* The meta information is well defined and has a fixed structure.
+   Sorting the keys does not destroys this natural structure and creates confusion. */
+
+const OPTIONS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    require: {
+      type: 'object',
+      default: {},
+      additionalProperties: false,
+      properties: {
+        ArrowFunctionExpression: {
+          default: false,
+          type: 'boolean'
+        },
+        ClassDeclaration: {
+          default: false,
+          type: 'boolean'
+        },
+        FunctionDeclaration: {
+          default: true,
+          type: 'boolean'
+        },
+        FunctionExpression: {
+          default: false,
+          type: 'boolean'
+        },
+        MethodDefinition: {
+          default: false,
+          type: 'boolean'
+        }
+      }
     }
+  }
+};
 
-    if (!context.options[0] || !context.options[0].require) {
-      return fallback;
-    }
+const getOption = (context, key) => {
+  if (!context.options.length) {
+    return OPTIONS_SCHEMA.properties.require.properties[key].default;
+  }
 
-    if (!context.options[0].require.hasOwnProperty(key)) {
-      return fallback;
-    }
+  if (!context.options[0] || !context.options[0].require) {
+    return OPTIONS_SCHEMA.properties.require.properties[key].default;
+  }
 
-    return context.options[0].require[key];
-  };
+  if (!context.options[0].require.hasOwnProperty(key)) {
+    return OPTIONS_SCHEMA.properties.require.properties[key].default;
+  }
 
-  const options = {
-    ArrowFunctionExpression: getOption('ArrowFunctionExpression', false),
-    ClassDeclaration: getOption('ClassDeclaration', false),
-    FunctionDeclaration: getOption('FunctionDeclaration', true),
-    FunctionExpression: getOption('FunctionExpression', false),
-    MethodDefinition: getOption('MethodDefinition', false)
-  };
+  return context.options[0].require[key];
+};
 
-  const checkJsDoc = (node) => {
-    const jsDocNode = context.getSourceCode().getJSDocComment(node);
-
-    if (jsDocNode) {
-      return;
-    }
-
-    context.report({
-      message: 'Missing JSDoc comment.',
-      node
-    });
-  };
-
+const getOptions = (context) => {
   return {
-    ArrowFunctionExpression: (node) => {
-      if (!options.ArrowFunctionExpression) {
-        return;
-      }
-
-      if (node.parent.type !== 'VariableDeclarator') {
-        return;
-      }
-
-      checkJsDoc(node);
-    },
-
-    ClassDeclaration: (node) => {
-      if (!options.ClassDeclaration) {
-        return;
-      }
-
-      checkJsDoc(node);
-    },
-
-    FunctionDeclaration: (node) => {
-      if (!options.FunctionDeclaration) {
-        return;
-      }
-
-      checkJsDoc(node);
-    },
-
-    FunctionExpression: (node) => {
-      if (options.MethodDefinition && node.parent.type === 'MethodDefinition') {
-        checkJsDoc(node);
-
-        return;
-      }
-
-      if (!options.FunctionExpression) {
-        return;
-      }
-
-      if (node.parent.type === 'VariableDeclarator') {
-        checkJsDoc(node);
-      }
-
-      if (node.parent.type === 'Property' && node === node.parent.value) {
-        checkJsDoc(node);
-      }
-    }
+    ArrowFunctionExpression: getOption(context, 'ArrowFunctionExpression'),
+    ClassDeclaration: getOption(context, 'ClassDeclaration'),
+    FunctionDeclaration: getOption(context, 'FunctionDeclaration'),
+    FunctionExpression: getOption(context, 'FunctionExpression'),
+    MethodDefinition: getOption(context, 'MethodDefinition')
   };
+};
+
+const checkJsDoc = (context, node) => {
+  const jsDocNode = context.getSourceCode().getJSDocComment(node);
+
+  if (jsDocNode) {
+    return;
+  }
+
+  context.report({
+    messageId: 'missingJsDoc',
+    node
+  });
+};
+
+export default {
+
+  meta: {
+    type: 'suggestion',
+
+    doc: {
+      description: 'Require JSDoc comments',
+      category: 'Stylistic Issues',
+      recommended: 'true',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc'
+    },
+
+    schema: [
+      OPTIONS_SCHEMA
+    ],
+
+    messages: {
+      missingJsDoc: 'Missing JSDoc comment.'
+    }
+  },
+
+  /**
+   * The entrypoint for the JSDoc rule.
+   *
+   * @param {*} context
+   *   a reference to the context which hold all important information
+   *   like settings and the sourcecode to check.
+   * @returns {*}
+   *   a list with parser callback function.
+   */
+  create (context) {
+    const options = getOptions(context);
+
+    return {
+      ArrowFunctionExpression: (node) => {
+        if (!options.ArrowFunctionExpression) {
+          return;
+        }
+
+        if (node.parent.type !== 'VariableDeclarator') {
+          return;
+        }
+
+        checkJsDoc(context, node);
+      },
+
+      ClassDeclaration: (node) => {
+        if (!options.ClassDeclaration) {
+          return;
+        }
+
+        checkJsDoc(context, node);
+      },
+
+      FunctionDeclaration: (node) => {
+        if (!options.FunctionDeclaration) {
+          return;
+        }
+
+        checkJsDoc(context, node);
+      },
+
+      FunctionExpression: (node) => {
+        if (options.MethodDefinition && node.parent.type === 'MethodDefinition') {
+          checkJsDoc(context, node);
+
+          return;
+        }
+
+        if (!options.FunctionExpression) {
+          return;
+        }
+
+        if (node.parent.type === 'VariableDeclarator') {
+          checkJsDoc(context, node);
+        }
+
+        if (node.parent.type === 'Property' && node === node.parent.value) {
+          checkJsDoc(context, node);
+        }
+      }
+    };
+  }
 };

--- a/src/rules/requireJSDoc.js
+++ b/src/rules/requireJSDoc.js
@@ -1,0 +1,93 @@
+//
+// The requireJDDoc rule at eslint is deprecated and won't get any bugfixes anymore.
+// Thus this method implements a compatible requireJSDoc rule.
+//
+
+export default (context) => {
+  const getOption = (key, fallback) => {
+    if (!context.options.length) {
+      return fallback;
+    }
+
+    if (!context.options[0] || !context.options[0].require) {
+      return fallback;
+    }
+
+    if (!context.options[0].require.hasOwnProperty(key)) {
+      return fallback;
+    }
+
+    return context.options[0].require[key];
+  };
+
+  const options = {
+    ArrowFunctionExpression: getOption('ArrowFunctionExpression', false),
+    ClassDeclaration: getOption('ClassDeclaration', false),
+    FunctionDeclaration: getOption('FunctionDeclaration', true),
+    FunctionExpression: getOption('FunctionExpression', false),
+    MethodDefinition: getOption('MethodDefinition', false)
+  };
+
+  const checkJsDoc = (node) => {
+    const jsDocNode = context.getSourceCode().getJSDocComment(node);
+
+    if (jsDocNode) {
+      return;
+    }
+
+    context.report({
+      message: 'Missing JSDoc comment.',
+      node
+    });
+  };
+
+  return {
+    ArrowFunctionExpression: (node) => {
+      if (!options.ArrowFunctionExpression) {
+        return;
+      }
+
+      if (node.parent.type !== 'VariableDeclarator') {
+        return;
+      }
+
+      checkJsDoc(node);
+    },
+
+    ClassDeclaration: (node) => {
+      if (!options.ClassDeclaration) {
+        return;
+      }
+
+      checkJsDoc(node);
+    },
+
+    FunctionDeclaration: (node) => {
+      if (!options.FunctionDeclaration) {
+        return;
+      }
+
+      checkJsDoc(node);
+    },
+
+    FunctionExpression: (node) => {
+      if (options.MethodDefinition && node.parent.type === 'MethodDefinition') {
+        checkJsDoc(node);
+
+        return;
+      }
+
+      if (!options.FunctionExpression) {
+        return;
+      }
+
+      if (node.parent.type === 'VariableDeclarator') {
+        checkJsDoc(node);
+      }
+
+      if (node.parent.type === 'Property' && node === node.parent.value) {
+        checkJsDoc(node);
+      }
+    }
+  };
+};

--- a/test/rules/assertions/requireJSDoc.js
+++ b/test/rules/assertions/requireJSDoc.js
@@ -1,6 +1,9 @@
-//
-// This file was adopted from the eslint project
-//
+/**
+ * This file was adopted/ported from the eslint project:
+ *   https://github.com/eslint/eslint/blob/master/tests/lib/rules/require-jsdoc.js
+ *
+ * It was originally licensed under MIT.
+ */
 
 export default {
   invalid: [

--- a/test/rules/assertions/requireJSDoc.js
+++ b/test/rules/assertions/requireJSDoc.js
@@ -1,0 +1,539 @@
+//
+// This file was adopted from the eslint project
+//
+
+export default {
+  invalid: [
+    {
+      code:
+        `
+          function quux (foo) {
+
+          }`,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc comment.'
+        }
+      ]
+    },
+    {
+      code: 'function myFunction() {}',
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionDeclaration'
+      }]
+    },
+    {
+      code:
+        `/**
+          * Description for A.
+          */
+         class A {
+            constructor(xs) {
+                 this.a = xs;
+            }
+         }`,
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionExpression'
+      }],
+      options: [{
+        require: {
+          ClassDeclaration: true,
+          MethodDefinition: true
+        }
+      }],
+      parserOptions: {
+        ecmaVersion: 6
+      }
+    },
+    {
+      code:
+        `class A {
+            /**
+             * Description for constructor.
+             * @param {object[]} xs - xs
+             */
+            constructor(xs) {
+                this.a = xs;
+            }
+        }`,
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'ClassDeclaration'
+      }],
+      options: [{
+        require: {
+          ClassDeclaration: true,
+          MethodDefinition: true
+        }
+      }],
+      parserOptions: {
+        ecmaVersion: 6
+      }
+    },
+    {
+      code:
+        `class A extends B {
+            /**
+             * Description for constructor.
+             * @param {object[]} xs - xs
+             */
+            constructor(xs) {
+                this.a = xs;
+            }
+        }`,
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'ClassDeclaration'
+      }],
+      options: [{
+        require: {
+          ClassDeclaration: true,
+          MethodDefinition: true
+        }
+      }],
+      parserOptions: {
+        ecmaVersion: 6
+      }
+    },
+    {
+      code:
+        `export class A extends B {
+            /**
+             * Description for constructor.
+             * @param {object[]} xs - xs
+             */
+            constructor(xs) {
+                this.a = xs;
+            }
+        }`,
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'ClassDeclaration'
+      }],
+      options: [{
+        require: {
+          ClassDeclaration: true,
+          MethodDefinition: true
+        }
+      }],
+      parserOptions: {
+        sourceType: 'module'
+      }
+    },
+    {
+      code:
+        `export default class A extends B {
+            /**
+             * Description for constructor.
+             * @param {object[]} xs - xs
+             */
+            constructor(xs) {
+                this.a = xs;
+            }
+        }`,
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'ClassDeclaration'
+      }],
+      options: [{
+        require: {
+          ClassDeclaration: true,
+          MethodDefinition: true
+        }
+      }],
+      parserOptions: {
+        sourceType: 'module'
+      }
+    },
+    {
+      code: 'var myFunction = () => {}',
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'ArrowFunctionExpression'
+      }],
+      options: [{
+        require: {
+          ArrowFunctionExpression: true
+        }
+      }],
+      parserOptions: {
+        ecmaVersion: 6
+      }
+    },
+    {
+      code: 'var myFunction = () => () => {}',
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'ArrowFunctionExpression'
+      }],
+      options: [{
+        require: {
+          ArrowFunctionExpression: true
+        }
+      }],
+      parserOptions: {
+        ecmaVersion: 6
+      }
+    },
+    {
+      code: 'var foo = function() {}',
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionExpression'
+      }],
+      options: [{
+        require: {
+          FunctionExpression: true
+        }
+      }]
+    },
+    {
+      code: 'const foo = {bar() {}}',
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionExpression'
+      }],
+      options: [{
+        require: {
+          FunctionExpression: true
+        }
+      }],
+      parserOptions: {
+        ecmaVersion: 6
+      }
+    },
+    {
+      code: 'var foo = {bar: function() {}}',
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionExpression'
+      }],
+      options: [{
+        require: {
+          FunctionExpression: true
+        }
+      }]
+    }
+  ],
+  valid: [{
+    code: `
+      var array = [1,2,3];
+      array.forEach(function() {});
+      
+      /**
+       * @class MyClass 
+       **/
+      function MyClass() {}
+
+      /**
+       Function doing something
+       */
+      function myFunction() {}
+      /**
+       Function doing something
+       */
+      var myFunction = function() {};
+      /**
+       Function doing something
+       */
+      Object.myFunction = function () {};
+      var obj = { 
+         /**
+          *  Function doing something
+          **/
+          myFunction: function () {} };
+  
+      /**
+       @func myFunction 
+       */
+      function myFunction() {}
+      /**
+       @method myFunction
+       */
+      function myFunction() {}
+      /**
+       @function myFunction
+       */
+      function myFunction() {}
+  
+      /**
+       @func myFunction 
+       */
+      var myFunction = function () {}
+      /**
+       @method myFunction
+       */
+      var myFunction = function () {}
+      /**
+       @function myFunction
+       */
+      var myFunction = function () {}
+  
+      /**
+       @func myFunction 
+       */
+      Object.myFunction = function() {}
+      /**
+       @method myFunction
+       */
+      Object.myFunction = function() {}
+      /**
+       @function myFunction
+       */
+      Object.myFunction = function() {}
+      (function(){})();
+  
+      var object = {
+        /**
+         *  @func myFunction - Some function 
+         */
+        myFunction: function() {} }
+      var object = {
+        /**
+         *  @method myFunction - Some function 
+         */
+        myFunction: function() {} }
+      var object = {
+        /**
+         *  @function myFunction - Some function 
+         */
+        myFunction: function() {} }
+  
+      var array = [1,2,3];
+      array.filter(function() {});
+      Object.keys(this.options.rules || {}).forEach(function(name) {}.bind(this));
+      var object = { name: 'key'};
+      Object.keys(object).forEach(function() {})
+    `
+  },
+  {
+    code: 'function myFunction() {}',
+    options: [{
+      require: {
+        ClassDeclaration: true,
+        FunctionDeclaration: false,
+        MethodDefinition: true
+      }
+    }]
+  },
+  {
+    code: 'var myFunction = function() {}',
+    options: [{
+      require: {
+        ClassDeclaration: true,
+        FunctionDeclaration: false,
+        MethodDefinition: true
+      }
+    }]
+  },
+  {
+    code: `
+      /**
+       * Description for A.
+       */
+      class A {
+          /**
+           * Description for constructor.
+           * @param {object[]} xs - xs
+           */
+          constructor(xs) {
+              this.a = xs;
+          }
+      }`,
+    options: [{
+      require: {
+        ClassDeclaration: true,
+        MethodDefinition: true
+      }
+    }],
+    parserOptions: {
+      ecmaVersion: 6
+    }
+  },
+  {
+    code:
+      `/**
+        * Description for A.
+        */
+       class App extends Component {
+           /**
+            * Description for constructor.
+            * @param {object[]} xs - xs
+            */
+           constructor(xs) {
+               this.a = xs;
+           }
+       }`,
+    options: [{
+      require: {
+        ClassDeclaration: true,
+        MethodDefinition: true
+      }
+    }],
+    parserOptions: {
+      ecmaVersion: 6
+    }
+  },
+  {
+    code:
+      `/**
+             * Description for A.
+             */
+            export default class App extends Component {
+                /**
+                 * Description for constructor.
+                 * @param {object[]} xs - xs
+                 */
+                constructor(xs) {
+                    this.a = xs;
+                }
+            }`,
+    options: [{
+      require: {
+        ClassDeclaration: true,
+        MethodDefinition: true
+      }
+    }],
+    parserOptions: {
+      ecmaVersion: 6,
+      sourceType: 'module'
+    }
+  },
+  {
+    code:
+      `/**
+             * Description for A.
+             */
+            export class App extends Component {
+                /**
+                 * Description for constructor.
+                 * @param {object[]} xs - xs
+                 */
+                constructor(xs) {
+                    this.a = xs;
+                }
+            }`,
+    options: [{
+      require: {
+        ClassDeclaration: true,
+        MethodDefinition: true
+      }
+    }],
+    parserOptions: {
+      ecmaVersion: 6,
+      sourceType: 'module'
+    }
+  },
+  {
+    code:
+      `class A {
+                  constructor(xs) {
+                      this.a = xs;
+                  }
+              }`,
+    options: [{
+      require: {
+        ClassDeclaration: false,
+        MethodDefinition: false
+      }
+    }],
+    parserOptions: {
+      ecmaVersion: 6
+    }
+  },
+  {
+    code:
+      `/**
+        Function doing something
+       */
+       var myFunction = () => {}`,
+    options: [{
+      require: {
+        ArrowFunctionExpression: true
+      }
+    }],
+    parserOptions: {
+      ecmaVersion: 6
+    }
+  },
+  {
+    code:
+      `/**
+        Function doing something
+       */
+       var myFunction = () => () => {}`,
+    options: [{
+      require: {
+        ArrowFunctionExpression: true
+      }
+    }],
+    parserOptions: {
+      ecmaVersion: 6
+    }
+  },
+  {
+    code: 'setTimeout(() => {}, 10);',
+    options: [{
+      require: {
+        ArrowFunctionExpression: true
+      }
+    }],
+    parserOptions: {
+      ecmaVersion: 6
+    }
+  },
+  {
+    code:
+      `/**
+       JSDoc Block
+       */
+       var foo = function() {}`,
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }]
+  },
+  {
+    code:
+      `const foo = {/**
+       JSDoc Block
+       */
+       bar() {}}`,
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    parserOptions: {
+      ecmaVersion: 6
+    }
+  },
+  {
+    code:
+      `var foo = {/**
+       JSDoc Block
+       */
+       bar: function() {}}`,
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }]
+  },
+  {
+    code: ' var foo = { [function() {}]: 1 };',
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    parserOptions: {
+      ecmaVersion: 6
+    }
+  }
+  ]
+};

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -17,6 +17,7 @@ _.forEach([
   'require-description-complete-sentence',
   'require-example',
   'require-hyphen-before-param-description',
+  'require-jsdoc',
   'require-param',
   'require-param-description',
   'require-param-name',


### PR DESCRIPTION
Implements a requireJSDoc compatible rule as described in issue #162.

The unit test file is ported from eslint and therefore MIT licensed for more details refer also to issue #162