### PR TITLE
Feat: make checkParamNames report location more precise

### DIFF
--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -11,6 +11,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Expected @param names to be "foo". Got "Foo".'
         }
       ]
@@ -112,6 +113,7 @@ export default {
       `,
       errors: [
         {
+          line: 4,
           message: '@param "bar" does not match an existing function parameter.'
         }
       ]


### PR DESCRIPTION
Previously the report locaiont is the entire jsdoc.
Now the report location is the line of the violating param tag.