### PR TITLE
Update to later ESLint rule format

### DIFF
--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -178,113 +178,116 @@ export {
   parseComment
 };
 
-export default (iterator) => {
-  return (context) => {
-    const sourceCode = context.getSourceCode();
-    const tagNamePreference = _.get(context, 'settings.jsdoc.tagNamePreference') || {};
-    const exampleCodeRegex = _.get(context, 'settings.jsdoc.exampleCodeRegex') || null;
-    const rejectExampleCodeRegex = _.get(context, 'settings.jsdoc.rejectExampleCodeRegex') || null;
-    const matchingFileName = _.get(context, 'settings.jsdoc.matchingFileName') || null;
-    const additionalTagNames = _.get(context, 'settings.jsdoc.additionalTagNames') || {};
-    const baseConfig = _.get(context, 'settings.jsdoc.baseConfig') || {};
-    const configFile = _.get(context, 'settings.jsdoc.configFile');
-    const eslintrcForExamples = _.get(context, 'settings.jsdoc.eslintrcForExamples') !== false;
-    const allowInlineConfig = _.get(context, 'settings.jsdoc.allowInlineConfig') !== false;
-    const allowEmptyNamepaths = _.get(context, 'settings.jsdoc.allowEmptyNamepaths') !== false;
-    const reportUnusedDisableDirectives = _.get(context, 'settings.jsdoc.reportUnusedDisableDirectives') !== false;
-    const captionRequired = Boolean(_.get(context, 'settings.jsdoc.captionRequired'));
-    const noDefaultExampleRules = Boolean(_.get(context, 'settings.jsdoc.noDefaultExampleRules'));
-    const allowOverrideWithoutParam = Boolean(_.get(context, 'settings.jsdoc.allowOverrideWithoutParam'));
-    const allowImplementsWithoutParam = Boolean(_.get(context, 'settings.jsdoc.allowImplementsWithoutParam'));
-    const allowAugmentsExtendsWithoutParam = Boolean(_.get(context, 'settings.jsdoc.allowAugmentsExtendsWithoutParam'));
-    const checkSeesForNamepaths = Boolean(_.get(context, 'settings.jsdoc.checkSeesForNamepaths'));
+export default (iterator, meta) => {
+  return {
+    create (context) {
+      const sourceCode = context.getSourceCode();
+      const tagNamePreference = _.get(context, 'settings.jsdoc.tagNamePreference') || {};
+      const exampleCodeRegex = _.get(context, 'settings.jsdoc.exampleCodeRegex') || null;
+      const rejectExampleCodeRegex = _.get(context, 'settings.jsdoc.rejectExampleCodeRegex') || null;
+      const matchingFileName = _.get(context, 'settings.jsdoc.matchingFileName') || null;
+      const additionalTagNames = _.get(context, 'settings.jsdoc.additionalTagNames') || {};
+      const baseConfig = _.get(context, 'settings.jsdoc.baseConfig') || {};
+      const configFile = _.get(context, 'settings.jsdoc.configFile');
+      const eslintrcForExamples = _.get(context, 'settings.jsdoc.eslintrcForExamples') !== false;
+      const allowInlineConfig = _.get(context, 'settings.jsdoc.allowInlineConfig') !== false;
+      const allowEmptyNamepaths = _.get(context, 'settings.jsdoc.allowEmptyNamepaths') !== false;
+      const reportUnusedDisableDirectives = _.get(context, 'settings.jsdoc.reportUnusedDisableDirectives') !== false;
+      const captionRequired = Boolean(_.get(context, 'settings.jsdoc.captionRequired'));
+      const noDefaultExampleRules = Boolean(_.get(context, 'settings.jsdoc.noDefaultExampleRules'));
+      const allowOverrideWithoutParam = Boolean(_.get(context, 'settings.jsdoc.allowOverrideWithoutParam'));
+      const allowImplementsWithoutParam = Boolean(_.get(context, 'settings.jsdoc.allowImplementsWithoutParam'));
+      const allowAugmentsExtendsWithoutParam = Boolean(_.get(context, 'settings.jsdoc.allowAugmentsExtendsWithoutParam'));
+      const checkSeesForNamepaths = Boolean(_.get(context, 'settings.jsdoc.checkSeesForNamepaths'));
 
-    const checkJsdoc = (functionNode) => {
-      const jsdocNode = sourceCode.getJSDocComment(functionNode);
+      const checkJsdoc = (functionNode) => {
+        const jsdocNode = sourceCode.getJSDocComment(functionNode);
 
-      if (!jsdocNode) {
-        return;
-      }
+        if (!jsdocNode) {
+          return;
+        }
 
-      const ancestors = context.getAncestors();
+        const ancestors = context.getAncestors();
 
-      const indent = _.repeat(' ', jsdocNode.loc.start.column);
+        const indent = _.repeat(' ', jsdocNode.loc.start.column);
 
-      const jsdoc = parseComment(jsdocNode, indent);
+        const jsdoc = parseComment(jsdocNode, indent);
 
-      const report = (message, fixer = null, jsdocLoc = null) => {
-        let loc;
+        const report = (message, fixer = null, jsdocLoc = null) => {
+          let loc;
 
-        if (jsdocLoc) {
-          const lineNumber = jsdocNode.loc.start.line + jsdocLoc.line;
+          if (jsdocLoc) {
+            const lineNumber = jsdocNode.loc.start.line + jsdocLoc.line;
 
-          loc = {
-            end: {line: lineNumber},
-            start: {line: lineNumber}
-          };
-          if (jsdocLoc.column) {
-            const colNumber = jsdocNode.loc.start.column + jsdocLoc.column;
+            loc = {
+              end: {line: lineNumber},
+              start: {line: lineNumber}
+            };
+            if (jsdocLoc.column) {
+              const colNumber = jsdocNode.loc.start.column + jsdocLoc.column;
 
-            loc.end.column = colNumber;
-            loc.start.column = colNumber;
+              loc.end.column = colNumber;
+              loc.start.column = colNumber;
+            }
           }
-        }
-        if (fixer === null) {
-          context.report({
-            loc,
-            message,
-            node: jsdocNode
-          });
-        } else {
-          context.report({
-            fix: fixer,
-            loc,
-            message,
-            node: jsdocNode
-          });
-        }
+          if (fixer === null) {
+            context.report({
+              loc,
+              message,
+              node: jsdocNode
+            });
+          } else {
+            context.report({
+              fix: fixer,
+              loc,
+              message,
+              node: jsdocNode
+            });
+          }
+        };
+
+        const utils = curryUtils(
+          functionNode,
+          jsdoc,
+          tagNamePreference,
+          exampleCodeRegex,
+          rejectExampleCodeRegex,
+          additionalTagNames,
+          baseConfig,
+          configFile,
+          captionRequired,
+          matchingFileName,
+          eslintrcForExamples,
+          allowInlineConfig,
+          allowEmptyNamepaths,
+          reportUnusedDisableDirectives,
+          noDefaultExampleRules,
+          allowOverrideWithoutParam,
+          allowImplementsWithoutParam,
+          allowAugmentsExtendsWithoutParam,
+          checkSeesForNamepaths,
+          ancestors,
+          sourceCode
+        );
+
+        iterator({
+          context,
+          functionNode,
+          indent,
+          jsdoc,
+          jsdocNode,
+          report,
+          sourceCode,
+          utils
+        });
       };
 
-      const utils = curryUtils(
-        functionNode,
-        jsdoc,
-        tagNamePreference,
-        exampleCodeRegex,
-        rejectExampleCodeRegex,
-        additionalTagNames,
-        baseConfig,
-        configFile,
-        captionRequired,
-        matchingFileName,
-        eslintrcForExamples,
-        allowInlineConfig,
-        allowEmptyNamepaths,
-        reportUnusedDisableDirectives,
-        noDefaultExampleRules,
-        allowOverrideWithoutParam,
-        allowImplementsWithoutParam,
-        allowAugmentsExtendsWithoutParam,
-        checkSeesForNamepaths,
-        ancestors,
-        sourceCode
-      );
-
-      iterator({
-        context,
-        functionNode,
-        indent,
-        jsdoc,
-        jsdocNode,
-        report,
-        sourceCode,
-        utils
-      });
-    };
-
-    return {
-      ArrowFunctionExpression: checkJsdoc,
-      FunctionDeclaration: checkJsdoc,
-      FunctionExpression: checkJsdoc
-    };
+      return {
+        ArrowFunctionExpression: checkJsdoc,
+        FunctionDeclaration: checkJsdoc,
+        FunctionExpression: checkJsdoc
+      };
+    },
+    meta
   };
 };

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -1,3 +1,5 @@
+import iterateJsdoc from '../iterateJsdoc';
+
 const OPTIONS_SCHEMA = {
   additionalProperties: false,
   properties: {
@@ -58,83 +60,7 @@ const getOptions = (context) => {
   };
 };
 
-const checkJsDoc = (context, node) => {
-  const jsDocNode = context.getSourceCode().getJSDocComment(node);
-
-  if (jsDocNode) {
-    return;
-  }
-
-  context.report({
-    messageId: 'missingJsDoc',
-    node
-  });
-};
-
-export default {
-  /**
-   * The entrypoint for the JSDoc rule.
-   *
-   * @param {*} context
-   *   a reference to the context which hold all important information
-   *   like settings and the sourcecode to check.
-   * @returns {*}
-   *   a list with parser callback function.
-   */
-  create (context) {
-    const options = getOptions(context);
-
-    return {
-      ArrowFunctionExpression: (node) => {
-        if (!options.ArrowFunctionExpression) {
-          return;
-        }
-
-        if (node.parent.type !== 'VariableDeclarator') {
-          return;
-        }
-
-        checkJsDoc(context, node);
-      },
-
-      ClassDeclaration: (node) => {
-        if (!options.ClassDeclaration) {
-          return;
-        }
-
-        checkJsDoc(context, node);
-      },
-
-      FunctionDeclaration: (node) => {
-        if (!options.FunctionDeclaration) {
-          return;
-        }
-
-        checkJsDoc(context, node);
-      },
-
-      FunctionExpression: (node) => {
-        if (options.MethodDefinition && node.parent.type === 'MethodDefinition') {
-          checkJsDoc(context, node);
-
-          return;
-        }
-
-        if (!options.FunctionExpression) {
-          return;
-        }
-
-        if (node.parent.type === 'VariableDeclarator') {
-          checkJsDoc(context, node);
-        }
-
-        if (node.parent.type === 'Property' && node === node.parent.value) {
-          checkJsDoc(context, node);
-        }
-      }
-    };
-  },
-
+export default iterateJsdoc(null, {
   meta: {
     doc: {
       category: 'Stylistic Issues',
@@ -152,5 +78,71 @@ export default {
     ],
 
     type: 'suggestion'
+  },
+  returns (context, sourceCode) {
+    const checkJsDoc = (node) => {
+      const jsDocNode = sourceCode.getJSDocComment(node);
+
+      if (jsDocNode) {
+        return;
+      }
+
+      context.report({
+        messageId: 'missingJsDoc',
+        node
+      });
+    };
+
+    const options = getOptions(context);
+
+    return {
+      ArrowFunctionExpression: (node) => {
+        if (!options.ArrowFunctionExpression) {
+          return;
+        }
+
+        if (node.parent.type !== 'VariableDeclarator') {
+          return;
+        }
+
+        checkJsDoc(node);
+      },
+
+      ClassDeclaration: (node) => {
+        if (!options.ClassDeclaration) {
+          return;
+        }
+
+        checkJsDoc(node);
+      },
+
+      FunctionDeclaration: (node) => {
+        if (!options.FunctionDeclaration) {
+          return;
+        }
+
+        checkJsDoc(node);
+      },
+
+      FunctionExpression: (node) => {
+        if (options.MethodDefinition && node.parent.type === 'MethodDefinition') {
+          checkJsDoc(node);
+
+          return;
+        }
+
+        if (!options.FunctionExpression) {
+          return;
+        }
+
+        if (node.parent.type === 'VariableDeclarator') {
+          checkJsDoc(node);
+        }
+
+        if (node.parent.type === 'Property' && node === node.parent.value) {
+          checkJsDoc(node);
+        }
+      }
+    };
   }
-};
+});

--- a/src/rules/requireReturnsCheck.js
+++ b/src/rules/requireReturnsCheck.js
@@ -3,16 +3,16 @@ import iterateJsdoc from '../iterateJsdoc';
 export default iterateJsdoc(({
   jsdoc,
   report,
-  functionNode,
+  node,
   utils
 }) => {
   // Implicit return like `() => foo` is ok
-  if (functionNode.type === 'ArrowFunctionExpression' && functionNode.expression) {
+  if (node.type === 'ArrowFunctionExpression' && node.expression) {
     return;
   }
 
   // Async function always returns a promise
-  if (functionNode.async) {
+  if (node.async) {
     return;
   }
 


### PR DESCRIPTION
- Change rule format (require-jsdoc already in this format and all other rules use iterateJsdoc.js) per issue #19

Fixes #19.