### PR TITLE
Change behavior of check-examples to also check classes

### DIFF
--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -371,8 +371,16 @@ export default (iterator, opts = {}) => {
         });
       };
 
-      if (opts.returns) {
+      if (typeof opts.returns === 'function') {
         return opts.returns(context, sourceCode, checkJsdoc);
+      }
+
+      if (Array.isArray(opts.returns)) {
+        return opts.returns.reduce((obj, prop) => {
+          obj[prop] = checkJsdoc;
+
+          return obj;
+        }, {});
       }
 
       return {

--- a/src/rules/checkExamples.js
+++ b/src/rules/checkExamples.js
@@ -188,4 +188,9 @@ export default iterateJsdoc(({
       );
     });
   });
-});
+}, {returns: [
+  'ArrowFunctionExpression',
+  'ClassDeclaration',
+  'FunctionDeclaration',
+  'FunctionExpression'
+]});

--- a/test/rules/assertions/checkExamples.js
+++ b/test/rules/assertions/checkExamples.js
@@ -34,6 +34,35 @@ export default {
     {
       code: `
           /**
+           * @example alert('hello')
+           */
+          class quux {
+
+          }
+      `,
+      errors: [
+        {
+          message: '@example error (no-alert): Unexpected alert.'
+        },
+        {
+          message: '@example error (semi): Missing semicolon.'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          baseConfig: {
+            rules: {
+              'no-alert': 2,
+              semi: ['error', 'always']
+            }
+          },
+          eslintrcForExamples: false
+        }
+      }
+    },
+    {
+      code: `
+          /**
            * @example \`\`\`js
            alert('hello');
            \`\`\`


### PR DESCRIPTION
While I know I could create config to determine at what level the rule follows, I think it may be better for us to settle on a project-wide approach. In the meantime, I think it makes sense for `check-examples` to work on classes as well as functions.