### PR TITLE
build: add coverage in `npm test`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,5 +12,10 @@
         }
       }
     ]
-  ]
+  ],
+  "env": {
+    "test": {
+      "plugins": [ "istanbul" ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@babel/preset-env": "^7.3.1",
     "@babel/register": "^7.0.0",
     "babel-plugin-add-module-exports": "^1.0.0",
+    "babel-plugin-istanbul": "^5.1.4",
     "chai": "^4.2.0",
     "eslint": "^5.14.1",
     "eslint-config-canonical": "^16.1.0",
@@ -27,6 +28,7 @@
     "husky": "^1.3.1",
     "marked": "^0.6.1",
     "mocha": "^6.0.1",
+    "nyc": "^14.1.1",
     "semantic-release": "^15.13.3"
   },
   "engines": {
@@ -58,7 +60,17 @@
     "build": "rm -fr ./dist && NODE_ENV=production babel ./src --out-dir ./dist --copy-files --source-maps",
     "create-readme": "gitdown ./.README/README.md --output-file ./README.md && npm run add-assertions",
     "lint": "eslint ./src ./test",
-    "test": "mocha --recursive --require @babel/register --reporter progress"
+    "test": "BABEL_ENV=test nyc --reporter text-summary mocha --recursive --require @babel/register --reporter progress"
+  },
+  "nyc": {
+    "require": [
+      "@babel/register"
+    ],
+    "sourceMap": false,
+    "instrument": false,
+    "include": [
+      "src/"
+    ]
   },
   "version": "1.0.0"
 }


### PR DESCRIPTION
closes #224

I think it's better to leave the task of adding codecov/coverall to the maintainer.