### PR TITLE
Meta.schema

### DIFF
--- a/src/rules/matchDescription.js
+++ b/src/rules/matchDescription.js
@@ -51,6 +51,35 @@ export default iterateJsdoc(({
   });
 }, {
   meta: {
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          matchDescription: {
+            format: 'regex',
+            type: 'string'
+          },
+          tags: {
+            patternProperties: {
+              '.*': {
+                oneOf: [
+                  {
+                    format: 'regex',
+                    type: 'string'
+                  },
+                  {
+                    enum: [true],
+                    type: 'boolean'
+                  }
+                ]
+              }
+            },
+            type: 'object'
+          }
+        },
+        type: 'object'
+      }
+    ],
     type: 'suggestion'
   }
 });

--- a/src/rules/newlineAfterDescription.js
+++ b/src/rules/newlineAfterDescription.js
@@ -57,5 +57,11 @@ export default iterateJsdoc(({
   meta: {
     fixable: 'whitespace',
     type: 'layout'
-  }
+  },
+  schema: [
+    {
+      enum: ['always'],
+      type: 'string'
+    }
+  ]
 });

--- a/src/rules/requireDescription.js
+++ b/src/rules/requireDescription.js
@@ -44,5 +44,29 @@ export default iterateJsdoc(({
       contexts :
       [...new Set([...defaultContexts, ...contexts])];
   },
+  schema: [
+    {
+      additionalProperties: false,
+      properties: {
+        contexts: {
+          oneOf: [
+            {
+              items: {
+                type: 'string'
+              },
+              type: 'array'
+            },
+            {
+              type: 'string'
+            }
+          ]
+        },
+        noDefaults: {
+          type: 'boolean'
+        }
+      },
+      type: 'object'
+    }
+  ],
   type: 'suggestion'
 });

--- a/src/rules/requireHyphenBeforeParamDescription.js
+++ b/src/rules/requireHyphenBeforeParamDescription.js
@@ -47,5 +47,11 @@ export default iterateJsdoc(({
   meta: {
     fixable: 'code',
     type: 'layout'
-  }
+  },
+  schema: [
+    {
+      enum: ['always'],
+      type: 'string'
+    }
+  ]
 });


### PR DESCRIPTION
The schema should, per the [ESLint docs](https://eslint.org/docs/developer-guide/working-with-rules#rule-basics), "prevent invalid rule configurations", so this is more than just informative meta-data as well (`require-jsdoc` already had one).