### PR TITLE
Deprecate param-specific settings to avoid docs in favor of generic ones

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -190,18 +190,16 @@ tags in the rule `check-tag-names`. The format of the configuration is as follow
 }
 ```
 
-### Allow `@override` Without Accompanying `@param` Tags
+### `@override`/`@augments`/`@extends`/`@implements` Without Accompanying `@param`/`@description`/`@example`/`@returns`
 
-Use any of the following settings to override `require-param` and allow
-`@param` to be omitted when the specified tags are present on the JSDoc
-comment or the parent class comment. The default value for each is `false`.
+The following settings allows the element(s) they reference to be omitted
+on the JSDoc comment block of the function or that of its parent class
+for any of the "require" rules (i.e., `require-param`, `require-description`,
+`require-example`, or `require-returns`).
 
-* `settings.jsdoc.allowOverrideWithoutParam` - Enables behavior with
-  `@override` tag
-* `settings.jsdoc.allowImplementsWithoutParam` - Enables behavior with
-  `@implements` tag
-* `settings.jsdoc.allowAugmentsExtendsWithoutParam` - Enables behavior with
-  `@augments` tag or its synonym `@extends`
+* `settings.jsdoc.overrideReplacesDocs` (`@override`) - Defaults to `true`
+* `settings.jsdoc.augmentsExtendsReplacesDocs` (`@augments` or its alias `@extends`) - Defaults to `false`.
+* `settings.jsdoc.implementsReplacesDocs` (`@implements`) - Defaults to `false`
 
 The format of the configuration is as follows:
 
@@ -210,13 +208,18 @@ The format of the configuration is as follows:
     "rules": {},
     "settings": {
         "jsdoc": {
-            "allowOverrideWithoutParam": true,
-            "allowImplementsWithoutParam": true,
-            "allowAugmentsExtendsWithoutParam": true
+            "overrideReplacesDocs": true,
+            "augmentsExtendsReplacesDocs": true,
+            "implementsReplacesDocs": true
         }
     }
 }
 ```
