### PR TITLE
fix: require-returns-check false positive

### DIFF
--- a/README.md
+++ b/README.md
@@ -2531,17 +2531,27 @@ function quux () {
  */
 const quux = () => foo;
 
-/** 
+/**
+ * @returns {undefined} Foo.
+ */
+function quux () {}
+
+/**
+ * @returns { void } Foo.
+ */
+function quux () {}
+
+/**
  * @returns {Promise<void>}
  */
 async function quux() {}
 
-/** 
+/**
  * @returns {Promise<void>}
  */
 async () => {}
 
-/** 
+/**
  * @returns Foo.
  * @abstract
  */

--- a/src/rules/requireReturnsCheck.js
+++ b/src/rules/requireReturnsCheck.js
@@ -37,6 +37,12 @@ export default iterateJsdoc(({
     return;
   }
 
+  const returnsTagType = jsdocTags[0].type && jsdocTags[0].type.trim();
+
+  if (returnsTagType === 'void' || returnsTagType === 'undefined') {
+    return;
+  }
+
   // An abstract function is by definition incomplete
   // so it is perfectly fine if the return is missing
   // a subclass may inherits the doc an implements the

--- a/test/rules/assertions/requireReturnsCheck.js
+++ b/test/rules/assertions/requireReturnsCheck.js
@@ -125,7 +125,23 @@ export default {
     },
     {
       code: `
-          /** 
+          /**
+           * @returns {undefined} Foo.
+           */
+          function quux () {}
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns { void } Foo.
+           */
+          function quux () {}
+      `
+    },
+    {
+      code: `
+          /**
            * @returns {Promise<void>}
            */
           async function quux() {}
@@ -136,7 +152,7 @@ export default {
     },
     {
       code: `
-          /** 
+          /**
            * @returns {Promise<void>}
            */
           async () => {}
@@ -147,7 +163,7 @@ export default {
     },
     {
       code: `
-          /** 
+          /**
            * @returns Foo.
            * @abstract
            */


### PR DESCRIPTION
Fixes #142 .

Make require-returns-checks ignore absence of return
statement if jsdoc return type is `void` or `undefined`.