### PR TITLE
`check-types` now expects "object" instead of "Object"

### DIFF
--- a/.README/rules/check-types.md
+++ b/.README/rules/check-types.md
@@ -10,7 +10,7 @@ null
 boolean
 number
 string
-Object
+object
 Array
 Date
 RegExp
@@ -41,18 +41,23 @@ new String('lard') // String {0: "l", 1: "a", 2: "r", 3: "d", length: 4}
 new String('lard') === 'lard' // false
 ```
 
-To make things more confusing, there are also object literals and object Objects. But object literals are still static Objects and object Objects are instantiated Objects. So an object primitive is still an object Object. (`Object.create(null)` objects are not, however.)
+To make things more confusing, there are also object literals and object Objects. But object literals are still static Objects and object Objects are instantiated Objects. So an object primitive is still an object Object.
+
+However, `Object.create(null)` objects are not `instanceof Object`, however, so
+in the case of this Object we lower-case to indicate possible support for
+these objects.
 
 Basically, for primitives, we want to define the type as a primitive, because that's what we use in 99.9% of cases. For everything else, we use the type rather than the primitive. Otherwise it would all just be `{object}`.
 
-In short: It's not about consistency, rather about the 99.9% use case.
+In short: It's not about consistency, rather about the 99.9% use case. (And some
+functions might not even support the objects if they are checking for identity.)
 
 type name | `typeof` | check-types | testcase
 --|--|--|--
-**Object** | object | **Object** | `({}) instanceof Object` -> `true`
 **Array** | object | **Array** | `([]) instanceof Array` -> `true`
 **Date** | object | **Date** | `(new Date()) instanceof Date` -> `true`
 **RegExp** | object | **RegExp** | `(new RegExp(/.+/)) instanceof RegExp` -> `true`
+**Object** | object | **object** | `({}) instanceof Object` -> `true` but `Object.create(null) instanceof Object` -> `false`
 Boolean | **boolean** | **boolean** | `(true) instanceof Boolean` -> **`false`**
 Number | **number** | **number** | `(41) instanceof Number` -> **`false`**
 String | **string** | **string** | `("test") instanceof String` -> **`false`**

--- a/README.md
+++ b/README.md
@@ -1248,7 +1248,7 @@ null
 boolean
 number
 string
-Object
+object
 Array
 Date
 RegExp
@@ -1281,18 +1281,23 @@ new String('lard') // String {0: "l", 1: "a", 2: "r", 3: "d", length: 4}
 new String('lard') === 'lard' // false
 ```
 
-To make things more confusing, there are also object literals and object Objects. But object literals are still static Objects and object Objects are instantiated Objects. So an object primitive is still an object Object. (`Object.create(null)` objects are not, however.)
+To make things more confusing, there are also object literals and object Objects. But object literals are still static Objects and object Objects are instantiated Objects. So an object primitive is still an object Object.
+
+However, `Object.create(null)` objects are not `instanceof Object`, however, so
+in the case of this Object we lower-case to indicate possible support for
+these objects.
 
 Basically, for primitives, we want to define the type as a primitive, because that's what we use in 99.9% of cases. For everything else, we use the type rather than the primitive. Otherwise it would all just be `{object}`.
 
-In short: It's not about consistency, rather about the 99.9% use case.
+In short: It's not about consistency, rather about the 99.9% use case. (And some
+functions might not even support the objects if they are checking for identity.)
 
 type name | `typeof` | check-types | testcase
 --|--|--|--
-**Object** | object | **Object** | `({}) instanceof Object` -> `true`
 **Array** | object | **Array** | `([]) instanceof Array` -> `true`
 **Date** | object | **Date** | `(new Date()) instanceof Date` -> `true`
 **RegExp** | object | **RegExp** | `(new RegExp(/.+/)) instanceof RegExp` -> `true`
+**Object** | object | **object** | `({}) instanceof Object` -> `true` but `Object.create(null) instanceof Object` -> `false`
 Boolean | **boolean** | **boolean** | `(true) instanceof Boolean` -> **`false`**
 Number | **number** | **number** | `(41) instanceof Number` -> **`false`**
 String | **string** | **string** | `("test") instanceof String` -> **`false`**
@@ -1375,11 +1380,11 @@ function qux(foo) {
 /**
  * @param {abc} foo
  * @param {cde} bar
- * @param {Object} baz
+ * @param {object} baz
  */
 function qux(foo, bar, baz) {
 }
-// Settings: {"jsdoc":{"preferredTypes":{"abc":{"message":"Messed up JSDoc @{{tagName}}{{tagValue}} type \"{{badType}}\"; prefer: \"{{preferredType}}\".","replacement":"Abc"},"cde":{"message":"More messed up JSDoc @{{tagName}}{{tagValue}} type \"{{badType}}\"; prefer: \"{{preferredType}}\".","replacement":"Cde"},"Object":"object"}}}
+// Settings: {"jsdoc":{"preferredTypes":{"abc":{"message":"Messed up JSDoc @{{tagName}}{{tagValue}} type \"{{badType}}\"; prefer: \"{{preferredType}}\".","replacement":"Abc"},"cde":{"message":"More messed up JSDoc @{{tagName}}{{tagValue}} type \"{{badType}}\"; prefer: \"{{preferredType}}\".","replacement":"Cde"},"object":"Object"}}}
 // Message: Messed up JSDoc @param "foo" type "abc"; prefer: "Abc".
 
 /**
@@ -1521,12 +1526,12 @@ function quux () {
 // Options: [{"noDefaults":true}]
 
 /**
- * @param {object} foo
+ * @param {Object} foo
  */
 function quux (foo) {
 
 }
-// Settings: {"jsdoc":{"preferredTypes":{"Object":"object"}}}
+// Settings: {"jsdoc":{"preferredTypes":{"object":"Object"}}}
 ````
 
 

--- a/src/rules/checkTypes.js
+++ b/src/rules/checkTypes.js
@@ -9,7 +9,7 @@ const strictNativeTypes = [
   'number',
   'string',
   'Array',
-  'Object',
+  'object',
   'RegExp',
   'Date',
   'Function'

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -204,7 +204,7 @@ export default {
           /**
            * @param {abc} foo
            * @param {cde} bar
-           * @param {Object} baz
+           * @param {object} baz
            */
           function qux(foo, bar, baz) {
           }
@@ -220,7 +220,7 @@ export default {
         },
         {
           line: 5,
-          message: 'Invalid JSDoc @param "baz" type "Object"; prefer: "object".'
+          message: 'Invalid JSDoc @param "baz" type "object"; prefer: "Object".'
         }
       ],
       settings: {
@@ -234,7 +234,7 @@ export default {
               message: 'More messed up JSDoc @{{tagName}}{{tagValue}} type "{{badType}}"; prefer: "{{preferredType}}".',
               replacement: 'Cde'
             },
-            Object: 'object'
+            object: 'Object'
           }
         }
       }
@@ -577,7 +577,7 @@ export default {
     {
       code: `
         /**
-         * @param {object} foo
+         * @param {Object} foo
          */
         function quux (foo) {
 
@@ -586,7 +586,7 @@ export default {
       settings: {
         jsdoc: {
           preferredTypes: {
-            Object: 'object'
+            object: 'Object'
           }
         }
       }


### PR DESCRIPTION
BREAKING CHANGE: `check-types` now expects "object" instead of "Object"

Makes consistent with Typescript recommendation and fact that `Object.create(null)` is not `instanceof Object` but its `typeof` is `object`.

Can restore old behavior through `settings: {jsdoc: {preferredTypes: {object: 'Object'}}}}` (and `check-types` still enabled). Closes #164