+
+`settings.jsdoc.allowOverrideWithoutParam`,
+`settings.jsdoc.allowImplementsWithoutParam`, and
+`settings.jsdoc.allowAugmentsExtendsWithoutParam` performed a similar function
+but restricted to `@param`. These settings are now deprecated.
 
 ### Settings to Configure `check-types` and `no-undefined-types`
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ JSDoc linting rules for ESLint.
         * [Exempting empty functions from `require-jsdoc`](#eslint-plugin-jsdoc-settings-exempting-empty-functions-from-require-jsdoc)
         * [Alias Preference](#eslint-plugin-jsdoc-settings-alias-preference)
         * [Additional Tag Names](#eslint-plugin-jsdoc-settings-additional-tag-names)
-        * [Allow `@override` Without Accompanying `@param` Tags](#eslint-plugin-jsdoc-settings-allow-override-without-accompanying-param-tags)
+        * [`@override`/`@augments`/`@extends`/`@implements` Without Accompanying `@param`/`@description`/`@example`/`@returns`](#eslint-plugin-jsdoc-settings-override-augments-extends-implements-without-accompanying-param-description-example-returns)
         * [Settings to Configure `check-types` and `no-undefined-types`](#eslint-plugin-jsdoc-settings-settings-to-configure-check-types-and-no-undefined-types)
         * [Settings to Configure `valid-types`](#eslint-plugin-jsdoc-settings-settings-to-configure-valid-types)
         * [Settings to Configure `require-returns`](#eslint-plugin-jsdoc-settings-settings-to-configure-require-returns)
@@ -241,19 +241,17 @@ tags in the rule `check-tag-names`. The format of the configuration is as follow
 }
 ```
 
-<a name="eslint-plugin-jsdoc-settings-allow-override-without-accompanying-param-tags"></a>
-### Allow <code>@override</code> Without Accompanying <code>@param</code> Tags
+<a name="eslint-plugin-jsdoc-settings-override-augments-extends-implements-without-accompanying-param-description-example-returns"></a>
+### <code>@override</code>/<code>@augments</code>/<code>@extends</code>/<code>@implements</code> Without Accompanying <code>@param</code>/<code>@description</code>/<code>@example</code>/<code>@returns</code>
 
-Use any of the following settings to override `require-param` and allow
-`@param` to be omitted when the specified tags are present on the JSDoc
-comment or the parent class comment. The default value for each is `false`.
+The following settings allows the element(s) they reference to be omitted
+on the JSDoc comment block of the function or that of its parent class
+for any of the "require" rules (i.e., `require-param`, `require-description`,
+`require-example`, or `require-returns`).
 
-* `settings.jsdoc.allowOverrideWithoutParam` - Enables behavior with
-  `@override` tag
-* `settings.jsdoc.allowImplementsWithoutParam` - Enables behavior with
-  `@implements` tag
-* `settings.jsdoc.allowAugmentsExtendsWithoutParam` - Enables behavior with
-  `@augments` tag or its synonym `@extends`
+* `settings.jsdoc.overrideReplacesDocs` (`@override`) - Defaults to `true`
+* `settings.jsdoc.augmentsExtendsReplacesDocs` (`@augments` or its alias `@extends`) - Defaults to `false`.
+* `settings.jsdoc.implementsReplacesDocs` (`@implements`) - Defaults to `false`
 
 The format of the configuration is as follows:
 
@@ -262,13 +260,18 @@ The format of the configuration is as follows:
     "rules": {},
     "settings": {
         "jsdoc": {
-            "allowOverrideWithoutParam": true,
-            "allowImplementsWithoutParam": true,
-            "allowAugmentsExtendsWithoutParam": true
+            "overrideReplacesDocs": true,
+            "augmentsExtendsReplacesDocs": true,
+            "implementsReplacesDocs": true
         }
     }
 }
 ```
+
+`settings.jsdoc.allowOverrideWithoutParam`,
+`settings.jsdoc.allowImplementsWithoutParam`, and
+`settings.jsdoc.allowAugmentsExtendsWithoutParam` performed a similar function
+but restricted to `@param`. These settings are now deprecated.
 
 <a name="eslint-plugin-jsdoc-settings-settings-to-configure-check-types-and-no-undefined-types"></a>
 ### Settings to Configure <code>check-types</code> and <code>no-undefined-types</code>

--- a/src/rules/requireDescription.js
+++ b/src/rules/requireDescription.js
@@ -6,6 +6,10 @@ export default iterateJsdoc(({
   report,
   utils
 }) => {
+  if (utils.avoidDocs()) {
+    return;
+  }
+
   const targetTagName = utils.getPreferredTagName('description');
 
   const functionExamples = _.filter(jsdoc.tags, {

--- a/src/rules/requireExample.js
+++ b/src/rules/requireExample.js
@@ -6,18 +6,15 @@ export default iterateJsdoc(({
   report,
   utils
 }) => {
+  if (utils.avoidDocs()) {
+    return;
+  }
+
   const targetTagName = 'example';
 
   const functionExamples = _.filter(jsdoc.tags, {
     tag: targetTagName
   });
-
-  if (utils.hasATag([
-    'inheritdoc',
-    'override'
-  ])) {
-    return;
-  }
 
   if (utils.avoidExampleOnConstructors() && (
     utils.hasATag([

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -8,27 +8,7 @@ export default iterateJsdoc(({
   const functionParameterNames = utils.getFunctionParameterNames();
   const jsdocParameterNames = utils.getJsdocParameterNames();
 
-  // inheritdoc implies that all documentation is inherited; see http://usejsdoc.org/tags-inheritdoc.html
-  if (utils.hasTag('inheritdoc')) {
-    return;
-  }
-
-  // When settings.jsdoc.allowOverrideWithoutParam is true, override implies that all documentation is inherited.
-  // See https://github.com/gajus/eslint-plugin-jsdoc/issues/73
-  if ((utils.hasTag('override') || utils.classHasTag('override')) && utils.isOverrideAllowedWithoutParam()) {
-    return;
-  }
-
-  // When settings.jsdoc.allowImplementsWithoutParam is true, implements implies that all documentation is inherited.
-  // See https://github.com/gajus/eslint-plugin-jsdoc/issues/100
-  if ((utils.hasTag('implements') || utils.classHasTag('implements')) && utils.isImplementsAllowedWithoutParam()) {
-    return;
-  }
-
-  // When settings.jsdoc.allowAugmentsExtendsWithoutParam is true, augments or extends implies that all documentation is inherited.
-  // See https://github.com/gajus/eslint-plugin-jsdoc/issues/100
-  if ((utils.hasTag('augments') || utils.hasTag('extends') ||
-    utils.classHasTag('augments') || utils.classHasTag('extends')) && utils.isAugmentsExtendsAllowedWithoutParam()) {
+  if (utils.avoidDocs('param')) {
     return;
   }
 

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -16,11 +16,7 @@ const canSkip = (utils) => {
     // inheritdoc implies that all documentation is inherited
     // see http://usejsdoc.org/tags-inheritdoc.html
     //
-    // As we do not know the parent method, we cannot perform any checks.
-    'inheritdoc',
-    'override',
-
-    // Different Tag similar story. Abstract methods are by definition incomplete,
+    // Abstract methods are by definition incomplete,
     // so it is not an error if it declares a return value but does not implement it.
     'abstract',
     'virtual',
@@ -31,19 +27,14 @@ const canSkip = (utils) => {
     'constructor',
 
     // This seems to imply a class as well
-    'interface',
-
-    // While we may, in a future rule, err in the case of (regular) functions
-    //  using @implements (see https://github.com/gajus/eslint-plugin-jsdoc/issues/201 ),
-    //  this should not error for those using the tag to indicate implementation of
-    //  a particular function signature
-    'implements'
+    'interface'
   ]) ||
     utils.isConstructor() ||
 
     // Though ESLint avoided getters: https://github.com/eslint/eslint/blob/master/lib/rules/valid-jsdoc.js#L435
     //  ... getters seem that they should, unlike setters, always return:
-    utils.isSetter();
+    utils.isSetter() ||
+    utils.avoidDocs();
 };
 
 export default iterateJsdoc(({

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -65,7 +65,12 @@ export default {
         {
           message: 'Missing JSDoc @param "foo" declaration.'
         }
-      ]
+      ],
+      settings: {
+        jsdoc: {
+          allowOverrideWithoutParam: false
+        }
+      }
     },
     {
       code: `
@@ -80,7 +85,12 @@ export default {
         {
           message: 'Missing JSDoc @param "foo" declaration.'
         }
-      ]
+      ],
+      settings: {
+        jsdoc: {
+          allowImplementsWithoutParam: false
+        }
+      }
     },
     {
       code: `
@@ -130,7 +140,12 @@ export default {
         {
           message: 'Missing JSDoc @param "foo" declaration.'
         }
-      ]
+      ],
+      settings: {
+        jsdoc: {
+          allowOverrideWithoutParam: false
+        }
+      }
     },
     {
       code: `
@@ -150,7 +165,12 @@ export default {
         {
           message: 'Missing JSDoc @param "foo" declaration.'
         }
-      ]
+      ],
+      settings: {
+        jsdoc: {
+          allowImplementsWithoutParam: false
+        }
+      }
     },
     {
       code: `
@@ -250,12 +270,62 @@ export default {
           function quux (foo) {
 
           }
+      `
+    },
+    {
+      code: `
+          /**
+           * @override
+           */
+          class A {
+            /**
+              *
+              */
+            quux (foo) {
+
+            }
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @override
+           */
+          function quux (foo) {
+
+          }
       `,
       settings: {
         jsdoc: {
           allowOverrideWithoutParam: true
         }
       }
+    },
+    {
+      code: `
+          /**
+           * @implements
+           */
+          class A {
+            /**
+             *
+             */
+            quux (foo) {
+
+            }
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @implements
+           */
+          function quux (foo) {
+
+          }
+      `
     },
     {
       code: `


### PR DESCRIPTION
When working on the `require-param` rule, I added some settings which now, in light of considering the other require-tag-presence-on-function rules (`require-description`, `require-returns`, and `require-example`), I believe it makes more sense to have generic rules to describe how `@override`, `@augments`/`@extends`, and `@implements` should behave, as the expectations are likely to be similar.

----
feat: add settings `overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs` and apply to  `require-param`, `require-description`, `require-example`, and `require-returns` for exempting all of these from errors in the case of the presence of `@override`, `@augments`/`@extends`, or `@implements`, respectively.

This commit also adds the following new behavior: with `require-description`, `inheritdoc` will avoid erring.

This commit also causes the following non-breaking changes:

With `require-example` and `require-returns`, `@override` may now err if the setting `overrideReplacesDocs` is set to false
With `require-returns`, `@implements` may now err if the setting `implementsReplacesDocs` is set to false
With `require-example`, `require-returns`, and `require-description`, `@augments` or `@extends` may now avoid erring if the setting `augmentsExtendsReplacesDocs` is set to true

Deprecating `settings.jsdoc.allowOverrideWithoutParam`, `settings.jsdoc.allowImplementsWithoutParam`, and `settings.jsdoc.allowAugmentsExtendsWithoutParam` in favor of the more tag-independent settings.