### PR TITLE
Integrate ESLint-deprecated `getJSDocComment`

### DIFF
--- a/src/eslint/LICENSE-MIT.txt
+++ b/src/eslint/LICENSE-MIT.txt
@@ -1,0 +1,19 @@
+Copyright JS Foundation and other contributors, https://js.foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/eslint/getJSDocComment.js
+++ b/src/eslint/getJSDocComment.js
@@ -1,0 +1,92 @@
+/**
+ * Obtained from {@link https://github.com/eslint/eslint/blob/master/lib/util/source-code.js#L313}
+ * @license MIT
+ */
+import astUtils from 'eslint/lib/util/ast-utils';
+
+/**
+ * Check to see if its a ES6 export declaration.
+ *
+ * @param {ASTNode} astNode An AST node.
+ * @returns {boolean} whether the given node represents an export declaration.
+ * @private
+ */
+const looksLikeExport = function (astNode) {
+  return astNode.type === 'ExportDefaultDeclaration' || astNode.type === 'ExportNamedDeclaration' ||
+    astNode.type === 'ExportAllDeclaration' || astNode.type === 'ExportSpecifier';
+};
+
+/**
+ * Retrieves the JSDoc comment for a given node.
+ *
+ * @param {SourceCode} sourceCode The ESLint SourceCode
+ * @param {ASTNode} node The AST node to get the comment for.
+ * @returns {Token|null} The Block comment token containing the JSDoc comment
+ *    for the given node or null if not found.
+ * @public
+ * @deprecated
+ */
+const getJSDocComment = function (sourceCode, node) {
+  /**
+   * Checks for the presence of a JSDoc comment for the given node and returns it.
+   *
+   * @param {ASTNode} astNode The AST node to get the comment for.
+   * @returns {Token|null} The Block comment token containing the JSDoc comment
+   *    for the given node or null if not found.
+   * @private
+   */
+  const findJSDocComment = (astNode) => {
+    const tokenBefore = sourceCode.getTokenBefore(astNode, {includeComments: true});
+
+    if (
+      tokenBefore &&
+      astUtils.isCommentToken(tokenBefore) &&
+      tokenBefore.type === 'Block' &&
+      tokenBefore.value.charAt(0) === '*' &&
+      astNode.loc.start.line - tokenBefore.loc.end.line <= 1
+    ) {
+      return tokenBefore;
+    }
+
+    return null;
+  };
+  let parent = node.parent;
+
+  switch (node.type) {
+  case 'ClassDeclaration':
+  case 'FunctionDeclaration':
+    return findJSDocComment(looksLikeExport(parent) ? parent : node);
+
+  case 'ClassExpression':
+    return findJSDocComment(parent.parent);
+
+  case 'ArrowFunctionExpression':
+  case 'FunctionExpression':
+    if (parent.type !== 'CallExpression' && parent.type !== 'NewExpression') {
+      while (
+        !sourceCode.getCommentsBefore(parent).length &&
+        !/Function/u.test(parent.type) &&
+        parent.type !== 'MethodDefinition' &&
+        parent.type !== 'Property'
+      ) {
+        parent = parent.parent;
+
+        if (!parent) {
+          break;
+        }
+      }
+
+      if (parent && parent.type !== 'FunctionDeclaration' && parent.type !== 'Program') {
+        return findJSDocComment(parent);
+      }
+    }
+
+    return findJSDocComment(node);
+
+  // falls through
+  default:
+    return null;
+  }
+};
+
+export default getJSDocComment;

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import commentParser from 'comment-parser';
 import jsdocUtils from './jsdocUtils';
+import getJSDocComment from './eslint/getJSDocComment';
 
 const parseComment = (commentNode, indent) => {
   // Preserve JSDoc block start/end indentation.
@@ -155,10 +156,6 @@ const curryUtils = (
     ], tag.tag);
   };
 
-  utils.isArrowExpression = () => {
-    return node.type === 'ArrowFunctionExpression' && node.expression;
-  };
-
   utils.hasDefinedTypeReturnTag = (tag) => {
     return jsdocUtils.hasDefinedTypeReturnTag(tag);
   };
@@ -181,21 +178,20 @@ const curryUtils = (
     return forceRequireReturn;
   };
 
-  utils.getClassJsdocNode = () => {
+  utils.getClassNode = () => {
     const greatGrandParent = ancestors.slice(-3)[0];
     const greatGrandParentValue = greatGrandParent && sourceCode.getFirstToken(greatGrandParent).value;
 
     if (greatGrandParentValue === 'class') {
-      const classJsdocNode = sourceCode.getJSDocComment(greatGrandParent);
-
-      return classJsdocNode;
+      return greatGrandParent;
     }
 
     return false;
   };
 
   utils.classHasTag = (tagName) => {
-    const classJsdocNode = utils.getClassJsdocNode();
+    const classNode = utils.getClassNode();
+    const classJsdocNode = getJSDocComment(sourceCode, classNode);
 
     if (classJsdocNode) {
       const indent = _.repeat(' ', classJsdocNode.loc.start.column);
@@ -252,7 +248,7 @@ export default (iterator, options) => {
       const avoidExampleOnConstructors = Boolean(_.get(context, 'settings.jsdoc.avoidExampleOnConstructors'));
 
       const checkJsdoc = (node) => {
-        const jsdocNode = sourceCode.getJSDocComment(node);
+        const jsdocNode = getJSDocComment(sourceCode, node);
 
         if (!jsdocNode) {
           return;


### PR DESCRIPTION
Fixes #189.

(FWIW, I switched from `getClassJsdocNode` to `getClassNode` because of another PR coming which needed this lower level functionality anyways.)