### PR TITLE
Change `preferredTypes` to require "<>" be appended to types by default in order to apply to parent types and otherwise apply them to child types only

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -243,6 +243,11 @@ If `no-undefined-types` has the option key `preferredTypesDefined` set to
 `true`, the preferred types indicated in the `settings.jsdoc.preferredTypes`
 map will be assumed to be defined.
 
+See the option of `check-types`, `unifyParentAndChildTypeChecks`, for
+how the keys of `preferredTypes` may have `<>` appended and its bearing
+on whether types are checked as parents/children only (e.g., to match `Array`
+if the type is `Array` vs. `Array.<string>`).
+
 ### Settings to Configure `valid-types`
 
 * `settings.jsdoc.allowEmptyNamepaths` - Set to `false` to disallow

--- a/.README/rules/check-types.md
+++ b/.README/rules/check-types.md
@@ -21,12 +21,20 @@ RegExp
 
 `check-types` allows one option:
 
-- An option object with the key `noDefaults` to insist that only the
-  supplied option type map is to be used, and that the default preferences
-  (such as "string" over "String") will not be enforced.
+- An option object:
+  - with the key `noDefaults` to insist that only the supplied option type
+    map is to be used, and that the default preferences (such as "string"
+    over "String") will not be enforced.
+  - with the key `unifyParentAndChildTypeChecks` to treat
+    `settings.jsdoc.preferredTypes` keys the same whether they are of the form
+    `SomeType` or `SomeType<>`. If this is `false` or unset, the former
+    will only apply to types which are not parent types/unions whereas the
+    latter will only apply for parent types/unions.
 
 See also the documentation on `settings.jsdoc.preferredTypes` which impacts
 the behavior of `check-types`.
+
+
 
 #### Why not capital case everything?
 
@@ -70,7 +78,7 @@ String | **string** | **string** | `("test") instanceof String` -> **`false`**
 |Tags|`class`, `constant`, `enum`, `implements`, `member`, `module`, `namespace`, `param`, `property`, `returns`, `throws`, `type`, `typedef`, `yields`|
 |Aliases|`constructor`, `const`, `var`, `arg`, `argument`, `prop`, `return`, `exception`|
 |Closure-only|`package`, `private`, `protected`, `public`, `static`|
-|Options|`noDefaults`|
+|Options|`noDefaults`, `unifyParentAndChildTypeChecks`|
 |Settings|`preferredTypes`|
 
 <!-- assertions checkTypes -->

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -487,6 +487,234 @@ export default {
           }
         }
       }
+    },
+    {
+      code: `
+      /**
+       * @param {Array} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "GenericArray".'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            Array: 'GenericArray'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {Array} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "GenericArray".'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            Array: 'GenericArray',
+            'Array<>': 'GenericArray'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {Array.<string>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "GenericArray".'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'Array<>': 'GenericArray'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {string[]} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "GenericArray".'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'Array<>': 'GenericArray'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {object} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "GenericObject".'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            object: 'GenericObject'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {object} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "GenericObject".'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            object: 'GenericObject',
+            'object<>': 'GenericObject'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {object.<string>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "GenericObject".'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'object<>': 'GenericObject'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {object.<string, number>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "GenericObject".'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'object<>': 'GenericObject'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {object.<string>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "GenericObject".'
+        }
+      ],
+      options: [{
+        unifyParentAndChildTypeChecks: true
+      }],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            object: 'GenericObject'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {object.<string, number>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "GenericObject".'
+        }
+      ],
+      options: [{
+        unifyParentAndChildTypeChecks: true
+      }],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            object: 'GenericObject'
+          }
+        }
+      }
     }
   ],
   valid: [
@@ -587,6 +815,128 @@ export default {
         jsdoc: {
           preferredTypes: {
             object: 'Object'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {Array} foo
+       */
+      function quux (foo) {
+
+      }
+      `
+    },
+    {
+      code: `
+      /**
+       * @param {Array.<string>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            Array: 'GenericArray'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {string[]} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            Array: 'GenericArray'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {Array} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'Array<>': 'GenericArray'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {object} foo
+       */
+      function quux (foo) {
+
+      }
+      `
+    },
+    {
+      code: `
+      /**
+       * @param {object.<string>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            object: 'GenericObject'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {object.<string, number>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            object: 'GenericObject'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {object} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'object<>': 'GenericObject'
           }
         }
       }


### PR DESCRIPTION
This PR fixes #87 - allowing one to forbid or rename types which are too generic, e.g., `Array`, `Promise`, or `Object` and have no child types specified.

----
BREAKING CHANGE: Cause `preferredTypes` setting not to apply by default to parent types; need to target type name with "<>" appended to target parent types (and only parent types); can alternatively; also adds option `unifyParentAndChildTypeChecks` to restore the old behavior

Allows for warning against overly generic types only (e.g., `Array` without its own children) or against the parent type only (to disallow `Array.<someType>`)

To restore old behavior, also target type names with "<>" or set the `unifyParentAndChildTypeChecks` option.
