### PR TITLE
- Support `@memberof!`

### DIFF
--- a/.README/rules/check-tag-names.md
+++ b/.README/rules/check-tag-names.md
@@ -44,6 +44,7 @@ license
 listens
 member
 memberof
+memberof!
 mixes
 mixin
 module

--- a/src/tagNames.js
+++ b/src/tagNames.js
@@ -62,6 +62,7 @@ export default {
     'var'
   ],
   memberof: [],
+  'memberof!': [],
   mixes: [],
   mixin: [],
   module: [],

--- a/test/rules/assertions/checkTagNames.js
+++ b/test/rules/assertions/checkTagNames.js
@@ -176,6 +176,16 @@ export default {
     {
       code: `
           /**
+           * @memberof! foo
+           */
+          function quux (foo) {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
            * @arg foo
            */
           function quux (foo) {

--- a/test/rules/assertions/jsdoc3Tags.js
+++ b/test/rules/assertions/jsdoc3Tags.js
@@ -35,6 +35,7 @@ export default [
   'listens',
   'member',
   'memberof',
+  'memberof!',
   'mixes',
   'mixin',
   'module',


### PR DESCRIPTION
Per http://usejsdoc.org/tags-memberof.html , a syntax `@memberof!` (with an exclamation mark) is allowed.