### PR TITLE
Prefix the tag name with an @ sign to avoid replacements in non-tag-names

### DIFF
--- a/src/rules/checkTagNames.js
+++ b/src/rules/checkTagNames.js
@@ -14,7 +14,7 @@ export default iterateJsdoc(({
 
       if (preferredTagName !== jsdocTag.tag) {
         report('Invalid JSDoc tag (preference). Replace "' + jsdocTag.tag + '" JSDoc tag with "' + preferredTagName + '".', (fixer) => {
-          const replacement = sourceCode.getText(jsdocNode).replace(jsdocTag.tag, preferredTagName);
+          const replacement = sourceCode.getText(jsdocNode).replace('@' + jsdocTag.tag, '@' + preferredTagName);
 
           return fixer.replaceText(jsdocNode, replacement);
         });


### PR DESCRIPTION
#184 added support for auto-fixing the `check-tag-names`, but it looks like the replacement is on the entire string, and not tag names specifically. This PR is to prefix the replacement with an `@` symbol to try and target tag names.

I'm not sure if it would be better to do a global find and replace so all tag names are updated, not just the first match? e.g. `new RegExp('@' + jsdocTag.tag, 'g')`

I was also looking to add tests, but I didn't see anything for the autofixes - if you have some guidance on how I might go about adding them, I'd be more than happy to.