### PR TITLE
`preferredTypes`

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -198,6 +198,31 @@ The format of the configuration is as follows:
 }
 ```
 
+### Settings to Configure `check-types` and `no-undefined-types`
+
+- `settings.jsdoc.preferredTypes` An option map to indicate preferred
+  or forbidden types (if default types are indicated here, these will
+  have precedence over the default recommendations for `check-types`).
+  The keys of this map are the types to be replaced (or forbidden) and
+  can include the "ANY" type, `*`.
+  The values can be:
+  - `false` to forbid the type
+  - a string to indicate the type that should be preferred in its place
+    (and which `fix` mode can replace)
+  - an object with the key `message` to provide a specific error message
+    when encountering the discouraged type and, if a type is to be preferred
+    in its place, the key `replacement` to indicate the type that should be
+    used in its place (and which `fix` mode can replace) or `false` if
+    forbidding the type. The message string will have the following
+    substrings with special meaning replaced with their corresponding
+    value (`{{tagName}}`, `{{tagValue}}`, `{{badType}}`, and
+    `{{preferredType}}`, noting that the latter is of no use when one is
+    merely forbidding a type).
+
+If `no-undefined-types` has the option key `preferredTypesDefined` set to
+`true`, the preferred types indicated in the `settings.jsdoc.preferredTypes`
+map will be assumed to be defined.
+
 ### Settings to Configure `valid-types`
 
 * `settings.jsdoc.allowEmptyNamepaths` - Set to `false` to disallow

--- a/.README/rules/check-types.md
+++ b/.README/rules/check-types.md
@@ -2,7 +2,7 @@
 
 Reports invalid types.
 
-Ensures that case of native types is the same as in this list:
+By default, ensures that case of native types is the same as in this list:
 
 ```
 undefined
@@ -15,6 +15,17 @@ Array
 Date
 RegExp
 ```
+
+#### Options
+
+`check-types` allows one option:
+
+- An option object with the key `noDefaults` to insist that only the
+  supplied option type map is to be used, and that the default preferences
+  (such as "string" over "String") will not be enforced.
+
+See also the documentation on `settings.jsdoc.preferredTypes` which impacts
+the behavior of `check-types`.
 
 #### Why not capital case everything?
 

--- a/.README/rules/no-undefined-types.md
+++ b/.README/rules/no-undefined-types.md
@@ -6,10 +6,29 @@ unimported types.
 When enabling this rule, types in jsdoc comments will resolve as used
 variables, i.e. will not be marked as unused by `no-unused-vars`.
 
-The following tags will be checked for name(paths) definitions to also serve
-as a potential "type" for checking the tag types in the table below:
+In addition to considering globals found in code (or in ESLint-indicated
+`globals`) as defined, the following tags will also be checked for
+name(path) definitions to also serve as a potential "type" for checking
+the tag types in the table below:
 
 `callback`, `class` (or `constructor`), `constant` (or `const`), `event`, `external` (or `host`), `function` (or `func` or `method`), `interface`, `member` (or `var`), `mixin`, `name`, `namespace`, `typedef`.
+
+The following types are always considered defined.
+
+- `null`, `undefined`, `string`, `boolean`
+- `number`, `NaN`, `Infinity`
+- `any`, `*`
+- `Array`, `Object`, `RegExp`, `Date`, `Function`
+
+#### Options
+
+An option object may have the following keys:
+
+- `preferredTypesDefined` -  If this option is set to `true` and preferred
+  types are indicated within `settings.jsdoc.preferredTypes`, any such
+  types will be assumed to be defined as well.
+- `definedTypes` - This array can be populated to indicate other types which
+  are automatically considered as defined (in addition to globals, etc.)
 
 |||
 |---|---|

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -293,7 +293,7 @@ export default (iterator, opts = {}) => {
 
         const jsdoc = parseComment(jsdocNode, indent);
 
-        const report = (message, fixer = null, jsdocLoc = null) => {
+        const report = (message, fixer = null, jsdocLoc = null, data = null) => {
           let loc;
 
           if (jsdocLoc) {
@@ -312,12 +312,14 @@ export default (iterator, opts = {}) => {
           }
           if (fixer === null) {
             context.report({
+              data,
               loc,
               message,
               node: jsdocNode
             });
           } else {
             context.report({
+              data,
               fix: fixer,
               loc,
               message,

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -12,7 +12,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Invalid JSDoc @param "foo" type "Number".'
+          message: 'Invalid JSDoc @param "foo" type "Number"; prefer: "number".'
         }
       ],
       output: `
@@ -36,7 +36,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Invalid JSDoc @arg "foo" type "Number".'
+          message: 'Invalid JSDoc @arg "foo" type "Number"; prefer: "number".'
         }
       ],
       output: `
@@ -61,11 +61,11 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Invalid JSDoc @returns type "Number".'
+          message: 'Invalid JSDoc @returns type "Number"; prefer: "number".'
         },
         {
           line: 4,
-          message: 'Invalid JSDoc @throws type "Number".'
+          message: 'Invalid JSDoc @throws type "Number"; prefer: "number".'
         }
       ]
     },
@@ -81,11 +81,11 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Invalid JSDoc @param "foo" type "Number".'
+          message: 'Invalid JSDoc @param "foo" type "Number"; prefer: "number".'
         },
         {
           line: 3,
-          message: 'Invalid JSDoc @param "foo" type "Boolean".'
+          message: 'Invalid JSDoc @param "foo" type "Boolean"; prefer: "boolean".'
         }
       ],
       output: `
