### PR TITLE
Rework require returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -2721,6 +2721,28 @@ function quux (foo) {
  */
 function quux (foo) {
 }
+
+/**
+ * @override
+ */
+function quux (foo) {
+
+  return foo;
+}
+
+/**
+ * @class
+ */
+function quux (foo) {
+
+}
+
+/**
+ * @constructor
+ */
+function quux (foo) {
+
+}
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -2515,7 +2515,7 @@ The following patterns are considered problems:
 function quux (foo) {
 
 }
-// Message: Present JSDoc @returns declaration but not available return expression in function.
+// Message: JSDoc @returns declaration present but return expression not available in function.
 
 /**
  * @return
@@ -2524,13 +2524,13 @@ function quux (foo) {
 
 }
 // Settings: {"jsdoc":{"tagNamePreference":{"returns":"return"}}}
-// Message: Present JSDoc @return declaration but not available return expression in function.
+// Message: JSDoc @return declaration present but return expression not available in function.
 
 /**
  * @returns
  */
 const quux = () => {}
-// Message: Present JSDoc @returns declaration but not available return expression in function.
+// Message: JSDoc @returns declaration present but return expression not available in function.
 
 /**
  * @returns {undefined} Foo.
@@ -2555,7 +2555,7 @@ function quux () {
 }
 
 /**
- * @returns {void} Foo.
+ * @returns {string} Foo.
  */
 function quux () {
 
@@ -2563,7 +2563,7 @@ function quux () {
 }
 
 /**
- * @returns {undefined} Foo.
+ * @returns {string} Foo.
  */
 function quux () {
 
@@ -2607,6 +2607,33 @@ async () => {}
  */
 function quux () {
   throw new Error('must be implemented by subclass!');
+}
+
+/**
+ * @returns Foo.
+ * @virtual
+ */
+function quux () {
+  throw new Error('must be implemented by subclass!');
+}
+
+/**
+ * @returns Foo.
+ * @constructor
+ */
+function quux () {
+}
+
+/**
+ * @returns {undefined} Foo.
+ */
+function quux () {
+}
+
+/**
+ * @returns {void} Foo.
+ */
+function quux () {
 }
 ````
 

--- a/README.md
+++ b/README.md
@@ -2712,6 +2712,14 @@ const quux = async function () {}
  */
 const quux = async () => {}
 // Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux () {
+}
+// Settings: {"jsdoc":{"forceRequireReturn":true}}
+// Message: Missing JSDoc @returns declaration.
 ````
 
 The following patterns are not considered problems:
@@ -2852,6 +2860,15 @@ function quux () {
 const quux = () => {
 
 }
+
+class Foo {
+  /**
+   *
+   */
+  constructor () {
+  }
+}
+// Settings: {"jsdoc":{"forceRequireReturn":true}}
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -2743,6 +2743,65 @@ function quux (foo) {
 function quux (foo) {
 
 }
+
+/**
+ * @returns {Object}
+ */
+function quux () {
+
+  return {a: foo};
+}
+
+/**
+ * @returns {Object}
+ */
+const quux = () => ({a: foo});
+
+/**
+ * @returns {Object}
+ */
+const quux = () => {
+  return {a: foo}
+};
+
+/**
+ * @returns {void}
+ */
+function quux () {
+}
+
+/**
+ * @returns {void}
+ */
+const quux = () => {
+
+}
+
+/**
+ * @returns {undefined}
+ */
+function quux () {
+}
+
+/**
+ * @returns {undefined}
+ */
+const quux = () => {
+
+}
+
+/**
+ *
+ */
+function quux () {
+}
+
+/**
+ *
+ */
+const quux = () => {
+
+}
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -2599,7 +2599,12 @@ async function quux() {}
 /**
  * @returns {Promise<void>}
  */
-async () => {}
+const quux = async function () {}
+
+/**
+ * @returns {Promise<void>}
+ */
+const quux = async () => {}
 
 /**
  * @returns Foo.
@@ -2689,6 +2694,24 @@ function quux (foo) {
 }
 // Settings: {"jsdoc":{"tagNamePreference":{"returns":"return"}}}
 // Message: Missing JSDoc @return declaration.
+
+/**
+ *
+ */
+async function quux() {}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+const quux = async function () {}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+const quux = async () => {}
+// Message: Missing JSDoc @returns declaration.
 ````
 
 The following patterns are not considered problems:

--- a/README.md
+++ b/README.md
@@ -2769,6 +2769,12 @@ function quux (foo) {
 }
 
 /**
+ * @implements
+ */
+function quux (foo) {
+}
+
+/**
  * @override
  */
 function quux (foo) {

--- a/README.md
+++ b/README.md
@@ -2541,6 +2541,17 @@ function quux () {
   return foo;
 }
 // Message: Found more than one @returns declaration.
+
+const language = {
+  /**
+   * @param {string} name
+   * @returns {string}
+   */
+  get name() {
+    this._name = name;
+  }
+}
+// Message: JSDoc @returns declaration present but return expression not available in function.
 ````
 
 The following patterns are not considered problems:
@@ -2720,6 +2731,16 @@ function quux () {
 }
 // Settings: {"jsdoc":{"forceRequireReturn":true}}
 // Message: Missing JSDoc @returns declaration.
+
+const language = {
+  /**
+   * @param {string} name
+   */
+  get name() {
+    return this._name;
+  }
+}
+// Message: Missing JSDoc @returns declaration.
 ````
 
 The following patterns are not considered problems:
@@ -2875,6 +2896,15 @@ class Foo {
   }
 }
 // Settings: {"jsdoc":{"forceRequireReturn":true}}
+
+const language = {
+  /**
+   * @param {string} name
+   */
+  set name(name) {
+    this._name = name;
+  }
+}
 ````
 
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -60,6 +60,10 @@ const curryUtils = (
     return node.parent && node.parent.kind === 'constructor';
   };
 
+  utils.isSetter = () => {
+    return functionNode.parent.kind === 'set';
+  };
+
   utils.getJsdocParameterNamesDeep = () => {
     return jsdocUtils.getJsdocParameterNamesDeep(jsdoc, utils.getPreferredTagName('param'));
   };

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -61,7 +61,7 @@ const curryUtils = (
   };
 
   utils.isSetter = () => {
-    return functionNode.parent.kind === 'set';
+    return node.parent.kind === 'set';
   };
 
   utils.getJsdocParameterNamesDeep = () => {

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -143,6 +143,10 @@ const curryUtils = (
     ], tag.tag);
   };
 
+  utils.isArrowExpression = () => {
+    return functionNode.type === 'ArrowFunctionExpression' && functionNode.expression;
+  };
+
   utils.getClassJsdocNode = () => {
     const greatGrandParent = ancestors.slice(-3)[0];
     const greatGrandParentValue = greatGrandParent && sourceCode.getFirstToken(greatGrandParent).value;

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -41,6 +41,7 @@ const curryUtils = (
   allowImplementsWithoutParam,
   allowAugmentsExtendsWithoutParam,
   checkSeesForNamepaths,
+  forceRequireReturn,
   ancestors,
   sourceCode,
   context
@@ -166,6 +167,10 @@ const curryUtils = (
     });
   };
 
+  utils.isForceRequireReturn = () => {
+    return forceRequireReturn;
+  };
+
   utils.getClassJsdocNode = () => {
     const greatGrandParent = ancestors.slice(-3)[0];
     const greatGrandParentValue = greatGrandParent && sourceCode.getFirstToken(greatGrandParent).value;
@@ -233,6 +238,7 @@ export default (iterator, options) => {
       const allowImplementsWithoutParam = Boolean(_.get(context, 'settings.jsdoc.allowImplementsWithoutParam'));
       const allowAugmentsExtendsWithoutParam = Boolean(_.get(context, 'settings.jsdoc.allowAugmentsExtendsWithoutParam'));
       const checkSeesForNamepaths = Boolean(_.get(context, 'settings.jsdoc.checkSeesForNamepaths'));
+      const forceRequireReturn = Boolean(_.get(context, 'settings.jsdoc.forceRequireReturn'));
 
       const checkJsdoc = (node) => {
         const jsdocNode = sourceCode.getJSDocComment(node);
@@ -300,6 +306,7 @@ export default (iterator, options) => {
           allowImplementsWithoutParam,
           allowAugmentsExtendsWithoutParam,
           checkSeesForNamepaths,
+          forceRequireReturn,
           ancestors,
           sourceCode
         );

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -42,7 +42,8 @@ const curryUtils = (
   allowAugmentsExtendsWithoutParam,
   checkSeesForNamepaths,
   ancestors,
-  sourceCode
+  sourceCode,
+  context
 ) => {
   const utils = {};
 
@@ -144,7 +145,25 @@ const curryUtils = (
   };
 
   utils.isArrowExpression = () => {
-    return functionNode.type === 'ArrowFunctionExpression' && functionNode.expression;
+    return node.type === 'ArrowFunctionExpression' && node.expression;
+  };
+
+  utils.hasDefinedTypeReturnTag = (tag) => {
+    return jsdocUtils.hasDefinedTypeReturnTag(tag);
+  };
+
+  utils.hasReturnValue = () => {
+    return jsdocUtils.hasReturnValue(node, context);
+  };
+
+  utils.getTags = (tagName) => {
+    if (!jsdoc.tags) {
+      return [];
+    }
+
+    return jsdoc.tags.filter((item) => {
+      return item.tag === tagName;
+    });
   };
 
   utils.getClassJsdocNode = () => {

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -284,7 +284,7 @@ const lookupTable = {
       return node.type === 'FunctionExpression';
     },
     check (node, context) {
-      return lookupTable.BlockStatement.check(node.body, context);
+      return node.async || lookupTable.BlockStatement.check(node.body, context);
     }
   },
   ArrowFunctionExpression: {
@@ -294,6 +294,7 @@ const lookupTable = {
     check (node, context) {
       // An expression always has a return value.
       return node.expression ||
+        node.async ||
         lookupTable.BlockStatement.check(node.body, context);
     }
   },
@@ -302,7 +303,7 @@ const lookupTable = {
       return node.type === 'FunctionDeclaration';
     },
     check (node, context) {
-      return lookupTable.BlockStatement.check(node.body, context);
+      return node.async || lookupTable.BlockStatement.check(node.body, context);
     }
   },
   '@default': {

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -92,6 +92,31 @@ const hasATag = (jsdoc : Object, targetTagNames : Array) : boolean => {
   });
 };
 
+/**
+ * Checks if the JSDoc comment declares a return value.
+ *
+ * @param {JsDocTag} tag
+ *   the tag which should be checked.
+ * @returns {boolean}
+ *   true in case a return value is declared; otherwise false.
+ */
+const hasDefinedTypeReturnTag = (tag) => {
+  // The function should not continue in the event @returns is not defined...
+  if (typeof tag === 'undefined' || tag === null) {
+    return false;
+  }
+
+  // .. same applies if it declares `@returns {undefined}` or `@returns {void}`
+  const tagType = tag.type.trim();
+  if (tagType === 'undefined' || tagType === 'void') {
+    return false;
+  }
+
+  // In any other case, something must be returned, and
+  // a return statement is expected
+  return true;
+};
+
 const namepathAsNameTags = [
   'alias',
   'augments',
@@ -115,12 +140,229 @@ const isNamepathType = (tagName, checkSeesForNamepaths) => {
     tagName === 'see' && checkSeesForNamepaths;
 };
 
+const LOOP_STATEMENTS = ['WhileStatement', 'DoWhileStatement', 'ForStatement', 'ForInStatement', 'ForOfStatement'];
+
+const STATEMENTS_WITH_CHILDREN = [
+  '@loop',
+  'SwitchStatement',
+  'IfStatement',
+  'BlockStatement',
+  'TryStatement'
+];
+
+const RETURNFREE_STATEMENTS = [
+  'VariableDeclaration',
+  'ThrowStatement',
+  'FunctionDeclaration',
+  'BreakStatement',
+  'ContinueStatement',
+  'LabeledStatement',
+  'DebuggerStatement',
+  'EmptyStatement',
+  'WithStatement',
+  'ThrowStatement',
+  'ExpressionStatement'
+];
+
+const ENTRY_POINTS = ['FunctionDeclaration', 'ArrowFunctionExpression', 'FunctionExpression'];
+
+/* eslint-disable sort-keys */
+const lookupTable = {
+  ReturnStatement: {
+    is (node) {
+      return node.type === 'ReturnStatement';
+    },
+    check (node) {
+      if (!lookupTable.ReturnStatement.is(node)) {
+        return false;
+      }
+
+      // A return without any arguments just exits the function
+      // and is typically not documented at all in jsdoc.
+      if (node.argument === null) {
+        return false;
+      }
+
+      return true;
+    }
+  },
+  IfStatement: {
+    is (node) {
+      return node.type === 'IfStatement';
+    },
+    check (node) {
+      if (!lookupTable.IfStatement.is(node)) {
+        return false;
+      }
+
+      if (lookupTable['@default'].check(node.consequent)) {
+        return true;
+      }
+
+      if (node.alternate && lookupTable['@default'].check(node.alternate)) {
+        return true;
+      }
+
+      return false;
+    }
+  },
+  '@loop': {
+    is (node) {
+      return LOOP_STATEMENTS.indexOf(node.type) !== -1;
+    },
+    check (node) {
+      return lookupTable['@default'].check(node.body);
+    }
+  },
+  SwitchStatement: {
+    is (node) {
+      return node.type === 'SwitchStatement';
+    },
+    check (node) {
+      for (const item of node.cases) {
+        for (const statement of item.consequent) {
+          if (lookupTable['@default'].check(statement)) {
+            return true;
+          }
+        }
+      }
+
+      return false;
+    }
+  },
+  TryStatement: {
+    is (node) {
+      return node.type === 'TryStatement';
+    },
+    check (node) {
+      if (!lookupTable.TryStatement.is(node)) {
+        return false;
+      }
+
+      if (lookupTable.BlockStatement.check(node.block)) {
+        return true;
+      }
+
+      if (node.handler && node.handler.block) {
+        if (lookupTable['@default'].check(node)) {
+          return true;
+        }
+      }
+
+      if (lookupTable.BlockStatement.check(node.finalizer)) {
+        return true;
+      }
+
+      return false;
+    }
+  },
+  BlockStatement: {
+    is (node) {
+      return node.type === 'BlockStatement';
+    },
+    check (node, context) {
+      // E.g. the catch block statement is optional.
+      if (typeof node === 'undefined' || node === null) {
+        return false;
+      }
+
+      if (!lookupTable.BlockStatement.is(node)) {
+        return false;
+      }
+
+      for (const item of node.body) {
+        if (lookupTable['@default'].check(item, context)) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+  },
+  FunctionExpression: {
+    is (node) {
+      return node.type === 'FunctionExpression';
+    },
+    check (node, context) {
+      return lookupTable.BlockStatement.check(node.body, context);
+    }
+  },
+  ArrowFunctionExpression: {
+    is (node) {
+      return node.type === 'ArrowFunctionExpression';
+    },
+    check (node, context) {
+      // An expression always has a return value.
+      return node.expression ||
+        lookupTable.BlockStatement.check(node.body, context);
+    }
+  },
+  FunctionDeclaration: {
+    is (node) {
+      return node.type === 'FunctionDeclaration';
+    },
+    check (node, context) {
+      return lookupTable.BlockStatement.check(node.body, context);
+    }
+  },
+  '@default': {
+    check (node, context) {
+      // In case it is a `ReturnStatement`, we found what we were looking for
+      if (lookupTable.ReturnStatement.is(node)) {
+        return lookupTable.ReturnStatement.check(node, context);
+      }
+
+      // In case the element has children, we need to traverse them.
+      // Examples are BlockStatement, Choices, TryStatement, Loops, ...
+      for (const item of STATEMENTS_WITH_CHILDREN) {
+        if (lookupTable[item].is(node)) {
+          return lookupTable[item].check(node, context);
+        }
+      }
+
+      // Everything else cannot return anything.
+      if (RETURNFREE_STATEMENTS.indexOf(node.type) !== -1) {
+        return false;
+      }
+
+      // If we end up here, we stumbled upon an unknown elements
+      // Most likely it is enough to add it to the blacklist.
+      //
+      // throw new Error('Unknown node type: ' + node.type);
+      return false;
+    }
+  }
+};
+
+/**
+ * Checks if the source code returns a return value.
+ * It traverses the parsed source code and returns as
+ * soon as it stumbles upon the first return statement.
+ *
+ * @param {Object} node
+ *   the node which should be checked.
+ * @returns {boolean}
+ *   true in case the code returns a return value
+ */
+const hasReturnValue = (node, context) => {
+  // Loop through all of our entry points
+  for (const item of ENTRY_POINTS) {
+    if (lookupTable[item].is(node)) {
+      return lookupTable[item].check(node, context);
+    }
+  }
+
+  throw new Error('Unknown element ' + node.type);
+};
+
 export default {
   getFunctionParameterNames,
   getJsdocParameterNames,
   getJsdocParameterNamesDeep,
   getPreferredTagName,
   hasATag,
+  hasDefinedTypeReturnTag,
+  hasReturnValue,
   hasTag,
   isNamepathType,
   isValidTag

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -261,7 +261,7 @@ const getTags = (jsdoc, tagName) => {
  *   true in case deep checking can be skipped; otherwise false.
  */
 const canSkip = (utils) => {
-  if (utils.hasATag([
+  return utils.hasATag([
     // inheritdoc implies that all documentation is inherited
     // see http://usejsdoc.org/tags-inheritdoc.html
     //
@@ -278,15 +278,7 @@ const canSkip = (utils) => {
     // So we can bail out here, too.
     'class',
     'constructor'
-  ])) {
-    return true;
-  }
-
-  if (utils.isConstructor()) {
-    return true;
-  }
-
-  return false;
+  ]) || utils.isConstructor();
 };
 
 export default iterateJsdoc(({
@@ -307,11 +299,6 @@ export default iterateJsdoc(({
 
   if (tags.length > 1) {
     report('Found more than one  @' + tagName + ' declaration.');
-  }
-
-  // In case a return value is declared in JSDoc we also expect one in the code.
-  if (hasReturnTag(tags[0], functionNode) && !hasReturnValue(functionNode, context)) {
-    report('Unexpected JSDoc @' + tagName + ' declaration.');
   }
 
   // In case the code returns something, we expect a return value in JSDoc.

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -1,254 +1,5 @@
 import iterateJsdoc from '../iterateJsdoc';
 
-const LOOP_STATEMENTS = ['WhileStatement', 'DoWhileStatement', 'ForStatement', 'ForInStatement', 'ForOfStatement'];
-
-const STATEMENTS_WITH_CHILDREN = [
-  '@loop',
-  'SwitchStatement',
-  'IfStatement',
-  'BlockStatement',
-  'TryStatement'
-];
-
-const RETURNFREE_STATEMENTS = [
-  'VariableDeclaration',
-  'ThrowStatement',
-  'FunctionDeclaration',
-  'BreakStatement',
-  'ContinueStatement',
-  'LabeledStatement',
-  'DebuggerStatement',
-  'EmptyStatement',
-  'WithStatement',
-  'ThrowStatement',
-  'ExpressionStatement'
-];
-
-const ENTRY_POINTS = ['FunctionDeclaration', 'ArrowFunctionExpression', 'FunctionExpression'];
-
-/* eslint-disable sort-keys */
-const lookupTable = {
-  ReturnStatement: {
-    is (node) {
-      return node.type === 'ReturnStatement';
-    },
-    check (node) {
-      if (!lookupTable.ReturnStatement.is(node)) {
-        return false;
-      }
-
-      // A return without any arguments just exits the function
-      // and is typically not documented at all in jsdoc.
-      if (node.argument === null) {
-        return false;
-      }
-
-      return true;
-    }
-  },
-  IfStatement: {
-    is (node) {
-      return node.type === 'IfStatement';
-    },
-    check (node) {
-      if (!lookupTable.IfStatement.is(node)) {
-        return false;
-      }
-
-      if (lookupTable['@default'].check(node.consequent)) {
-        return true;
-      }
-
-      if (node.alternate && lookupTable['@default'].check(node.alternate)) {
-        return true;
-      }
-
-      return false;
-    }
-  },
-  '@loop': {
-    is (node) {
-      return LOOP_STATEMENTS.indexOf(node.type) !== -1;
-    },
-    check (node) {
-      return lookupTable['@default'].check(node.body);
-    }
-  },
-  SwitchStatement: {
-    is (node) {
-      return node.type === 'SwitchStatement';
-    },
-    check (node) {
-      for (const item of node.cases) {
-        for (const statement of item.consequent) {
-          if (lookupTable['@default'].check(statement)) {
-            return true;
-          }
-        }
-      }
-
-      return false;
-    }
-  },
-  TryStatement: {
-    is (node) {
-      return node.type === 'TryStatement';
-    },
-    check (node) {
-      if (!lookupTable.TryStatement.is(node)) {
-        return false;
-      }
-
-      if (lookupTable.BlockStatement.check(node.block)) {
-        return true;
-      }
-
-      if (node.handler && node.handler.block) {
-        if (lookupTable['@default'].check(node)) {
-          return true;
-        }
-      }
-
-      if (lookupTable.BlockStatement.check(node.finalizer)) {
-        return true;
-      }
-
-      return false;
-    }
-  },
-  BlockStatement: {
-    is (node) {
-      return node.type === 'BlockStatement';
-    },
-    check (node, context) {
-      // E.g. the catch block statement is optional.
-      if (typeof node === 'undefined' || node === null) {
-        return false;
-      }
-
-      if (!lookupTable.BlockStatement.is(node)) {
-        return false;
-      }
-
-      for (const item of node.body) {
-        if (lookupTable['@default'].check(item, context)) {
-          return true;
-        }
-      }
-
-      return false;
-    }
-  },
-  FunctionExpression: {
-    is (node) {
-      return node.type === 'FunctionExpression';
-    },
-    check (node, context) {
-      return lookupTable.BlockStatement.check(node.body, context);
-    }
-  },
-  ArrowFunctionExpression: {
-    is (node) {
-      return node.type === 'ArrowFunctionExpression';
-    },
-    check (node, context) {
-      // An expression always has a return value.
-      return node.expression ||
-        lookupTable.BlockStatement.check(node.body, context);
-    }
-  },
-  FunctionDeclaration: {
-    is (node) {
-      return node.type === 'FunctionDeclaration';
-    },
-    check (node, context) {
-      return lookupTable.BlockStatement.check(node.body, context);
-    }
-  },
-  '@default': {
-    check (node, context) {
-      // In case it is a `ReturnStatement`, we found what we were looking for
-      if (lookupTable.ReturnStatement.is(node)) {
-        return lookupTable.ReturnStatement.check(node, context);
-      }
-
-      // In case the element has children, we need to traverse them.
-      // Examples are BlockStatement, Choices, TryStatement, Loops, ...
-      for (const item of STATEMENTS_WITH_CHILDREN) {
-        if (lookupTable[item].is(node)) {
-          return lookupTable[item].check(node, context);
-        }
-      }
-
-      // Everything else cannot return anything.
-      if (RETURNFREE_STATEMENTS.indexOf(node.type) !== -1) {
-        return false;
-      }
-
-      // If we end up here, we stumbled upon an unknown elements
-      // Most likely it is enough to add it to the blacklist.
-      //
-      // throw new Error('Unknown node type: ' + node.type);
-      return false;
-    }
-  }
-};
-
-/**
- * Checks if the source code returns a return value.
- * It traverses the parsed source code and returns as
- * soon as it stumbles upon the first return statement.
- *
- * @param {Object} node
- *   the node which should be checked.
- * @returns {boolean}
- *   true in case the code returns a return value
- */
-const hasReturnValue = (node, context) => {
-  // Loop through all of our entry points
-  for (const item of ENTRY_POINTS) {
-    if (lookupTable[item].is(node)) {
-      return lookupTable[item].check(node, context);
-    }
-  }
-
-  throw new Error('Unknown element ' + node.type);
-};
-
-/**
- * Checks if the JSDoc comment declares a return value.
- *
- * @param {JsDocTag} tag
- *   the tag which should be checked.
- * @returns {boolean}
- *   true in case a return value is declared; otherwise false.
- */
-const hasReturnTag = (tag) => {
-  // The function should not continue in the event @returns is not defined...
-  if (typeof tag === 'undefined' || tag === null) {
-    return false;
-  }
-
-  // .. same applies if it declares `@returns {undefined}` or `@returns {void}`
-  if (tag.type === 'undefined' || tag.type === 'void') {
-    return false;
-  }
-
-  // In any other case, something must be returned, and
-  // a return statement is expected
-  return true;
-};
-
-const getTags = (jsdoc, tagName) => {
-  if (!jsdoc.tags) {
-    return [];
-  }
-
-  return jsdoc.tags.filter((item) => {
-    return item.tag === tagName;
-  });
-};
-
 /**
  * We can skip checking for a return value, in case the documentation is inherited
  * or the method is either a constructor or an abstract method.
@@ -282,11 +33,8 @@ const canSkip = (utils) => {
 };
 
 export default iterateJsdoc(({
-  jsdoc,
   report,
-  functionNode,
-  utils,
-  context
+  utils
 }) => {
   // A preflight check. We do not need to run a deep check
   // in case the @returns comment is optional or undefined.
@@ -295,14 +43,14 @@ export default iterateJsdoc(({
   }
 
   const tagName = utils.getPreferredTagName('returns');
-  const tags = getTags(jsdoc, tagName);
+  const tags = utils.getTags(tagName);
 
   if (tags.length > 1) {
     report('Found more than one  @' + tagName + ' declaration.');
   }
 
   // In case the code returns something, we expect a return value in JSDoc.
-  if (!hasReturnTag(tags[0], functionNode) && hasReturnValue(functionNode, context)) {
+  if (!utils.hasDefinedTypeReturnTag(tags[0]) && utils.hasReturnValue()) {
     report('Missing JSDoc @' + tagName + ' declaration.');
   }
 });

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -30,12 +30,20 @@ const canSkip = (utils) => {
     'class',
     'constructor',
 
+    // This seems to imply a class as well
+    'interface',
+
     // While we may, in a future rule, err in the case of (regular) functions
     //  using @implements (see https://github.com/gajus/eslint-plugin-jsdoc/issues/201 ),
     //  this should not error for those using the tag to indicate implementation of
     //  a particular function signature
     'implements'
-  ]) || utils.isConstructor();
+  ]) ||
+    utils.isConstructor() ||
+
+    // Though ESLint avoided getters: https://github.com/eslint/eslint/blob/master/lib/rules/valid-jsdoc.js#L435
+    //  ... getters seem that they should, unlike setters, always return:
+    utils.isSetter();
 };
 
 export default iterateJsdoc(({

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -28,7 +28,13 @@ const canSkip = (utils) => {
     // Constructors do not have a return value by definition (http://usejsdoc.org/tags-class.html)
     // So we can bail out here, too.
     'class',
-    'constructor'
+    'constructor',
+
+    // While we may, in a future rule, err in the case of (regular) functions
+    //  using @implements (see https://github.com/gajus/eslint-plugin-jsdoc/issues/201 ),
+    //  this should not error for those using the tag to indicate implementation of
+    //  a particular function signature
+    'implements'
   ]) || utils.isConstructor();
 };
 

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -1,10 +1,308 @@
-import _ from 'lodash';
 import iterateJsdoc from '../iterateJsdoc';
+
+const DEFAULT = '@default';
+const LOOP = '@loop';
+
+const RETURN_STATEMENT = 'ReturnStatement';
+const IF_STATEMENT = 'IfStatement';
+const EXPRESSION_STATEMENT = 'ExpressionStatement';
+const SWITCH_STATEMENT = 'SwitchStatement';
+const BLOCK_STATEMENT = 'BlockStatement';
+const FUNCTION_EXPRESSION = 'FunctionExpression';
+const ARROW_FUNCTION_EXPRESSION = 'ArrowFunctionExpression';
+const FUNCTION_DECLARATION = 'FunctionDeclaration';
+const TRY_STATEMENT = 'TryStatement';
+
+const LOOP_STATEMENTS = ['WhileStatement', 'DoWhileStatement', 'ForStatement', 'ForInStatement', 'ForOfStatement'];
+
+const STATEMENTS_WITH_CHILDREN = [
+  LOOP,
+  SWITCH_STATEMENT,
+  IF_STATEMENT,
+  BLOCK_STATEMENT,
+  TRY_STATEMENT
+];
+
+const RETURNFREE_STATEMENTS = [
+  'VariableDeclaration',
+  'ThrowStatement',
+  'FunctionDeclaration',
+  'BreakStatement',
+  'ContinueStatement',
+  'LabeledStatement',
+  'DebuggerStatement',
+  'EmptyStatement',
+  'WithStatement',
+  'ThrowStatement',
+  EXPRESSION_STATEMENT
+];
+
+const ENTRY_POINTS = [FUNCTION_DECLARATION, ARROW_FUNCTION_EXPRESSION, FUNCTION_EXPRESSION];
+
+/* eslint-disable sort-keys */
+const lookupTable = {
+  [RETURN_STATEMENT]: {
+    is: (node) => {
+      return node.type === RETURN_STATEMENT;
+    },
+    check: (node) => {
+      if (!lookupTable[RETURN_STATEMENT].is(node)) {
+        return false;
+      }
+
+      // A return without any arguments just exits the function
+      // and is typically not documented at all in jsdoc.
+      if (node.argument === null) {
+        return false;
+      }
+
+      return true;
+    }
+  },
+  [IF_STATEMENT]: {
+    is: (node) => {
+      return node.type === IF_STATEMENT;
+    },
+    check: (node) => {
+      if (!lookupTable[IF_STATEMENT].is(node)) {
+        return false;
+      }
+
+      if (lookupTable[DEFAULT].check(node.consequent)) {
+        return true;
+      }
+
+      if (node.alternate && lookupTable[DEFAULT].check(node.alternate)) {
+        return true;
+      }
+
+      return false;
+    }
+  },
+  [LOOP]: {
+    is: (node) => {
+      return LOOP_STATEMENTS.indexOf(node.type) !== -1;
+    },
+    check: (node) => {
+      lookupTable[DEFAULT].check(node.body);
+    }
+  },
+  [SWITCH_STATEMENT]: {
+    is: (node) => {
+      return node.type === SWITCH_STATEMENT;
+    },
+    check: (node) => {
+      for (const item of node.cases) {
+        for (const statement of item.consequent) {
+          if (lookupTable[DEFAULT].check(statement)) {
+            return true;
+          }
+        }
+      }
+
+      return false;
+    }
+  },
+  [TRY_STATEMENT]: {
+    is: (node) => {
+      return node.type === TRY_STATEMENT;
+    },
+    check: (node) => {
+      if (!lookupTable[TRY_STATEMENT].is(node)) {
+        return false;
+      }
+
+      if (lookupTable[BLOCK_STATEMENT].check(node.block)) {
+        return true;
+      }
+
+      if (node.handler && node.handler.block) {
+        if (lookupTable[DEFAULT].check(node)) {
+          return true;
+        }
+      }
+
+      if (lookupTable[BLOCK_STATEMENT].check(node.finalizer)) {
+        return true;
+      }
+
+      return false;
+    }
+  },
+  [BLOCK_STATEMENT]: {
+    is: (node) => {
+      return node.type === BLOCK_STATEMENT;
+    },
+    check: (node, context) => {
+      // E.g. the catch block statement is optional.
+      if (typeof node === 'undefined' || node === null) {
+        return false;
+      }
+
+      if (!lookupTable[BLOCK_STATEMENT].is(node)) {
+        return false;
+      }
+
+      for (const item of node.body) {
+        if (lookupTable[DEFAULT].check(item, context)) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+  },
+  [FUNCTION_EXPRESSION]: {
+    is: (node) => {
+      return node.type === FUNCTION_EXPRESSION;
+    },
+    check: (node, context) => {
+      return lookupTable[BLOCK_STATEMENT].check(node.body, context);
+    }
+  },
+  [ARROW_FUNCTION_EXPRESSION]: {
+    is: (node) => {
+      return node.type === ARROW_FUNCTION_EXPRESSION;
+    },
+    check: (node) => {
+      // An expression has always a return value.
+      return node.expression;
+    }
+  },
+  [FUNCTION_DECLARATION]: {
+    is: (node) => {
+      return node.type === FUNCTION_DECLARATION;
+    },
+    check: (node, context) => {
+      return lookupTable[BLOCK_STATEMENT].check(node.body, context);
+    }
+  },
+  [DEFAULT]: {
+    check: (node) => {
+      // In case it is a ReturnStatement we found what we were looking for
+      if (lookupTable[RETURN_STATEMENT].is(node)) {
+        return lookupTable[RETURN_STATEMENT].check(node);
+      }
+
+      // In case the element has children we need to traverse the them.
+      // Examples are BlockStatement, Choices, TryStatement, Loops, ...
+      for (const item of STATEMENTS_WITH_CHILDREN) {
+        if (lookupTable[item].is(node)) {
+          return lookupTable[item].check(node);
+        }
+      }
+
+      // Everything else can not return anything.
+      if (RETURNFREE_STATEMENTS.indexOf(node.type) !== -1) {
+        return false;
+      }
+
+      // If we endup here we stumbled upon an unknown elements
+      // Most likely it is enough to add it to the blacklist.
+      //
+      // throw new Error('Unknown node type: ' + node.type);
+      return false;
+    }
+  }
+};
+
+/**
+ * Checks if the source code returns a retrun value.
+ * It traverse the parsed source code an retruns as
+ * soon as it stumbles upon the first return statement.
+ *
+ * @param {Object} node
+ *   the node which should be checked.
+ * @returns {boolean}
+ *   true in case the code returns a return value
+ */
+const hasReturnValue = (node) => {
+  // Loop through all of our entry points
+  for (const item of ENTRY_POINTS) {
+    if (lookupTable[item].is(node)) {
+      return lookupTable[item].check(node);
+    }
+  }
+
+  throw new Error('Unknown element ' + node.type);
+};
+
+/**
+ * Checks if the JSDoc comment declares a return value.
+ *
+ * @param {JsDocTag} tag
+ *   the tag which should be checked.
+ * @returns {boolean}
+ *   true in case a return value is declared otherwise false.
+ */
+const hasReturnTag = (tag) => {
+  // The function should not return in case not @retruns is defined...
+  if (typeof tag === 'undefined' || tag === null) {
+    return false;
+  }
+
+  // .. same applies if it declares '@returns undefined' or '@returns void'
+  if (tag.type === 'undefined' || tag.type === 'void') {
+    return false;
+  }
+
+  // in any other it has to return something and
+  // we have to find a return statement
+  return true;
+};
+
+const getTags = (jsdoc, tagName) => {
+  if (!jsdoc.tags) {
+    return [];
+  }
+
+  return jsdoc.tags.filter((item) => {
+    return item.tag === tagName;
+  });
+};
+
+/**
+ * We can skip checking for a return value, in case the documentation is inherited
+ * or the method is either a constructor or an abstract method.
+ *
+ * In either of these cases the return value is optional or not defined.
+ *
+ * @param {*} utils
+ *   a reference to the utils which are used to probe if a tag is present or not.
+ * @returns {boolean}
+ *   true in case deep checking can be skipped otherwise false.
+ */
+const canSkip = (utils) => {
+  // Inheritdoc implies all documentation is inherited (see http://usejsdoc.org/tags-inheritdoc.html)
+  // same applies to the override tag (http://usejsdoc.org/tags-override.html)
+  //
+  // But as we do not know the parent method, we cannot perform any checks.
+  // So we bail out there instead of returning false positives.
+  if (utils.hasTag('inheritdoc') || utils.hasTag('override')) {
+    return false;
+  }
+
+  // Different Tag similar story. Abstract methods are by definition in complete.
+  // So it is not an error if it declares a return value but does not implement it.
+  if (utils.hasTag('abstract') || utils.hasTag('virtual')) {
+    return false;
+  }
+
+  // Constructors do not have a return value by definition (http://usejsdoc.org/tags-class.html)
+  // So we can bail out here, too.
+  if (utils.hasTag('class') || utils.hasTag('constructor')) {
+    return false;
+  }
+
+  return true;
+};
 
 export default iterateJsdoc(({
   jsdoc,
   report,
-  utils
+  functionNode,
+  utils,
+  context
 }) => {
   if (utils.hasATag([
     // inheritdoc implies that all documentation is inherited
@@ -24,38 +322,26 @@ export default iterateJsdoc(({
     return;
   }
 
-  const targetTagName = utils.getPreferredTagName('returns');
+  // A preflight check. We do not need to run a deep check
+  // in case the @retruns comment is optional or undefined.
+  if (canSkip(utils)) {
+    return;
+  }
 
-  const jsdocTags = _.filter(jsdoc.tags, {
-    tag: targetTagName
-  });
+  const tagName = utils.getPreferredTagName('returns');
+  const tags = getTags(jsdoc, tagName);
 
-  const sourcecode = utils.getFunctionSourceCode();
+  if (tags.length > 1) {
+    report('Found more than one  @' + tagName + ' declaration.');
+  }
 
-  // build a one-liner to test against
-  const flattenedSource = sourcecode.replace(/\r?\n|\r|\s/g, '');
+  // In case a return value is decleared in JSDoc we also expect one in the code.
+  if (hasReturnTag(tags[0], functionNode) && !hasReturnValue(functionNode, context)) {
+    report('Unexpected JSDoc @' + tagName + ' declaration.');
+  }
 
-  const startsWithReturn = '(\\)\\s?\\{return)';
-
-  const endsWithReturn = '(return.*\\})';
-
-  const implicitReturn = '(\\s?=>\\s?\\b.*)';
-
-  const implicitObjectReturn = '(\\s?=>\\s?\\(\\{)';
-
-  const matcher = new RegExp([
-    startsWithReturn,
-    endsWithReturn,
-    implicitObjectReturn,
-    implicitReturn
-  ].join('|'), 'gim');
-
-  const positiveTest = (flattenedSource.match(matcher) || []).length > 0;
-
-  const negativeTest = (flattenedSource.match(/(\{.*\{.*return)/gim) || []).length > 0 &&
-    (flattenedSource.match(/(return)/gim) || []).length < 2;
-
-  if (JSON.stringify(jsdocTags) === '[]' && positiveTest && !negativeTest) {
-    report('Missing JSDoc @' + targetTagName + ' declaration.');
+  // In case the code retuns something we expect a return value in JSDoc.
+  if (!hasReturnTag(tags[0], functionNode) && hasReturnValue(functionNode, context)) {
+    report('Missing JSDoc @' + tagName + ' declaration.');
   }
 });

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -279,22 +279,22 @@ const canSkip = (utils) => {
   // But as we do not know the parent method, we cannot perform any checks.
   // So we bail out there instead of returning false positives.
   if (utils.hasTag('inheritdoc') || utils.hasTag('override')) {
-    return false;
+    return true;
   }
 
   // Different Tag similar story. Abstract methods are by definition in complete.
   // So it is not an error if it declares a return value but does not implement it.
   if (utils.hasTag('abstract') || utils.hasTag('virtual')) {
-    return false;
+    return true;
   }
 
   // Constructors do not have a return value by definition (http://usejsdoc.org/tags-class.html)
   // So we can bail out here, too.
   if (utils.hasTag('class') || utils.hasTag('constructor')) {
-    return false;
+    return true;
   }
 
-  return true;
+  return false;
 };
 
 export default iterateJsdoc(({

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -151,9 +151,10 @@ const lookupTable = {
     is (node) {
       return node.type === 'ArrowFunctionExpression';
     },
-    check (node) {
+    check (node, context) {
       // An expression always has a return value.
-      return node.expression;
+      return node.expression ||
+        lookupTable.BlockStatement.check(node.body, context);
     }
   },
   FunctionDeclaration: {
@@ -165,17 +166,17 @@ const lookupTable = {
     }
   },
   '@default': {
-    check (node) {
+    check (node, context) {
       // In case it is a `ReturnStatement`, we found what we were looking for
       if (lookupTable.ReturnStatement.is(node)) {
-        return lookupTable.ReturnStatement.check(node);
+        return lookupTable.ReturnStatement.check(node, context);
       }
 
       // In case the element has children, we need to traverse them.
       // Examples are BlockStatement, Choices, TryStatement, Loops, ...
       for (const item of STATEMENTS_WITH_CHILDREN) {
         if (lookupTable[item].is(node)) {
-          return lookupTable[item].check(node);
+          return lookupTable[item].check(node, context);
         }
       }
 
@@ -203,11 +204,11 @@ const lookupTable = {
  * @returns {boolean}
  *   true in case the code returns a return value
  */
-const hasReturnValue = (node) => {
+const hasReturnValue = (node, context) => {
   // Loop through all of our entry points
   for (const item of ENTRY_POINTS) {
     if (lookupTable[item].is(node)) {
-      return lookupTable[item].check(node);
+      return lookupTable[item].check(node, context);
     }
   }
 

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -50,7 +50,9 @@ export default iterateJsdoc(({
   }
 
   // In case the code returns something, we expect a return value in JSDoc.
-  if (!utils.hasDefinedTypeReturnTag(tags[0]) && utils.hasReturnValue()) {
+  if (!utils.hasDefinedTypeReturnTag(tags[0]) && (
+    utils.isForceRequireReturn() || utils.hasReturnValue()
+  )) {
     report('Missing JSDoc @' + tagName + ' declaration.');
   }
 });

--- a/src/rules/requireReturnsCheck.js
+++ b/src/rules/requireReturnsCheck.js
@@ -1,33 +1,28 @@
 import iterateJsdoc from '../iterateJsdoc';
 
-const canSkip = (utils, node) => {
+const canSkip = (utils) => {
   return utils.hasATag([
     // An abstract function is by definition incomplete
-    // so it is perfectly fine if the return is missing.
+    // so it is perfectly fine if a return is documented but
+    // not present within the function.
     // A subclass may inherit the doc and implement the
     // missing return.
     'abstract',
     'virtual',
 
-    // A constructor function returns `this` by default
-    'constructor'
-  ]) ||
-
-    utils.isConstructor() ||
-
-    // Implicit return like `() => foo` is ok
-    utils.isArrowExpression() ||
-
-    // Async function always returns a `Promise`
-    node.async;
+    // A constructor function returns `this` by default, so may be `@returns`
+    //   tag indicating this but no explicit return
+    'class',
+    'constructor',
+    'interface'
+  ]) || utils.isConstructor();
 };
 
 export default iterateJsdoc(({
   report,
-  node,
   utils
 }) => {
-  if (canSkip(utils, node)) {
+  if (canSkip(utils)) {
     return;
   }
 

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -135,6 +135,26 @@ export default {
       parserOptions: {
         ecmaVersion: 8
       }
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          forceRequireReturn: true
+        }
+      }
     }
   ],
   valid: [
@@ -333,6 +353,22 @@ export default {
 
           }
       `
+    },
+    {
+      code: `
+      class Foo {
+        /**
+         *
+         */
+        constructor () {
+        }
+      }
+      `,
+      settings: {
+        jsdoc: {
+          forceRequireReturn: true
+        }
+      }
     }
   ]
 };

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -240,6 +240,15 @@ export default {
     {
       code: `
           /**
+           * @implements
+           */
+          function quux (foo) {
+          }
+      `
+    },
+    {
+      code: `
+          /**
            * @override
            */
           function quux (foo) {

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -196,6 +196,92 @@ export default {
 
           }
       `
+    },
+    {
+      code: `
+          /**
+           * @returns {Object}
+           */
+          function quux () {
+
+            return {a: foo};
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns {Object}
+           */
+          const quux = () => ({a: foo});
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns {Object}
+           */
+          const quux = () => {
+            return {a: foo}
+          };
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns {void}
+           */
+          function quux () {
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns {void}
+           */
+          const quux = () => {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns {undefined}
+           */
+          function quux () {
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns {undefined}
+           */
+          const quux = () => {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          const quux = () => {
+
+          }
+      `
     }
   ]
 };

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -155,6 +155,24 @@ export default {
           forceRequireReturn: true
         }
       }
+    },
+    {
+      code: `
+      const language = {
+        /**
+         * @param {string} name
+         */
+        get name() {
+          return this._name;
+        }
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing JSDoc @returns declaration.'
+        }
+      ]
     }
   ],
   valid: [
@@ -378,6 +396,18 @@ export default {
           forceRequireReturn: true
         }
       }
+    },
+    {
+      code: `
+      const language = {
+        /**
+         * @param {string} name
+         */
+        set name(name) {
+          this._name = name;
+        }
+      }
+      `
     }
   ]
 };

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -84,6 +84,57 @@ export default {
           }
         }
       }
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          async function quux() {}
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.'
+        }
+      ],
+      parserOptions: {
+        ecmaVersion: 8
+      }
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          const quux = async function () {}
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.'
+        }
+      ],
+      parserOptions: {
+        ecmaVersion: 8
+      }
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          const quux = async () => {}
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.'
+        }
+      ],
+      parserOptions: {
+        ecmaVersion: 8
+      }
     }
   ],
   valid: [

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -165,6 +165,37 @@ export default {
           function quux (foo) {
           }
       `
+    },
+    {
+      code: `
+          /**
+           * @override
+           */
+          function quux (foo) {
+
+            return foo;
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @class
+           */
+          function quux (foo) {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @constructor
+           */
+          function quux (foo) {
+
+          }
+      `
     }
   ]
 };

--- a/test/rules/assertions/requireReturnsCheck.js
+++ b/test/rules/assertions/requireReturnsCheck.js
@@ -70,6 +70,25 @@ export default {
           message: 'Found more than one @returns declaration.'
         }
       ]
+    },
+    {
+      code: `
+      const language = {
+        /**
+         * @param {string} name
+         * @returns {string}
+         */
+        get name() {
+          this._name = name;
+        }
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'JSDoc @returns declaration present but return expression not available in function.'
+        }
+      ]
     }
   ],
   valid: [

--- a/test/rules/assertions/requireReturnsCheck.js
+++ b/test/rules/assertions/requireReturnsCheck.js
@@ -12,7 +12,7 @@ export default {
       errors: [
         {
           line: 2,
-          message: 'Present JSDoc @returns declaration but not available return expression in function.'
+          message: 'JSDoc @returns declaration present but return expression not available in function.'
         }
       ]
     },
@@ -28,7 +28,7 @@ export default {
       errors: [
         {
           line: 2,
-          message: 'Present JSDoc @return declaration but not available return expression in function.'
+          message: 'JSDoc @return declaration present but return expression not available in function.'
         }
       ],
       settings: {
@@ -49,7 +49,7 @@ export default {
       errors: [
         {
           line: 2,
-          message: 'Present JSDoc @returns declaration but not available return expression in function.'
+          message: 'JSDoc @returns declaration present but return expression not available in function.'
         }
       ]
     },
@@ -87,7 +87,7 @@ export default {
     {
       code: `
           /**
-           * @returns {void} Foo.
+           * @returns {string} Foo.
            */
           function quux () {
 
@@ -98,7 +98,7 @@ export default {
     {
       code: `
           /**
-           * @returns {undefined} Foo.
+           * @returns {string} Foo.
            */
           function quux () {
 
@@ -169,6 +169,45 @@ export default {
            */
           function quux () {
             throw new Error('must be implemented by subclass!');
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns Foo.
+           * @virtual
+           */
+          function quux () {
+            throw new Error('must be implemented by subclass!');
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns Foo.
+           * @constructor
+           */
+          function quux () {
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns {undefined} Foo.
+           */
+          function quux () {
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @returns {void} Foo.
+           */
+          function quux () {
           }
       `
     }

--- a/test/rules/assertions/requireReturnsCheck.js
+++ b/test/rules/assertions/requireReturnsCheck.js
@@ -155,7 +155,18 @@ export default {
           /**
            * @returns {Promise<void>}
            */
-          async () => {}
+          const quux = async function () {}
+      `,
+      parserOptions: {
+        ecmaVersion: 8
+      }
+    },
+    {
+      code: `
+          /**
+           * @returns {Promise<void>}
+           */
+          const quux = async () => {}
       `,
       parserOptions: {
         ecmaVersion: 8


### PR DESCRIPTION
This build's on @thsmi 's great work with #194, refactoring to use string literals in place of the string constants as requested.

I also switched arrow functions to object shorthand since there was no advantage to using arrow functions here; besides taking up slightly more space, they are less performant. (See https://medium.com/@charpeni/arrow-functions-in-class-properties-might-not-be-as-great-as-we-think-3b3551c440b1 )

Note that this also fixes #151, #158, #200 and #201.