### PR TITLE
`require-hyphen-before-param-description` and `tagNamePreference` setting

### DIFF
--- a/src/rules/requireHyphenBeforeParamDescription.js
+++ b/src/rules/requireHyphenBeforeParamDescription.js
@@ -10,27 +10,29 @@ export default iterateJsdoc(({
 }) => {
   let always;
 
+  const targetTagName = utils.getPreferredTagName('param');
+
   if (_.has(context.options, 0)) {
     always = context.options[0] === 'always';
   } else {
     always = true;
   }
 
-  utils.forEachTag('param', (jsdocTag) => {
+  utils.forEachTag(targetTagName, (jsdocTag) => {
     if (!jsdocTag.description) {
       return;
     }
 
     if (always) {
       if (!jsdocTag.description.startsWith('-')) {
-        report('There must be a hyphen before @param description.', (fixer) => {
+        report('There must be a hyphen before @' + targetTagName + ' description.', (fixer) => {
           const replacement = sourceCode.getText(jsdocNode).replace(jsdocTag.description, '- ' + jsdocTag.description);
 
           return fixer.replaceText(jsdocNode, replacement);
         }, jsdocTag);
       }
     } else if (jsdocTag.description.startsWith('-')) {
-      report('There must be no hyphen before @param description.', (fixer) => {
+      report('There must be no hyphen before @' + targetTagName + ' description.', (fixer) => {
         const [unwantedPart] = /-\s*/.exec(jsdocTag.description);
 
         const replacement = sourceCode


### PR DESCRIPTION
- For consistency with other rules, have `require-hyphen-before-param-description` check `tagNamePreference` setting (via `utils.getPreferredTagName`)

Pending any decision about https://github.com/gajus/eslint-plugin-jsdoc/issues/216#issuecomment-492897759 , I think the PR should be applied for consistency with the other param rules (and for easier finding of all the relevant rules if a change is made).