@@ -109,11 +109,11 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Invalid JSDoc @param "foo" type "Number".'
+          message: 'Invalid JSDoc @param "foo" type "Number"; prefer: "number".'
         },
         {
           line: 3,
-          message: 'Invalid JSDoc @param "foo" type "String".'
+          message: 'Invalid JSDoc @param "foo" type "String"; prefer: "string".'
         }
       ],
       output: `
@@ -124,6 +124,369 @@ export default {
 
           }
       `
+    },
+    {
+      code: `
+          /**
+           * @param {abc} foo
+           */
+          function qux(foo) {
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @param "foo" type "abc"; prefer: "Abc".'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            abc: 'Abc',
+            string: 'Str'
+          }
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @param {abc} foo
+           */
+          function qux(foo) {
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @param "foo" type "abc"; prefer: "Abc".'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            abc: {
+              replacement: 'Abc'
+            },
+            string: 'Str'
+          }
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @param {abc} foo
+           */
+          function qux(foo) {
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Messed up JSDoc @param "foo" type "abc"; prefer: "Abc".'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            abc: {
+              message: 'Messed up JSDoc @{{tagName}}{{tagValue}} type "{{badType}}"; prefer: "{{preferredType}}".',
+              replacement: 'Abc'
+            },
+            string: 'Str'
+          }
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @param {abc} foo
+           * @param {cde} bar
+           * @param {Object} baz
+           */
+          function qux(foo, bar, baz) {
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Messed up JSDoc @param "foo" type "abc"; prefer: "Abc".'
+        },
+        {
+          line: 4,
+          message: 'More messed up JSDoc @param "bar" type "cde"; prefer: "Cde".'
+        },
+        {
+          line: 5,
+          message: 'Invalid JSDoc @param "baz" type "Object"; prefer: "object".'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            abc: {
+              message: 'Messed up JSDoc @{{tagName}}{{tagValue}} type "{{badType}}"; prefer: "{{preferredType}}".',
+              replacement: 'Abc'
+            },
+            cde: {
+              message: 'More messed up JSDoc @{{tagName}}{{tagValue}} type "{{badType}}"; prefer: "{{preferredType}}".',
+              replacement: 'Cde'
+            },
+            Object: 'object'
+          }
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @param {abc} foo
+           */
+          function qux(foo) {
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Messed up JSDoc @param "foo" type "abc".'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            abc: {
+              message: 'Messed up JSDoc @{{tagName}}{{tagValue}} type "{{badType}}".',
+              replacement: false
+            },
+            string: 'Str'
+          }
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @param {abc} foo
+           */
+          function qux(foo) {
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Messed up JSDoc @param "foo" type "abc".'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            abc: {
+              message: 'Messed up JSDoc @{{tagName}}{{tagValue}} type "{{badType}}".'
+            },
+            string: 'Str'
+          }
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @param {abc} foo
+           * @param {Number} bar
+           */
+          function qux(foo, bar) {
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @param "foo" type "abc"; prefer: "Abc".'
+        }
+      ],
+      options: [{
+        noDefaults: true
+      }],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            abc: 'Abc',
+            string: 'Str'
+          }
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @param {abc} foo
+           * @param {Number} bar
+           */
+          function qux(foo, bar) {
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @param "foo" type "abc"; prefer: "Abc".'
+        },
+        {
+          line: 4,
+          message: 'Invalid JSDoc @param "bar" type "Number"; prefer: "number".'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            abc: 'Abc',
+            string: 'Str'
+          }
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @param {abc} foo
+           */
+          function qux(foo) {
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @param "foo" type "abc".'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            abc: false,
+            string: 'Str'
+          }
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @param {abc} foo
+           */
+          function qux(foo) {
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @param "foo" type "abc".'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            abc: false
+          }
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @param {*} baz
+           */
+          function qux(baz) {
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @param "baz" type "*".'
+        }
+      ],
+      output: `
+          /**
+           * @param {*} baz
+           */
+          function qux(baz) {
+          }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            '*': false,
+            abc: 'Abc',
+            string: 'Str'
+          }
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @param {*} baz
+           */
+          function qux(baz) {
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @param "baz" type "*"; prefer: "aaa".'
+        }
+      ],
+      output: `
+          /**
+           * @param {aaa} baz
+           */
+          function qux(baz) {
+          }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            '*': 'aaa',
+            abc: 'Abc',
+            string: 'Str'
+          }
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @param {abc} foo
+           * @param {Number} bar
+           */
+          function qux(foo, bar) {
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @param "foo" type "abc"; prefer: "Abc".'
+        },
+        {
+          line: 4,
+          message: 'Invalid JSDoc @param "bar" type "Number"; prefer: "number".'
+        }
+      ],
+      output: `
+          /**
+           * @param {Abc} foo
+           * @param {Number} bar
+           */
+          function qux(foo, bar) {
+          }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            abc: 'Abc',
+            string: 'Str'
+          }
+        }
+      }
     }
   ],
   valid: [
@@ -196,6 +559,37 @@ export default {
           function qux(foo) {
           }
       `
+    },
+    {
+      code: `
+          /**
+           * @returns {Number} foo
+           * @throws {Number} foo
+           */
+          function quux () {
+
+          }
+      `,
+      options: [{
+        noDefaults: true
+      }]
+    },
+    {
+      code: `
+        /**
+         * @param {object} foo
+         */
+        function quux (foo) {
+
+        }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            Object: 'object'
+          }
+        }
+      }
     }
   ]
 };

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -18,6 +18,89 @@ export default {
       rules: {
         'no-undef': 'error'
       }
+    },
+    {
+      code: `
+        /**
+         * @param {MyType} foo - Bar.
+         * @param {HisType} bar - Foo.
+         */
+         function quux(foo, bar) {
+
+         }
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'The type \'HisType\' is undefined.'
+        }
+      ],
+      options: [{
+        definedTypes: ['MyType']
+      }]
+    },
+    {
+      code: `
+        /**
+         * @param {MyType} foo - Bar.
+         * @param {HisType} bar - Foo.
+         * @param {HerType} baz - Foo.
+         */
+       function quux(foo, bar, baz) {
+
+       }
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'The type \'HisType\' is undefined.'
+        }
+      ],
+      options: [{
+        definedTypes: ['MyType'],
+        preferredTypesDefined: true
+      }],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            hertype: {
+              replacement: 'HerType'
+            }
+          }
+        }
+      }
+    },
+    {
+      code: `
+        /**
+         * @param {MyType} foo - Bar.
+         * @param {HisType} bar - Foo.
+         * @param {HerType} baz - Foo.
+         */
+       function quux(foo, bar, baz) {
+
+       }
+      `,
+      errors: [
+        {
+          line: 5,
+          message: 'The type \'HerType\' is undefined.'
+        }
+      ],
+      options: [{
+        definedTypes: ['MyType'],
+        preferredTypesDefined: true
+      }],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            hertype: {
+              replacement: false
+            },
+            histype: 'HisType'
+          }
+        }
+      }
     }
   ],
   valid: [
@@ -177,6 +260,46 @@ export default {
 
       }
       `
+    },
+    {
+      code: `
+        /**
+         * @param {MyType} foo - Bar.
+         * @param {HisType} bar - Foo.
+         */
+         function quux(foo, bar) {
+
+         }
+      `,
+      options: [{
+        definedTypes: ['MyType', 'HisType']
+      }]
+    },
+    {
+      code: `
+        /**
+         * @param {MyType} foo - Bar.
+         * @param {HisType} bar - Foo.
+         * @param {HerType} baz - Foo.
+         */
+       function quux(foo, bar, baz) {
+
+       }
+      `,
+      options: [{
+        definedTypes: ['MyType'],
+        preferredTypesDefined: true
+      }],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            hertype: {
+              replacement: 'HerType'
+            },
+            histype: 'HisType'
+          }
+        }
+      }
     }
   ]
 };


### PR DESCRIPTION
- Change: `check-types` will now include the preferred type in its report message
- Change: `no-undefined-types` now automatically allows `NaN` and `Infinity` types
- Enhancement: `check-types` and `no-undefined-types`: utilize `settings.jsdoc.preferredTypes` map
- Enhancement: `check-types`: Add option object with `noDefaults`
- Enhancement: `no-undefined-types`: Add option object with `preferredTypesAreDefined` and `definedTypes`
- Docs: `no-undefined-types`: Mention role of globals

Closes #107, #164, #166, #215 .

Also unblocks the one item I think is remaining for #1 , namely to correlate our new `preferredTypes` to eslint's deprecated `valid-jsdoc`.

Regarding #164, @gajus, I wonder if you want to also make a breaking change to the default behavior and require `object` instead of `Object`, given that valid-jsdoc did so and TypeScript [recommends so](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html). I think the rationale for this is that `Object.create(null)` will create an object whose `typeof` is `object` but which is *not* `instanceof Object`. While this PR allows overriding the default behavior, I think this makes sense as a new default as well, especially considering the `Object.create(null)` aspect.

There is also one issue in this PR I have not been able to figure out, and wonder if it is an issue with eslint itself. Though I changed this to get the test to passed, what I would expect in line 477 at https://github.com/brettz9/eslint-plugin-jsdoc/blob/a571c68bb988732b45308f3f6ae0353ce71678b3/test/rules/assertions/checkTypes.js#L477  really would instead be "number" lower-cased, as I'd think that both reported errors for this test would be fixed, but only one is. This seems not to be tied to this specific problem but it appears to me only one fix can get made. Any idea why that is?