### PR TITLE
npm updates

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,8 @@
   "extends": "canonical",
   "root": true,
   "rules": {
-    "filenames/match-regex": 0
+    "filenames/match-regex": 0,
+    "prefer-named-capture-group": 0,
+    "unicorn/prevent-abbreviations": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,25 +11,25 @@
   },
   "description": "JSDoc linting rules for ESLint.",
   "devDependencies": {
-    "@babel/cli": "^7.2.3",
-    "@babel/core": "^7.3.3",
+    "@babel/cli": "^7.4.4",
+    "@babel/core": "^7.4.4",
     "@babel/node": "^7.2.2",
-    "@babel/plugin-transform-flow-strip-types": "^7.2.3",
-    "@babel/preset-env": "^7.3.1",
-    "@babel/register": "^7.0.0",
-    "babel-plugin-add-module-exports": "^1.0.0",
+    "@babel/plugin-transform-flow-strip-types": "^7.4.4",
+    "@babel/preset-env": "^7.4.4",
+    "@babel/register": "^7.4.4",
+    "babel-plugin-add-module-exports": "^1.0.2",
     "babel-plugin-istanbul": "^5.1.4",
     "chai": "^4.2.0",
     "eslint": "^5.14.1",
-    "eslint-config-canonical": "^16.1.0",
+    "eslint-config-canonical": "^17.1.0",
     "gitdown": "^2.5.7",
-    "glob": "^7.1.3",
-    "globby": "^9.0.0",
-    "husky": "^1.3.1",
-    "marked": "^0.6.1",
-    "mocha": "^6.0.1",
+    "glob": "^7.1.4",
+    "globby": "^9.2.0",
+    "husky": "^2.3.0",
+    "marked": "^0.6.2",
+    "mocha": "^6.1.4",
     "nyc": "^14.1.1",
-    "semantic-release": "^15.13.3"
+    "semantic-release": "^15.13.12"
   },
   "engines": {
     "node": ">=6"
@@ -49,7 +49,7 @@
   "main": "./dist/index.js",
   "name": "eslint-plugin-jsdoc",
   "peerDependencies": {
-    "eslint": ">=4.14.0"
+    "eslint": ">=5.16.0"
   },
   "repository": {
     "type": "git",

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -276,7 +276,7 @@ const lookupTable = {
   },
   '@loop': {
     is (node) {
-      return LOOP_STATEMENTS.indexOf(node.type) !== -1;
+      return LOOP_STATEMENTS.includes(node.type);
     },
     check (node) {
       return lookupTable['@default'].check(node.body);
@@ -390,7 +390,7 @@ const lookupTable = {
       }
 
       // Everything else cannot return anything.
-      if (RETURNFREE_STATEMENTS.indexOf(node.type) !== -1) {
+      if (RETURNFREE_STATEMENTS.includes(node.type)) {
         return false;
       }
 

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": "canonical/mocha",
   "rules": {
-    "no-restricted-syntax": 0
+    "no-restricted-syntax": 0,
+    "unicorn/prevent-abbreviations": 0
   }
 }


### PR DESCRIPTION
- npm: Update devDeps and peerDep (breaking change?)
- Linting: Disable two new rules; prefer `includes`

I ran `npm-check-updates` and found the devDep items in the PR ready for updates.

It also updated the peerDependency, eslint. I don't know if you'd consider that a breaking change, since it will probably only alert users rather than require them to use eslint 5, but I figure it may be time for a change?
