### PR TITLE
Ensure `no-undefined-types` catches modular scope for Node/commonjs env's

### DIFF
--- a/README.md
+++ b/README.md
@@ -1391,6 +1391,15 @@ const MyType = require('my-library').MyType;
 
 }
 
+const MyType = require('my-library').MyType;
+
+/**
+ * @param {MyType} foo - Bar.
+ */
+  function quux(foo) {
+
+}
+
 import {MyType} from 'my-library';
 
 /**

--- a/README.md
+++ b/README.md
@@ -1371,6 +1371,13 @@ function quux(foo) {
 
 }
 
+/**
+ * @param {Promise} foo - Bar.
+ */
+function quux(foo) {
+
+}
+
 class MyClass {}
 
 /**
@@ -1411,7 +1418,7 @@ import {MyType} from 'my-library';
 
 }
 
-/*global MyType*/
+/*globals MyType*/
 
 /**
  * @param {MyType} foo - Bar.

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -51,9 +51,20 @@ export default iterateJsdoc(({
   })
 
     // If the file is a module, concat the variables from the module scope.
-    .concat(scopeManager.isModule() ? globalScope.childScopes[0].variables.map((variable) => {
-      return variable.name;
-    }) : [])
+    .concat(
+
+      // This covers `commonjs` as well as `node`
+      scopeManager.__options.nodejsScope ||
+      scopeManager.isModule() ?
+        globalScope.childScopes.reduce((arr, {variables}) => {
+          // Flatten
+          arr.push(...variables);
+
+          return arr;
+        }, []).map(({name}) => {
+          return name;
+        }) : []
+    )
     .concat(extraTypes)
     .concat(typedefDeclarations);
 

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -58,7 +58,25 @@ export default {
           function quux(foo) {
 
         }
-      `
+      `,
+      env: {
+        node: true
+      }
+    },
+    {
+      code: `
+        const MyType = require('my-library').MyType;
+
+        /**
+         * @param {MyType} foo - Bar.
+         */
+          function quux(foo) {
+
+        }
+      `,
+      env: {
+        node: false
+      }
     },
     {
       code: `

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -33,6 +33,19 @@ export default {
     },
     {
       code: `
+          /**
+           * @param {Promise} foo - Bar.
+           */
+          function quux(foo) {
+
+          }
+      `,
+      env: {
+        es6: true
+      }
+    },
+    {
+      code: `
           class MyClass {}
 
           /**
@@ -97,7 +110,7 @@ export default {
     },
     {
       code: `
-        /*global MyType*/
+        /*globals MyType*/
 
         /**
          * @param {MyType} foo - Bar.


### PR DESCRIPTION
- Consider Node.js/Commonjs as module (including variables in module scope as well as global)
- (Ensure all child scopes included if there can be more than 1)
- Testing: Add one test with node false and another with node true

Fixes #109.