### PR TITLE
`forceRequireReturn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2705,6 +2705,28 @@ function quux (foo) {
  */
 function quux (foo) {
 }
+
+/**
+ * @override
+ */
+function quux (foo) {
+
+  return foo;
+}
+
+/**
+ * @class
+ */
+function quux (foo) {
+
+}
+
+/**
+ * @constructor
+ */
+function quux (foo) {
+
+}
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -2727,6 +2727,65 @@ function quux (foo) {
 function quux (foo) {
 
 }
+
+/**
+ * @returns {Object}
+ */
+function quux () {
+
+  return {a: foo};
+}
+
+/**
+ * @returns {Object}
+ */
+const quux = () => ({a: foo});
+
+/**
+ * @returns {Object}
+ */
+const quux = () => {
+  return {a: foo}
+};
+
+/**
+ * @returns {void}
+ */
+function quux () {
+}
+
+/**
+ * @returns {void}
+ */
+const quux = () => {
+
+}
+
+/**
+ * @returns {undefined}
+ */
+function quux () {
+}
+
+/**
+ * @returns {undefined}
+ */
+const quux = () => {
+
+}
+
+/**
+ *
+ */
+function quux () {
+}
+
+/**
+ *
+ */
+const quux = () => {
+
+}
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -2048,6 +2048,15 @@ function quux (foo) {
 function quux (foo) {
 
 }
+
+class Foo {
+  /**
+   *
+   */
+  constructor () {
+  }
+}
+// Settings: {"jsdoc":{"forceRequireReturn":true}}
 ````
 
 
@@ -2646,6 +2655,14 @@ function quux (foo) {
 }
 // Settings: {"jsdoc":{"tagNamePreference":{"returns":"return"}}}
 // Message: Missing JSDoc @return declaration.
+
+/**
+ *
+ */
+function quux () {
+}
+// Settings: {"jsdoc":{"forceRequireReturn":true}}
+// Message: Missing JSDoc @returns declaration.
 ````
 
 The following patterns are not considered problems:

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -41,6 +41,7 @@ const curryUtils = (
   allowImplementsWithoutParam,
   allowAugmentsExtendsWithoutParam,
   checkSeesForNamepaths,
+  forceRequireReturn,
   ancestors,
   sourceCode
 ) => {
@@ -143,21 +144,24 @@ const curryUtils = (
     ], tag.tag);
   };
 
-  utils.getClassJsdocNode = () => {
+  utils.isForceRequireReturn = () => {
+    return forceRequireReturn;
+  };
+
+  utils.getClassNode = () => {
     const greatGrandParent = ancestors.slice(-3)[0];
     const greatGrandParentValue = greatGrandParent && sourceCode.getFirstToken(greatGrandParent).value;
 
     if (greatGrandParentValue === 'class') {
-      const classJsdocNode = sourceCode.getJSDocComment(greatGrandParent);
-
-      return classJsdocNode;
+      return greatGrandParent;
     }
 
     return false;
   };
 
   utils.classHasTag = (tagName) => {
-    const classJsdocNode = utils.getClassJsdocNode();
+    const classNode = utils.getClassNode();
+    const classJsdocNode = sourceCode.getJSDocComment(classNode);
 
     if (classJsdocNode) {
       const indent = _.repeat(' ', classJsdocNode.loc.start.column);
@@ -198,6 +202,7 @@ export default (iterator) => {
     const allowImplementsWithoutParam = Boolean(_.get(context, 'settings.jsdoc.allowImplementsWithoutParam'));
     const allowAugmentsExtendsWithoutParam = Boolean(_.get(context, 'settings.jsdoc.allowAugmentsExtendsWithoutParam'));
     const checkSeesForNamepaths = Boolean(_.get(context, 'settings.jsdoc.checkSeesForNamepaths'));
+    const forceRequireReturn = Boolean(_.get(context, 'settings.jsdoc.forceRequireReturn'));
 
     const checkJsdoc = (functionNode) => {
       const jsdocNode = sourceCode.getJSDocComment(functionNode);
@@ -265,6 +270,7 @@ export default (iterator) => {
         allowImplementsWithoutParam,
         allowAugmentsExtendsWithoutParam,
         checkSeesForNamepaths,
+        forceRequireReturn,
         ancestors,
         sourceCode
       );

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -315,7 +315,9 @@ export default iterateJsdoc(({
   }
 
   // In case the code returns something, we expect a return value in JSDoc.
-  if (!hasReturnTag(tags[0], functionNode) && hasReturnValue(functionNode, context)) {
+  if (!hasReturnTag(tags[0], functionNode) && (
+    utils.isForceRequireReturn() || hasReturnValue(functionNode, context)
+  )) {
     report('Missing JSDoc @' + tagName + ' declaration.');
   }
 });

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -1,10 +1,308 @@
-import _ from 'lodash';
 import iterateJsdoc from '../iterateJsdoc';
+
+const DEFAULT = '@default';
+const LOOP = '@loop';
+
+const RETURN_STATEMENT = 'ReturnStatement';
+const IF_STATEMENT = 'IfStatement';
+const EXPRESSION_STATEMENT = 'ExpressionStatement';
+const SWITCH_STATEMENT = 'SwitchStatement';
+const BLOCK_STATEMENT = 'BlockStatement';
+const FUNCTION_EXPRESSION = 'FunctionExpression';
+const ARROW_FUNCTION_EXPRESSION = 'ArrowFunctionExpression';
+const FUNCTION_DECLARATION = 'FunctionDeclaration';
+const TRY_STATEMENT = 'TryStatement';
+
+const LOOP_STATEMENTS = ['WhileStatement', 'DoWhileStatement', 'ForStatement', 'ForInStatement', 'ForOfStatement'];
+
+const STATEMENTS_WITH_CHILDREN = [
+  LOOP,
+  SWITCH_STATEMENT,
+  IF_STATEMENT,
+  BLOCK_STATEMENT,
+  TRY_STATEMENT
+];
+
+const RETURNFREE_STATEMENTS = [
+  'VariableDeclaration',
+  'ThrowStatement',
+  'FunctionDeclaration',
+  'BreakStatement',
+  'ContinueStatement',
+  'LabeledStatement',
+  'DebuggerStatement',
+  'EmptyStatement',
+  'WithStatement',
+  'ThrowStatement',
+  EXPRESSION_STATEMENT
+];
+
+const ENTRY_POINTS = [FUNCTION_DECLARATION, ARROW_FUNCTION_EXPRESSION, FUNCTION_EXPRESSION];
+
+/* eslint-disable sort-keys */
+const lookupTable = {
+  [RETURN_STATEMENT]: {
+    is: (node) => {
+      return node.type === RETURN_STATEMENT;
+    },
+    check: (node) => {
+      if (!lookupTable[RETURN_STATEMENT].is(node)) {
+        return false;
+      }
+
+      // A return without any arguments just exits the function
+      // and is typically not documented at all in jsdoc.
+      if (node.argument === null) {
+        return false;
+      }
+
+      return true;
+    }
+  },
+  [IF_STATEMENT]: {
+    is: (node) => {
+      return node.type === IF_STATEMENT;
+    },
+    check: (node) => {
+      if (!lookupTable[IF_STATEMENT].is(node)) {
+        return false;
+      }
+
+      if (lookupTable[DEFAULT].check(node.consequent)) {
+        return true;
+      }
+
+      if (node.alternate && lookupTable[DEFAULT].check(node.alternate)) {
+        return true;
+      }
+
+      return false;
+    }
+  },
+  [LOOP]: {
+    is: (node) => {
+      return LOOP_STATEMENTS.indexOf(node.type) !== -1;
+    },
+    check: (node) => {
+      lookupTable[DEFAULT].check(node.body);
+    }
+  },
+  [SWITCH_STATEMENT]: {
+    is: (node) => {
+      return node.type === SWITCH_STATEMENT;
+    },
+    check: (node) => {
+      for (const item of node.cases) {
+        for (const statement of item.consequent) {
+          if (lookupTable[DEFAULT].check(statement)) {
+            return true;
+          }
+        }
+      }
+
+      return false;
+    }
+  },
+  [TRY_STATEMENT]: {
+    is: (node) => {
+      return node.type === TRY_STATEMENT;
+    },
+    check: (node) => {
+      if (!lookupTable[TRY_STATEMENT].is(node)) {
+        return false;
+      }
+
+      if (lookupTable[BLOCK_STATEMENT].check(node.block)) {
+        return true;
+      }
+
+      if (node.handler && node.handler.block) {
+        if (lookupTable[DEFAULT].check(node)) {
+          return true;
+        }
+      }
+
+      if (lookupTable[BLOCK_STATEMENT].check(node.finalizer)) {
+        return true;
+      }
+
+      return false;
+    }
+  },
+  [BLOCK_STATEMENT]: {
+    is: (node) => {
+      return node.type === BLOCK_STATEMENT;
+    },
+    check: (node, context) => {
+      // E.g. the catch block statement is optional.
+      if (typeof node === 'undefined' || node === null) {
+        return false;
+      }
+
+      if (!lookupTable[BLOCK_STATEMENT].is(node)) {
+        return false;
+      }
+
+      for (const item of node.body) {
+        if (lookupTable[DEFAULT].check(item, context)) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+  },
+  [FUNCTION_EXPRESSION]: {
+    is: (node) => {
+      return node.type === FUNCTION_EXPRESSION;
+    },
+    check: (node, context) => {
+      return lookupTable[BLOCK_STATEMENT].check(node.body, context);
+    }
+  },
+  [ARROW_FUNCTION_EXPRESSION]: {
+    is: (node) => {
+      return node.type === ARROW_FUNCTION_EXPRESSION;
+    },
+    check: (node) => {
+      // An expression has always a return value.
+      return node.expression;
+    }
+  },
+  [FUNCTION_DECLARATION]: {
+    is: (node) => {
+      return node.type === FUNCTION_DECLARATION;
+    },
+    check: (node, context) => {
+      return lookupTable[BLOCK_STATEMENT].check(node.body, context);
+    }
+  },
+  [DEFAULT]: {
+    check: (node) => {
+      // In case it is a ReturnStatement we found what we were looking for
+      if (lookupTable[RETURN_STATEMENT].is(node)) {
+        return lookupTable[RETURN_STATEMENT].check(node);
+      }
+
+      // In case the element has children we need to traverse the them.
+      // Examples are BlockStatement, Choices, TryStatement, Loops, ...
+      for (const item of STATEMENTS_WITH_CHILDREN) {
+        if (lookupTable[item].is(node)) {
+          return lookupTable[item].check(node);
+        }
+      }
+
+      // Everything else can not return anything.
+      if (RETURNFREE_STATEMENTS.indexOf(node.type) !== -1) {
+        return false;
+      }
+
+      // If we endup here we stumbled upon an unknown elements
+      // Most likely it is enough to add it to the blacklist.
+      //
+      // throw new Error('Unknown node type: ' + node.type);
+      return false;
+    }
+  }
+};
+
+/**
+ * Checks if the source code returns a retrun value.
+ * It traverse the parsed source code an retruns as
+ * soon as it stumbles upon the first return statement.
+ *
+ * @param {Object} node
+ *   the node which should be checked.
+ * @returns {boolean}
+ *   true in case the code returns a return value
+ */
+const hasReturnValue = (node) => {
+  // Loop through all of our entry points
+  for (const item of ENTRY_POINTS) {
+    if (lookupTable[item].is(node)) {
+      return lookupTable[item].check(node);
+    }
+  }
+
+  throw new Error('Unknown element ' + node.type);
+};
+
+/**
+ * Checks if the JSDoc comment declares a return value.
+ *
+ * @param {JsDocTag} tag
+ *   the tag which should be checked.
+ * @returns {boolean}
+ *   true in case a return value is declared otherwise false.
+ */
+const hasReturnTag = (tag) => {
+  // The function should not return in case not @retruns is defined...
+  if (typeof tag === 'undefined' || tag === null) {
+    return false;
+  }
+
+  // .. same applies if it declares '@returns undefined' or '@returns void'
+  if (tag.type === 'undefined' || tag.type === 'void') {
+    return false;
+  }
+
+  // in any other it has to return something and
+  // we have to find a return statement
+  return true;
+};
+
+const getTags = (jsdoc, tagName) => {
+  if (!jsdoc.tags) {
+    return [];
+  }
+
+  return jsdoc.tags.filter((item) => {
+    return item.tag === tagName;
+  });
+};
+
+/**
+ * We can skip checking for a return value, in case the documentation is inherited
+ * or the method is either a constructor or an abstract method.
+ *
+ * In either of these cases the return value is optional or not defined.
+ *
+ * @param {*} utils
+ *   a reference to the utils which are used to probe if a tag is present or not.
+ * @returns {boolean}
+ *   true in case deep checking can be skipped otherwise false.
+ */
+const canSkip = (utils) => {
+  // Inheritdoc implies all documentation is inherited (see http://usejsdoc.org/tags-inheritdoc.html)
+  // same applies to the override tag (http://usejsdoc.org/tags-override.html)
+  //
+  // But as we do not know the parent method, we cannot perform any checks.
+  // So we bail out there instead of returning false positives.
+  if (utils.hasTag('inheritdoc') || utils.hasTag('override')) {
+    return false;
+  }
+
+  // Different Tag similar story. Abstract methods are by definition in complete.
+  // So it is not an error if it declares a return value but does not implement it.
+  if (utils.hasTag('abstract') || utils.hasTag('virtual')) {
+    return false;
+  }
+
+  // Constructors do not have a return value by definition (http://usejsdoc.org/tags-class.html)
+  // So we can bail out here, too.
+  if (utils.hasTag('class') || utils.hasTag('constructor')) {
+    return false;
+  }
+
+  return true;
+};
 
 export default iterateJsdoc(({
   jsdoc,
   report,
-  utils
+  functionNode,
+  utils,
+  context
 }) => {
   if (utils.hasATag([
     // inheritdoc implies that all documentation is inherited
@@ -24,38 +322,26 @@ export default iterateJsdoc(({
     return;
   }
 
-  const targetTagName = utils.getPreferredTagName('returns');
+  // A preflight check. We do not need to run a deep check
+  // in case the @retruns comment is optional or undefined.
+  if (canSkip(utils)) {
+    return;
+  }
 
-  const jsdocTags = _.filter(jsdoc.tags, {
-    tag: targetTagName
-  });
+  const tagName = utils.getPreferredTagName('returns');
+  const tags = getTags(jsdoc, tagName);
 
-  const sourcecode = utils.getFunctionSourceCode();
+  if (tags.length > 1) {
+    report('Found more than one  @' + tagName + ' declaration.');
+  }
 
-  // build a one-liner to test against
-  const flattenedSource = sourcecode.replace(/\r?\n|\r|\s/g, '');
+  // In case a return value is decleared in JSDoc we also expect one in the code.
+  if (hasReturnTag(tags[0], functionNode) && !hasReturnValue(functionNode, context)) {
+    report('Unexpected JSDoc @' + tagName + ' declaration.');
+  }
 
-  const startsWithReturn = '(\\)\\s?\\{return)';
-
-  const endsWithReturn = '(return.*\\})';
-
-  const implicitReturn = '(\\s?=>\\s?\\b.*)';
-
-  const implicitObjectReturn = '(\\s?=>\\s?\\(\\{)';
-
-  const matcher = new RegExp([
-    startsWithReturn,
-    endsWithReturn,
-    implicitObjectReturn,
-    implicitReturn
-  ].join('|'), 'gim');
-
-  const positiveTest = (flattenedSource.match(matcher) || []).length > 0;
-
-  const negativeTest = (flattenedSource.match(/(\{.*\{.*return)/gim) || []).length > 0 &&
-    (flattenedSource.match(/(return)/gim) || []).length < 2;
-
-  if (JSON.stringify(jsdocTags) === '[]' && positiveTest && !negativeTest) {
-    report('Missing JSDoc @' + targetTagName + ' declaration.');
+  // In case the code retuns something we expect a return value in JSDoc.
+  if (!hasReturnTag(tags[0], functionNode) && hasReturnValue(functionNode, context)) {
+    report('Missing JSDoc @' + tagName + ' declaration.');
   }
 });

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -279,22 +279,22 @@ const canSkip = (utils) => {
   // But as we do not know the parent method, we cannot perform any checks.
   // So we bail out there instead of returning false positives.
   if (utils.hasTag('inheritdoc') || utils.hasTag('override')) {
-    return false;
+    return true;
   }
 
   // Different Tag similar story. Abstract methods are by definition in complete.
   // So it is not an error if it declares a return value but does not implement it.
   if (utils.hasTag('abstract') || utils.hasTag('virtual')) {
-    return false;
+    return true;
   }
 
   // Constructors do not have a return value by definition (http://usejsdoc.org/tags-class.html)
   // So we can bail out here, too.
   if (utils.hasTag('class') || utils.hasTag('constructor')) {
-    return false;
+    return true;
   }
 
-  return true;
+  return false;
 };
 
 export default iterateJsdoc(({

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -151,9 +151,10 @@ const lookupTable = {
     is (node) {
       return node.type === 'ArrowFunctionExpression';
     },
-    check (node) {
+    check (node, context) {
       // An expression always has a return value.
-      return node.expression;
+      return node.expression ||
+        lookupTable.BlockStatement.check(node.body, context);
     }
   },
   FunctionDeclaration: {
@@ -165,17 +166,17 @@ const lookupTable = {
     }
   },
   '@default': {
-    check (node) {
+    check (node, context) {
       // In case it is a `ReturnStatement`, we found what we were looking for
       if (lookupTable.ReturnStatement.is(node)) {
-        return lookupTable.ReturnStatement.check(node);
+        return lookupTable.ReturnStatement.check(node, context);
       }
 
       // In case the element has children, we need to traverse them.
       // Examples are BlockStatement, Choices, TryStatement, Loops, ...
       for (const item of STATEMENTS_WITH_CHILDREN) {
         if (lookupTable[item].is(node)) {
-          return lookupTable[item].check(node);
+          return lookupTable[item].check(node, context);
         }
       }
 
@@ -203,11 +204,11 @@ const lookupTable = {
  * @returns {boolean}
  *   true in case the code returns a return value
  */
-const hasReturnValue = (node) => {
+const hasReturnValue = (node, context) => {
   // Loop through all of our entry points
   for (const item of ENTRY_POINTS) {
     if (lookupTable[item].is(node)) {
-      return lookupTable[item].check(node);
+      return lookupTable[item].check(node, context);
     }
   }
 

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -196,6 +196,92 @@ export default {
 
           }
       `
