### PR TITLE
Avoid example on constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1825,6 +1825,23 @@ function quux () {
 
 }
 // Message: Missing JSDoc @example description.
+
+/**
+ * @constructor
+ */
+function quux () {
+
+}
+// Message: Missing JSDoc @example declaration.
+
+/**
+ * @constructor
+ * @example
+ */
+function quux () {
+
+}
+// Message: Missing JSDoc @example description.
 ````
 
 The following patterns are not considered problems:
@@ -1852,6 +1869,30 @@ function quux () {
  *
  * @example <caption>Invalid usage</caption>
  * quux('random unwanted arg'); // results in an error
+ */
+function quux () {
+
+}
+
+/**
+ * @constructor
+ */
+function quux () {
+
+}
+// Settings: {"jsdoc":{"avoidExampleOnConstructors":true}}
+
+/**
+ * @constructor
+ * @example
+ */
+function quux () {
+
+}
+// Settings: {"jsdoc":{"avoidExampleOnConstructors":true}}
+
+/**
+ * @inheritdoc
  */
 function quux () {
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -42,6 +42,7 @@ const curryUtils = (
   allowAugmentsExtendsWithoutParam,
   checkSeesForNamepaths,
   forceRequireReturn,
+  avoidExampleOnConstructors,
   ancestors,
   sourceCode,
   context
@@ -142,6 +143,11 @@ const curryUtils = (
   utils.isNamepathType = (tagName) => {
     return jsdocUtils.isNamepathType(tagName, checkSeesForNamepaths);
   };
+
+  utils.avoidExampleOnConstructors = () => {
+    return avoidExampleOnConstructors;
+  };
+
   utils.passesEmptyNamepathCheck = (tag) => {
     return !tag.name && allowEmptyNamepaths && _.includes([
       // These may serve some minor purpose when empty
@@ -243,6 +249,7 @@ export default (iterator, options) => {
       const allowAugmentsExtendsWithoutParam = Boolean(_.get(context, 'settings.jsdoc.allowAugmentsExtendsWithoutParam'));
       const checkSeesForNamepaths = Boolean(_.get(context, 'settings.jsdoc.checkSeesForNamepaths'));
       const forceRequireReturn = Boolean(_.get(context, 'settings.jsdoc.forceRequireReturn'));
+      const avoidExampleOnConstructors = Boolean(_.get(context, 'settings.jsdoc.avoidExampleOnConstructors'));
 
       const checkJsdoc = (node) => {
         const jsdocNode = sourceCode.getJSDocComment(node);
@@ -311,6 +318,7 @@ export default (iterator, options) => {
           allowAugmentsExtendsWithoutParam,
           checkSeesForNamepaths,
           forceRequireReturn,
+          avoidExampleOnConstructors,
           ancestors,
           sourceCode
         );

--- a/src/rules/requireExample.js
+++ b/src/rules/requireExample.js
@@ -12,11 +12,30 @@ export default iterateJsdoc(({
     tag: targetTagName
   });
 
-  if (_.isEmpty(functionExamples)) {
-    return report('Missing JSDoc @' + targetTagName + ' declaration.');
+  if (utils.hasATag([
+    'inheritdoc',
+    'override'
+  ])) {
+    return;
   }
 
-  return _.forEach(functionExamples, (example) => {
+  if (utils.avoidExampleOnConstructors() && (
+    utils.hasATag([
+      'class',
+      'constructor'
+    ]) ||
+    utils.isConstructor()
+  )) {
+    return;
+  }
+
+  if (_.isEmpty(functionExamples)) {
+    report('Missing JSDoc @' + targetTagName + ' declaration.');
+
+    return;
+  }
+
+  _.forEach(functionExamples, (example) => {
     const exampleContent = _.compact((example.name + ' ' + example.description).trim().split('\n'));
 
     if (_.isEmpty(exampleContent)) {

--- a/test/rules/assertions/requireExample.js
+++ b/test/rules/assertions/requireExample.js
@@ -29,6 +29,37 @@ export default {
           message: 'Missing JSDoc @example description.'
         }
       ]
+    },
+    {
+      code: `
+      /**
+       * @constructor
+       */
+      function quux () {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @example declaration.'
+        }
+      ]
+    },
+    {
+      code: `
+      /**
+       * @constructor
+       * @example
+       */
+      function quux () {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @example description.'
+        }
+      ]
     }
   ],
   valid: [
@@ -66,6 +97,47 @@ export default {
           function quux () {
 
           }
+      `
+    },
+    {
+      code: `
+      /**
+       * @constructor
+       */
+      function quux () {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          avoidExampleOnConstructors: true
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @constructor
+       * @example
+       */
+      function quux () {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          avoidExampleOnConstructors: true
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @inheritdoc
+       */
+      function quux () {
+
+      }
       `
     }
   ]


### PR DESCRIPTION
also skip if possesses `inheritdoc`/`override`

Fixes #40