### PR TITLE
fix: make `checkTagNames` report position more precise

### DIFF
--- a/src/rules/checkTagNames.js
+++ b/src/rules/checkTagNames.js
@@ -17,7 +17,7 @@ export default iterateJsdoc(({
           const replacement = sourceCode.getText(jsdocNode).replace('@' + jsdocTag.tag, '@' + preferredTagName);
 
           return fixer.replaceText(jsdocNode, replacement);
-        });
+        }, jsdocTag);
       }
     } else {
       report('Invalid JSDoc tag name "' + jsdocTag.tag + '".', null, jsdocTag);

--- a/test/rules/assertions/checkTagNames.js
+++ b/test/rules/assertions/checkTagNames.js
@@ -47,7 +47,7 @@ export default {
       `,
       errors: [
         {
-          line: 2,
+          line: 3,
           message: 'Invalid JSDoc tag (preference). Replace "arg" JSDoc tag with "param".'
         }
       ]
@@ -63,7 +63,7 @@ export default {
       `,
       errors: [
         {
-          line: 2,
+          line: 3,
           message: 'Invalid JSDoc tag (preference). Replace "param" JSDoc tag with "arg".'
         }
       ],
@@ -86,7 +86,7 @@ export default {
       `,
       errors: [
         {
-          line: 2,
+          line: 3,
           message: 'Invalid JSDoc tag (preference). Replace "param" JSDoc tag with "parameter".'
         }
       ],


### PR DESCRIPTION
Previously the report location is the entrie jsdoc.
Now the report location is the line of the tag.