+    },
+    {
+      code: `
+          /**
+           * @returns {Object}
+           */
+          function quux () {
+
+            return {a: foo};
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns {Object}
+           */
+          const quux = () => ({a: foo});
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns {Object}
+           */
+          const quux = () => {
+            return {a: foo}
+          };
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns {void}
+           */
+          function quux () {
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns {void}
+           */
+          const quux = () => {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns {undefined}
+           */
+          function quux () {
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns {undefined}
+           */
+          const quux = () => {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          const quux = () => {
+
+          }
+      `
     }
   ]
 };

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -84,6 +84,26 @@ export default {
           }
         }
       }
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          forceRequireReturn: true
+        }
+      }
     }
   ],
   valid: [
@@ -282,6 +302,22 @@ export default {
 
           }
       `
+    },
+    {
+      code: `
+      class Foo {
+        /**
+         *
+         */
+        constructor () {
+        }
+      }
+      `,
+      settings: {
+        jsdoc: {
+          forceRequireReturn: true
+        }
+      }
     }
   ]
 };

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -165,6 +165,37 @@ export default {
           function quux (foo) {
           }
       `
+    },
+    {
+      code: `
+          /**
+           * @override
+           */
+          function quux (foo) {
+
+            return foo;
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @class
+           */
+          function quux (foo) {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @constructor
+           */
+          function quux (foo) {
+
+          }
+      `
     }
   ]
 };


### PR DESCRIPTION
- Add setting `forceRequireReturn` to require checks regardless of whether a non-nested return exists in the function

The advantage is for the sake of flagging to documenters that the `undefined` return value was considered and documented with no need for further documentation rather than being indeterminate and the function's return in need of examination.