### PR TITLE
Fix: Avoid error for `check-syntax` when tags not present

### DIFF
--- a/src/rules/checkSyntax.js
+++ b/src/rules/checkSyntax.js
@@ -4,7 +4,7 @@ export default iterateJsdoc(({
   jsdoc,
   report
 }) => {
-  if (!jsdoc.tags.length) {
+  if (!jsdoc.tags) {
     return;
   }
 

--- a/test/rules/assertions/checkSyntax.js
+++ b/test/rules/assertions/checkSyntax.js
@@ -26,6 +26,16 @@ export default {
 
           }
       `
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+
+          }
+      `
     }
   ]
 };


### PR DESCRIPTION
`jsdoc.tags` may be empty when there is a JSDoc-style comment but no tags present, so this fixes the error which occurs in this situation. It is also not necessary to check for `length` as the array iteration block that follows will not be entered upon an empty array.