### PR TITLE
Only check tags expected to have types for `no-undefined-types` and `valid-types`

### DIFF
--- a/.README/rules/valid-types.md
+++ b/.README/rules/valid-types.md
@@ -2,17 +2,19 @@
 
 Requires all types to be valid JSDoc or Closure compiler types without syntax errors.
 
-Also impacts behaviors on namepath-pointing or event-pointing tags:
+Also impacts behaviors on namepath (or event)-defining and pointing tags:
 
-1.  `@alias`, `@augments`, `@extends`, `@lends`, `@memberof`, `@memberof!`, `@mixes`, `@name`, `@this`
-1.  `@callback`, `@event`, `@listens`, `@fires`, `@emits`
-1.  `@borrows`
+1. Name(path)-defining tags: `@alias`, `@augments`, `@extends`, `@lends`, `@memberof`, `@memberof!`, `@mixes`, `@this`
+1. Name(path)-pointing tags: `@class`, `@constructor`, `@constant`, `@const`, `@external`, `@host`, `@function`, `@func`, `@method`, `@interface`, `@member`, `@var`, `@mixin`, `@name`, `@namespace`, `@type`, `@typedef`
+1. Name(path)-defining tags (which may have value without namepath): `@callback`, `@event`
+1. Name(path)-pointing tags (which may have value without namepath): `@listens`, `@fires`, `@emits`
+1. Name(path)-pointing tags (multiple names in one): `@borrows`
 
 The following apply to the above sets:
 
--   Expect tags in set 1 or 2 to have a valid namepath if present
--   Prevent set 2 from being empty by setting `allowEmptyNamepaths` to `false` as these tags might have some indicative value without a path (but set 1 will always fail if empty)
--   For the special case of set 3, i.e., `@borrows <that namepath> as <this namepath>`, check that both namepaths are present and valid and ensure there is an `as ` between them.
+- Expect tags in set 1-4 to have a valid namepath if present
+- Prevent sets 3-4 from being empty by setting `allowEmptyNamepaths` to `false` as these tags might have some indicative value without a path (but sets 1-2 will always fail if empty)
+- For the special case of set 5, i.e., `@borrows <that namepath> as <this namepath>`, check that both namepaths are present and valid and ensure there is an `as ` between them.
 
 |||
 |---|---|

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -424,6 +424,13 @@ const hasReturnValue = (node, context) => {
   throw new Error('Unknown element ' + node.type);
 };
 
+/** @param {string} tag */
+/*
+const isInlineTag = (tag) => {
+  return /^(@link|@linkcode|@linkplain|@tutorial) /.test(tag);
+};
+*/
+
 export default {
   getFunctionParameterNames,
   getJsdocParameterNames,

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -54,7 +54,11 @@ export default iterateJsdoc(({
     .concat(extraTypes)
     .concat(typedefDeclarations);
 
-  jsdoc.tags.forEach((tag) => {
+  const jsdocTags = jsdoc.tags.filter((tag) => {
+    return utils.isTagWithType(tag.tag);
+  });
+
+  jsdocTags.forEach((tag) => {
     let parsedType;
 
     try {

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -1,11 +1,6 @@
 import {parse} from 'jsdoctypeparser';
 import iterateJsdoc from '../iterateJsdoc';
 
-/** @param {string} tag */
-const isInlineTag = (tag) => {
-  return /^(@link|@linkcode|@linkplain|@tutorial) /.test(tag);
-};
-
 const asExpression = /as\s+/;
 
 export default iterateJsdoc(({
@@ -47,7 +42,7 @@ export default iterateJsdoc(({
         return;
       }
       validTypeParsing(tag.name);
-    } else if (tag.type && !isInlineTag(tag.type)) {
+    } else if (tag.type && utils.isTagWithType(tag.tag)) {
       validTypeParsing(tag.type);
     }
   });


### PR DESCRIPTION
- Optimization: For `no-undefined-types`, only check tags expected to have types (as with `check-types`) or, for `valid-types`, tags expected to have types or namepaths
- Docs: For `valid-types`, indicate this grouping of name(path) defining vs. pointing tags

Fixes part of #233.