### PR TITLE
Add exported functions option to require-jsdoc rule

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -122,6 +122,7 @@ Finally, enable all of the rules that you would like to use.
 
 - `settings.jsdoc.publicFunctionsOnly` - Missing jsdoc blocks
   are only reported for function bodies that are exported from the module.
+  May be a boolean or object.
 
   This setting object supports the following keys:
 

--- a/.README/README.md
+++ b/.README/README.md
@@ -120,8 +120,8 @@ Finally, enable all of the rules that you would like to use.
 
 ### Requiring JSDoc comments for exported functions in <code>require-jsdoc</code>
 
-- `settings.jsdoc.publicFunctionsOnly` - Missing jsdoc blocks
-  are only reported for function bodies that are exported from the module.
+- `settings.jsdoc.publicOnly` - Missing jsdoc blocks
+  are only reported for function bodies / class declarations that are exported from the module.
   May be a boolean or object.
 
   This setting object supports the following keys:

--- a/.README/README.md
+++ b/.README/README.md
@@ -126,6 +126,7 @@ Finally, enable all of the rules that you would like to use.
 
   This setting object supports the following keys:
 
+  - `ancestorsOnly` - Only check node ancestors to check if node is exported
   - `exports` - ESM exports are checked for JSDoc comments
   - `modules` - CommonJS exports are checked for JSDoc comments
   - `browserEnv` - Populates window variable

--- a/.README/README.md
+++ b/.README/README.md
@@ -126,9 +126,9 @@ Finally, enable all of the rules that you would like to use.
 
   This setting object supports the following keys:
 
-  - `exports`
-  - `modules`
-  - `browserEnv`
+  - `exports` - ESM exports are checked for JSDoc comments
+  - `modules` - CommonJS exports are checked for JSDoc comments
+  - `browserEnv` - Populates window variable
 
 ### Alias Preference
 

--- a/.README/README.md
+++ b/.README/README.md
@@ -118,19 +118,6 @@ Finally, enable all of the rules that you would like to use.
   above functions/methods with no parameters or return values (intended where
   variable names are sufficient for themselves as documentation).
 
-### Requiring JSDoc comments for exported functions in <code>require-jsdoc</code>
-
-- `settings.jsdoc.publicOnly` - Missing jsdoc blocks
-  are only reported for function bodies / class declarations that are exported from the module.
-  May be a boolean or object.
-
-  This setting object supports the following keys:
-
-  - `ancestorsOnly` - Only check node ancestors to check if node is exported
-  - `exports` - ESM exports are checked for JSDoc comments
-  - `modules` - CommonJS exports are checked for JSDoc comments
-  - `browserEnv` - Populates window variable
-
 ### Alias Preference
 
 Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a JSDoc tag. The format of the configuration is: `<primary tag name>: <preferred alias name>`, e.g.

--- a/.README/README.md
+++ b/.README/README.md
@@ -118,6 +118,17 @@ Finally, enable all of the rules that you would like to use.
   above functions/methods with no parameters or return values (intended where
   variable names are sufficient for themselves as documentation).
 
+### Requiring JSDoc comments for exported functions in <code>require-jsdoc</code>
+
+- `settings.jsdoc.publicFunctionsOnly` - Missing jsdoc blocks
+  are only reported for function bodies that are exported from the module.
+
+  This setting object supports the following keys:
+
+  - `exports`
+  - `modules`
+  - `browserEnv`
+
 ### Alias Preference
 
 Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a JSDoc tag. The format of the configuration is: `<primary tag name>: <preferred alias name>`, e.g.

--- a/.README/rules/require-jsdoc.md
+++ b/.README/rules/require-jsdoc.md
@@ -22,7 +22,7 @@ be checked by the rule.
   - `ancestorsOnly` - Only check node ancestors to check if node is exported
   - `exports` - ESM exports are checked for JSDoc comments (Defaults to `true`)
   - `modules` - CommonJS exports are checked for JSDoc comments  (Defaults to `true`)
-  - `browserEnv` - Populates window variable
+  - `browserEnv` - Window global exports are checked for JSDoc comments
 
 - `require` - An object with the following optional boolean keys which all
     default to `false` except as noted:

--- a/.README/rules/require-jsdoc.md
+++ b/.README/rules/require-jsdoc.md
@@ -7,6 +7,6 @@ functions.
 |---|---|
 |Context|`ArrowFunctionExpression`, `ClassDeclaration`, `FunctionDeclaration`, `FunctionExpression`|
 |Tags|N/A|
-|Settings|`exemptEmptyFunctions`|
+|Settings|`exemptEmptyFunctions`, `publicFunctionsOnly`|
 
 <!-- assertions requireJsdoc -->

--- a/.README/rules/require-jsdoc.md
+++ b/.README/rules/require-jsdoc.md
@@ -20,8 +20,8 @@ be checked by the rule.
   otherwise noted):
 
   - `ancestorsOnly` - Only check node ancestors to check if node is exported
-  - `exports` - ESM exports are checked for JSDoc comments (Defaults to `true`)
-  - `modules` - CommonJS exports are checked for JSDoc comments  (Defaults to `true`)
+  - `esm` - ESM exports are checked for JSDoc comments (Defaults to `true`)
+  - `cjs` - CommonJS exports are checked for JSDoc comments  (Defaults to `true`)
   - `browserEnv` - Window global exports are checked for JSDoc comments
 
 - `require` - An object with the following optional boolean keys which all

--- a/.README/rules/require-jsdoc.md
+++ b/.README/rules/require-jsdoc.md
@@ -22,7 +22,7 @@ be checked by the rule.
   - `ancestorsOnly` - Only check node ancestors to check if node is exported
   - `esm` - ESM exports are checked for JSDoc comments (Defaults to `true`)
   - `cjs` - CommonJS exports are checked for JSDoc comments  (Defaults to `true`)
-  - `browserEnv` - Window global exports are checked for JSDoc comments
+  - `window` - Window global exports are checked for JSDoc comments
 
 - `require` - An object with the following optional boolean keys which all
     default to `false` except as noted:

--- a/.README/rules/require-jsdoc.md
+++ b/.README/rules/require-jsdoc.md
@@ -3,10 +3,32 @@
 Checks for presence of jsdoc comments, on class declarations as well as
 functions.
 
+#### Options
+
+Accepts one optional options object, with two optional keys, `publicOnly`
+for confining JSDoc comments to be checked to exported functions (with "exported"
+allowing for ESM exports, CJS exports, or browser window global export)
+in `require-jsdoc`, and `require` for limiting the contexts which are to
+be checked by the rule.
+
+- `publicOnly` - Missing jsdoc blocks are only reported for function
+  bodies / class declarations that are exported from the module.
+  May be a boolean or object. If set to `true`, the defaults below will
+  be used.
+
+  This object supports the following optional boolean keys (`false` unless
+  otherwise noted):
+
+  - `ancestorsOnly` - Only check node ancestors to check if node is exported
+  - `exports` - ESM exports are checked for JSDoc comments (Defaults to `true`)
+  - `modules` - CommonJS exports are checked for JSDoc comments  (Defaults to `true`)
+  - `browserEnv` - Populates window variable
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `ClassDeclaration`, `FunctionDeclaration`, `FunctionExpression`|
 |Tags|N/A|
-|Settings|`exemptEmptyFunctions`, `publicFunctionsOnly`|
+|Options|`publicOnly`|
+|Settings|`exemptEmptyFunctions`|
 
 <!-- assertions requireJsdoc -->

--- a/.README/rules/require-jsdoc.md
+++ b/.README/rules/require-jsdoc.md
@@ -24,6 +24,15 @@ be checked by the rule.
   - `modules` - CommonJS exports are checked for JSDoc comments  (Defaults to `true`)
   - `browserEnv` - Populates window variable
 
+- `require` - An object with the following optional boolean keys which all
+    default to `false` except as noted:
+
+  - `ArrowFunctionExpression`
+  - `ClassDeclaration`
+  - `FunctionDeclaration` (defaults to `true`)
+  - `FunctionExpression`
+  - `MethodDefinition`
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `ClassDeclaration`, `FunctionDeclaration`, `FunctionExpression`|

--- a/README.md
+++ b/README.md
@@ -168,12 +168,17 @@ Finally, enable all of the rules that you would like to use.
   above functions/methods with no parameters or return values (intended where
   variable names are sufficient for themselves as documentation).
 
-<a name="eslint-plugin-jsdoc-settings-requiring-jsdoc-comments-for-exported-functions-in-require-jsdoc"></a>
 <a name="eslint-plugin-jsdoc-settings-requiring-jsdoc-comments-for-exported-functions-in-code-require-jsdoc-code"></a>
 ### Requiring JSDoc comments for exported functions in <code>require-jsdoc</code>
 
 - `settings.jsdoc.publicFunctionsOnly` - Missing jsdoc blocks
   are only reported for function bodies that are exported from the module.
+
+  This setting object supports the following keys:
+
+  - `exports`
+  - `modules`
+  - `browserEnv`
 
 <a name="eslint-plugin-jsdoc-settings-alias-preference"></a>
 ### Alias Preference
@@ -3428,11 +3433,7 @@ functions.
 |---|---|
 |Context|`ArrowFunctionExpression`, `ClassDeclaration`, `FunctionDeclaration`, `FunctionExpression`|
 |Tags|N/A|
-|Settings|`exemptEmptyFunctions`|
-|Settings|`publicFunctionsOnly`|
-|Settings|`publicFunctionsOnly.exports`|
-|Settings|`publicFunctionsOnly.modules`|
-|Settings|`publicFunctionsOnly.browserEnv`|
+|Settings|`exemptEmptyFunctions`, `publicFunctionsOnly`|
 
 The following patterns are considered problems:
 

--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ Finally, enable all of the rules that you would like to use.
 <a name="eslint-plugin-jsdoc-settings-requiring-jsdoc-comments-for-exported-functions-in-code-require-jsdoc-code"></a>
 ### Requiring JSDoc comments for exported functions in <code>require-jsdoc</code>
 
-- `settings.jsdoc.publicFunctionsOnly` - Missing jsdoc blocks
-  are only reported for function bodies that are exported from the module.
+- `settings.jsdoc.publicOnly` - Missing jsdoc blocks
+  are only reported for function bodies / class declarations that are exported from the module.
   May be a boolean or object.
 
   This setting object supports the following keys:
@@ -3539,7 +3539,7 @@ function foo () {
 module.exports = function quux () {
 
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
@@ -3548,7 +3548,7 @@ module.exports = {
 
   }
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
@@ -3559,14 +3559,14 @@ module.exports = {
     }
   }
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 const test = module.exports = function () {
 
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
@@ -3578,7 +3578,7 @@ const test = module.exports = function () {
 }
 
 test.prototype.method = function() {}
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
@@ -3588,7 +3588,7 @@ const test = function () {
 module.exports = {
   test: test
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
@@ -3598,7 +3598,7 @@ const test = () => {
 module.exports = {
   test: test
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"ArrowFunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
@@ -3608,14 +3608,14 @@ class Test {
     }
 }
 module.exports = Test;
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"MethodDefinition":true}}]
 // Message: Missing JSDoc comment.
 
 export default function quux () {
 
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
@@ -3623,14 +3623,14 @@ function quux () {
 
 }
 export default quux;
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 export function test() {
 
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
@@ -3639,7 +3639,7 @@ var test = function () {
 }
 var test2 = 2;
 export { test, test2 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
@@ -3647,14 +3647,14 @@ var test = function () {
 
 }
 export { test as test2 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 export default class A {
 
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"ClassDeclaration":true}}]
 // Message: Missing JSDoc comment.
 ````
@@ -3873,7 +3873,7 @@ const test = {};
 module.exports = {
   prop: { prop2: test.method }
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 
 /**
@@ -3886,7 +3886,7 @@ function test() {
 module.exports = {
 prop: { prop2: test }
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 
 /**
@@ -3899,7 +3899,7 @@ test = function() {
 module.exports = {
   prop: { prop2: test }
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":{"browserEnv":false,"modules":true}}}
+// Settings: {"jsdoc":{"publicOnly":{"browserEnv":false,"modules":true}}}
 // Options: [{"require":{"FunctionExpression":true}}]
 
 /**
@@ -3912,7 +3912,7 @@ test = function() {
 exports.someMethod = {
   prop: { prop2: test }
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":{"browserEnv":false,"exports":true}}}
+// Settings: {"jsdoc":{"publicOnly":{"browserEnv":false,"exports":true}}}
 // Options: [{"require":{"FunctionExpression":true}}]
 
 /**
@@ -3925,7 +3925,7 @@ const test = () => {
 module.exports = {
 prop: { prop2: test }
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"ArrowFunctionExpression":true}}]
 
 /**
@@ -3938,7 +3938,7 @@ window.test = function() {
 module.exports = {
 prop: window
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 
 test = function() {
@@ -3955,7 +3955,7 @@ test = function() {
 module.exports = {
 prop: { prop2: test }
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 
 test = function() {
@@ -3967,7 +3967,7 @@ test = 2;
 module.exports = {
 prop: { prop2: test }
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 
 /**
@@ -3987,7 +3987,7 @@ test.prototype.method = function() {
 module.exports = {
 prop: { prop2: test }
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 
 class Test {
@@ -3999,7 +3999,7 @@ class Test {
   }
 }
 module.exports = Test;
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"MethodDefinition":true}}]
 
 /**
@@ -4008,7 +4008,7 @@ module.exports = Test;
 export default function quux () {
 
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 
 /**
@@ -4018,7 +4018,7 @@ function quux () {
 
 }
 export default quux;
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 
 /**
@@ -4027,7 +4027,7 @@ export default quux;
 export function test() {
 
 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 
 /**
@@ -4038,7 +4038,7 @@ var test = function () {
 }
 var test2 = 2;
 export { test, test2 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 
 /**
@@ -4048,7 +4048,7 @@ var test = function () {
 
 }
 export { test as test2 }
-// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
 ````
 
@@ -4230,6 +4230,7 @@ The following patterns are considered problems:
 function quux (foo) {
 
 }
+// Settings: {"jsdoc":{"allowOverrideWithoutParam":false}}
 // Message: Missing JSDoc @param "foo" declaration.
 
 /**
@@ -4255,6 +4256,7 @@ function quux (foo, bar) {
 function quux (foo) {
 
 }
+// Settings: {"jsdoc":{"allowImplementsWithoutParam":false}}
 // Message: Missing JSDoc @param "foo" declaration.
 
 /**
@@ -4292,6 +4294,7 @@ class A {
 
   }
 }
+// Settings: {"jsdoc":{"allowOverrideWithoutParam":false}}
 // Message: Missing JSDoc @param "foo" declaration.
 
 /**
@@ -4305,6 +4308,7 @@ class A {
 
   }
 }
+// Settings: {"jsdoc":{"allowImplementsWithoutParam":false}}
 // Message: Missing JSDoc @param "foo" declaration.
 
 /**
@@ -4373,7 +4377,45 @@ function quux (foo) {
 function quux (foo) {
 
 }
+
+/**
+ * @override
+ */
+class A {
+  /**
+    *
+    */
+  quux (foo) {
+
+  }
+}
+
+/**
+ * @override
+ */
+function quux (foo) {
+
+}
 // Settings: {"jsdoc":{"allowOverrideWithoutParam":true}}
+
+/**
+ * @implements
+ */
+class A {
+  /**
+   *
+   */
+  quux (foo) {
+
+  }
+}
+
+/**
+ * @implements
+ */
+function quux (foo) {
+
+}
 
 /**
  * @implements

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ JSDoc linting rules for ESLint.
     * [Settings](#eslint-plugin-jsdoc-settings)
         * [Allow `@private` to disable rules for that comment block](#eslint-plugin-jsdoc-settings-allow-private-to-disable-rules-for-that-comment-block)
         * [Exempting empty functions from `require-jsdoc`](#eslint-plugin-jsdoc-settings-exempting-empty-functions-from-require-jsdoc)
+        * [Requiring JSDoc comments for exported functions in <code>require-jsdoc</code>](#eslint-plugin-jsdoc-settings-requiring-jsdoc-comments-for-exported-functions-in-code-require-jsdoc-code)
         * [Alias Preference](#eslint-plugin-jsdoc-settings-alias-preference)
         * [Additional Tag Names](#eslint-plugin-jsdoc-settings-additional-tag-names)
         * [`@override`/`@augments`/`@extends`/`@implements` Without Accompanying `@param`/`@description`/`@example`/`@returns`](#eslint-plugin-jsdoc-settings-override-augments-extends-implements-without-accompanying-param-description-example-returns)
@@ -166,6 +167,13 @@ Finally, enable all of the rules that you would like to use.
 - `settings.jsdoc.exemptEmptyFunctions` - Will not report missing jsdoc blocks
   above functions/methods with no parameters or return values (intended where
   variable names are sufficient for themselves as documentation).
+
+<a name="eslint-plugin-jsdoc-settings-requiring-jsdoc-comments-for-exported-functions-in-require-jsdoc"></a>
+<a name="eslint-plugin-jsdoc-settings-requiring-jsdoc-comments-for-exported-functions-in-code-require-jsdoc-code"></a>
+### Requiring JSDoc comments for exported functions in <code>require-jsdoc</code>
+
+- `settings.jsdoc.publicFunctionsOnly` - Missing jsdoc blocks
+  are only reported for function bodies that are exported from the module.
 
 <a name="eslint-plugin-jsdoc-settings-alias-preference"></a>
 ### Alias Preference
@@ -3421,6 +3429,10 @@ functions.
 |Context|`ArrowFunctionExpression`, `ClassDeclaration`, `FunctionDeclaration`, `FunctionExpression`|
 |Tags|N/A|
 |Settings|`exemptEmptyFunctions`|
+|Settings|`publicFunctionsOnly`|
+|Settings|`publicFunctionsOnly.exports`|
+|Settings|`publicFunctionsOnly.modules`|
+|Settings|`publicFunctionsOnly.browserEnv`|
 
 The following patterns are considered problems:
 
@@ -3520,6 +3532,121 @@ function foo () {
   return true;
 }
 // Settings: {"jsdoc":{"exemptEmptyFunctions":false}}
+// Message: Missing JSDoc comment.
+
+module.exports = function quux () {
+
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
+module.exports = {
+  method: function() {
+
+  }
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
+module.exports = {
+  test: {
+    test2: function() {
+
+    }
+  }
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
+const test = module.exports = function () {
+
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
+/**
+*
+*/
+const test = module.exports = function () {
+
+}
+
+test.prototype.method = function() {}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
+const test = function () {
+
+}
+module.exports = {
+  test: test
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
+const test = () => {
+
+}
+module.exports = {
+  test: test
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"ArrowFunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
+class Test {
+    method() {
+
+    }
+}
+module.exports = Test;
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"MethodDefinition":true}}]
+// Message: Missing JSDoc comment.
+
+export default function quux () {
+
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
+function quux () {
+
+}
+export default quux;
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
+export function test() {
+
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
+var test = function () {
+
+}
+var test2 = 2;
+export { test, test2 }
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
+var test = function () {
+
+}
+export { test as test2 }
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 ````
 
@@ -3726,6 +3853,181 @@ function foo () {
   return;
 }
 // Settings: {"jsdoc":{"exemptEmptyFunctions":true}}
+
+const test = {};
+/**
+ * test
+ */
+ test.method = function () {
+
+}
+module.exports = {
+  prop: { prop2: test.method }
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+
+/**
+*
+*/
+function test() {
+
+}
+
+module.exports = {
+prop: { prop2: test }
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+
+/**
+ *
+ */
+test = function() {
+
+}
+
+module.exports = {
+prop: { prop2: test }
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":{"browserEnv":false,"modules":true}}}
+// Options: [{"require":{"FunctionExpression":true}}]
+
+/**
+ *
+ */
+const test = () => {
+
+}
+
+module.exports = {
+prop: { prop2: test }
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"ArrowFunctionExpression":true}}]
+
+/**
+ *
+ */
+window.test = function() {
+
+}
+
+module.exports = {
+prop: window
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+
+test = function() {
+
+}
+
+/**
+ *
+ */
+test = function() {
+
+}
+
+module.exports = {
+prop: { prop2: test }
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+
+test = function() {
+
+}
+
+test = 2;
+
+module.exports = {
+prop: { prop2: test }
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+
+/**
+ *
+ */
+function test() {
+
+}
+
+/**
+ *
+ */
+test.prototype.method = function() {
+
+}
+
+module.exports = {
+prop: { prop2: test }
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+
+class Test {
+  /**
+   * Test
+   */
+  method() {
+
+  }
+}
+module.exports = Test;
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"MethodDefinition":true}}]
+
+/**
+ *
+ */
+export default function quux () {
+
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+
+/**
+ *
+ */
+function quux () {
+
+}
+export default quux;
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+
+/**
+ *
+ */
+export function test() {
+
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+
+/**
+ *
+ */
+var test = function () {
+
+}
+var test2 = 2;
+export { test, test2 }
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+
+/**
+ *
+ */
+var test = function () {
+
+}
+export { test as test2 }
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
 ````
 
 
@@ -3931,7 +4233,6 @@ function quux (foo, bar) {
 function quux (foo) {
 
 }
-// Settings: {"jsdoc":{"allowOverrideWithoutParam":false}}
 // Message: Missing JSDoc @param "foo" declaration.
 
 /**
@@ -3940,7 +4241,6 @@ function quux (foo) {
 function quux (foo) {
 
 }
-// Settings: {"jsdoc":{"allowImplementsWithoutParam":false}}
 // Message: Missing JSDoc @param "foo" declaration.
 
 /**
@@ -3970,7 +4270,6 @@ class A {
 
   }
 }
-// Settings: {"jsdoc":{"allowOverrideWithoutParam":false}}
 // Message: Missing JSDoc @param "foo" declaration.
 
 /**
@@ -3984,7 +4283,6 @@ class A {
 
   }
 }
-// Settings: {"jsdoc":{"allowImplementsWithoutParam":false}}
 // Message: Missing JSDoc @param "foo" declaration.
 
 /**
@@ -4053,45 +4351,7 @@ function quux (foo) {
 function quux (foo) {
 
 }
-
-/**
- * @override
- */
-class A {
-  /**
-    *
-    */
-  quux (foo) {
-
-  }
-}
-
-/**
- * @override
- */
-function quux (foo) {
-
-}
 // Settings: {"jsdoc":{"allowOverrideWithoutParam":true}}
-
-/**
- * @implements
- */
-class A {
-  /**
-   *
-   */
-  quux (foo) {
-
-  }
-}
-
-/**
- * @implements
- */
-function quux (foo) {
-
-}
 
 /**
  * @implements

--- a/README.md
+++ b/README.md
@@ -3436,7 +3436,7 @@ be checked by the rule.
   - `ancestorsOnly` - Only check node ancestors to check if node is exported
   - `exports` - ESM exports are checked for JSDoc comments (Defaults to `true`)
   - `modules` - CommonJS exports are checked for JSDoc comments  (Defaults to `true`)
-  - `browserEnv` - Populates window variable
+  - `browserEnv` - Window global exports are checked for JSDoc comments
 
 - `require` - An object with the following optional boolean keys which all
     default to `false` except as noted:
@@ -3694,6 +3694,24 @@ export default class A {
 
 }
 // Options: [{"publicOnly":{"ancestorsOnly":true},"require":{"ClassDeclaration":true}}]
+// Message: Missing JSDoc comment.
+
+var test = function () {
+
+}
+// Options: [{"publicOnly":{"browserEnv":true},"require":{"FunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
+window.test = function () {
+
+}
+// Options: [{"publicOnly":{"browserEnv":true},"require":{"FunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
+function test () {
+
+}
+// Options: [{"publicOnly":{"browserEnv":true}}]
 // Message: Missing JSDoc comment.
 ````
 
@@ -4111,6 +4129,19 @@ export default class A {
 
 }
 // Options: [{"publicOnly":{"ancestorsOnly":true},"require":{"ClassDeclaration":true}}]
+
+/**
+ *
+ */
+var test = function () {
+
+}
+// Options: [{"publicOnly":{"browserEnv":true},"require":{"FunctionExpression":true}}]
+
+let test = function () {
+
+}
+// Options: [{"publicOnly":{"browserEnv":true},"require":{"FunctionExpression":true}}]
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Finally, enable all of the rules that you would like to use.
 
 - `settings.jsdoc.publicFunctionsOnly` - Missing jsdoc blocks
   are only reported for function bodies that are exported from the module.
+  May be a boolean or object.
 
   This setting object supports the following keys:
 
@@ -3889,9 +3890,22 @@ test = function() {
 }
 
 module.exports = {
-prop: { prop2: test }
+  prop: { prop2: test }
 }
 // Settings: {"jsdoc":{"publicFunctionsOnly":{"browserEnv":false,"modules":true}}}
+// Options: [{"require":{"FunctionExpression":true}}]
+
+/**
+ *
+ */
+test = function() {
+
+}
+
+exports.someMethod = {
+  prop: { prop2: test }
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":{"browserEnv":false,"exports":true}}}
 // Options: [{"require":{"FunctionExpression":true}}]
 
 /**

--- a/README.md
+++ b/README.md
@@ -3438,6 +3438,15 @@ be checked by the rule.
   - `modules` - CommonJS exports are checked for JSDoc comments  (Defaults to `true`)
   - `browserEnv` - Populates window variable
 
+- `require` - An object with the following optional boolean keys which all
+    default to `false` except as noted:
+
+  - `ArrowFunctionExpression`
+  - `ClassDeclaration`
+  - `FunctionDeclaration` (defaults to `true`)
+  - `FunctionExpression`
+  - `MethodDefinition`
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `ClassDeclaration`, `FunctionDeclaration`, `FunctionExpression`|

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ JSDoc linting rules for ESLint.
     * [Settings](#eslint-plugin-jsdoc-settings)
         * [Allow `@private` to disable rules for that comment block](#eslint-plugin-jsdoc-settings-allow-private-to-disable-rules-for-that-comment-block)
         * [Exempting empty functions from `require-jsdoc`](#eslint-plugin-jsdoc-settings-exempting-empty-functions-from-require-jsdoc)
-        * [Requiring JSDoc comments for exported functions in <code>require-jsdoc</code>](#eslint-plugin-jsdoc-settings-requiring-jsdoc-comments-for-exported-functions-in-code-require-jsdoc-code)
         * [Alias Preference](#eslint-plugin-jsdoc-settings-alias-preference)
         * [Additional Tag Names](#eslint-plugin-jsdoc-settings-additional-tag-names)
         * [`@override`/`@augments`/`@extends`/`@implements` Without Accompanying `@param`/`@description`/`@example`/`@returns`](#eslint-plugin-jsdoc-settings-override-augments-extends-implements-without-accompanying-param-description-example-returns)
@@ -167,20 +166,6 @@ Finally, enable all of the rules that you would like to use.
 - `settings.jsdoc.exemptEmptyFunctions` - Will not report missing jsdoc blocks
   above functions/methods with no parameters or return values (intended where
   variable names are sufficient for themselves as documentation).
-
-<a name="eslint-plugin-jsdoc-settings-requiring-jsdoc-comments-for-exported-functions-in-code-require-jsdoc-code"></a>
-### Requiring JSDoc comments for exported functions in <code>require-jsdoc</code>
-
-- `settings.jsdoc.publicOnly` - Missing jsdoc blocks
-  are only reported for function bodies / class declarations that are exported from the module.
-  May be a boolean or object.
-
-  This setting object supports the following keys:
-
-  - `ancestorsOnly` - Only check node ancestors to check if node is exported
-  - `exports` - ESM exports are checked for JSDoc comments
-  - `modules` - CommonJS exports are checked for JSDoc comments
-  - `browserEnv` - Populates window variable
 
 <a name="eslint-plugin-jsdoc-settings-alias-preference"></a>
 ### Alias Preference
@@ -3431,11 +3416,34 @@ function quux () {
 Checks for presence of jsdoc comments, on class declarations as well as
 functions.
 
+<a name="eslint-plugin-jsdoc-rules-require-jsdoc-options-3"></a>
+#### Options
+
+Accepts one optional options object, with two optional keys, `publicOnly`
+for confining JSDoc comments to be checked to exported functions (with "exported"
+allowing for ESM exports, CJS exports, or browser window global export)
+in `require-jsdoc`, and `require` for limiting the contexts which are to
+be checked by the rule.
+
+- `publicOnly` - Missing jsdoc blocks are only reported for function
+  bodies / class declarations that are exported from the module.
+  May be a boolean or object. If set to `true`, the defaults below will
+  be used.
+
+  This object supports the following optional boolean keys (`false` unless
+  otherwise noted):
+
+  - `ancestorsOnly` - Only check node ancestors to check if node is exported
+  - `exports` - ESM exports are checked for JSDoc comments (Defaults to `true`)
+  - `modules` - CommonJS exports are checked for JSDoc comments  (Defaults to `true`)
+  - `browserEnv` - Populates window variable
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `ClassDeclaration`, `FunctionDeclaration`, `FunctionExpression`|
 |Tags|N/A|
-|Settings|`exemptEmptyFunctions`, `publicFunctionsOnly`|
+|Options|`publicOnly`|
+|Settings|`exemptEmptyFunctions`|
 
 The following patterns are considered problems:
 
@@ -3540,15 +3548,13 @@ function foo () {
 module.exports = function quux () {
 
 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 module.exports = function quux () {
 
 }
-// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"ancestorsOnly":true},"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 module.exports = {
@@ -3556,8 +3562,7 @@ module.exports = {
 
   }
 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 module.exports = {
@@ -3567,8 +3572,7 @@ module.exports = {
     }
   }
 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 module.exports = {
@@ -3578,15 +3582,13 @@ module.exports = {
     }
   }
 }
-// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"ancestorsOnly":true},"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 const test = module.exports = function () {
 
 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 /**
@@ -3597,8 +3599,7 @@ const test = module.exports = function () {
 }
 
 test.prototype.method = function() {}
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 const test = function () {
@@ -3607,8 +3608,7 @@ const test = function () {
 module.exports = {
   test: test
 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 const test = () => {
@@ -3617,8 +3617,7 @@ const test = () => {
 module.exports = {
   test: test
 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"ArrowFunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"ArrowFunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 class Test {
@@ -3627,44 +3626,38 @@ class Test {
     }
 }
 module.exports = Test;
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"MethodDefinition":true}}]
+// Options: [{"publicOnly":true,"require":{"MethodDefinition":true}}]
 // Message: Missing JSDoc comment.
 
 export default function quux () {
 
 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 export default function quux () {
 
 }
-// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"ancestorsOnly":true},"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 function quux () {
 
 }
 export default quux;
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 export function test() {
 
 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 export function test() {
 
 }
-// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"ancestorsOnly":true},"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 var test = function () {
@@ -3672,30 +3665,26 @@ var test = function () {
 }
 var test2 = 2;
 export { test, test2 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 var test = function () {
 
 }
 export { test as test2 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 export default class A {
 
 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"ClassDeclaration":true}}]
+// Options: [{"publicOnly":true,"require":{"ClassDeclaration":true}}]
 // Message: Missing JSDoc comment.
 
 export default class A {
 
 }
-// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
-// Options: [{"require":{"ClassDeclaration":true}}]
+// Options: [{"publicOnly":{"ancestorsOnly":true},"require":{"ClassDeclaration":true}}]
 // Message: Missing JSDoc comment.
 ````
 
@@ -3913,8 +3902,7 @@ const test = {};
 module.exports = {
   prop: { prop2: test.method }
 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 
 /**
 *
@@ -3926,8 +3914,7 @@ function test() {
 module.exports = {
 prop: { prop2: test }
 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 
 /**
  *
@@ -3939,8 +3926,7 @@ test = function() {
 module.exports = {
   prop: { prop2: test }
 }
-// Settings: {"jsdoc":{"publicOnly":{"browserEnv":false,"modules":true}}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"browserEnv":false,"modules":true},"require":{"FunctionExpression":true}}]
 
 /**
  *
@@ -3952,8 +3938,7 @@ test = function() {
 exports.someMethod = {
   prop: { prop2: test }
 }
-// Settings: {"jsdoc":{"publicOnly":{"browserEnv":false,"exports":true}}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"browserEnv":false,"exports":true},"require":{"FunctionExpression":true}}]
 
 /**
  *
@@ -3965,8 +3950,7 @@ const test = () => {
 module.exports = {
 prop: { prop2: test }
 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"ArrowFunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"ArrowFunctionExpression":true}}]
 
 const test = () => {
 
@@ -3974,8 +3958,7 @@ const test = () => {
 module.exports = {
   prop: { prop2: test }
 }
-// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
-// Options: [{"require":{"ArrowFunctionExpression":true}}]
+// Options: [{"publicOnly":{"ancestorsOnly":true},"require":{"ArrowFunctionExpression":true}}]
 
 /**
  *
@@ -3987,8 +3970,7 @@ window.test = function() {
 module.exports = {
 prop: window
 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 
 test = function() {
 
@@ -4004,8 +3986,7 @@ test = function() {
 module.exports = {
 prop: { prop2: test }
 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 
 test = function() {
 
@@ -4016,8 +3997,7 @@ test = 2;
 module.exports = {
 prop: { prop2: test }
 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 
 /**
  *
@@ -4036,8 +4016,7 @@ test.prototype.method = function() {
 module.exports = {
 prop: { prop2: test }
 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 
 class Test {
   /**
@@ -4048,8 +4027,7 @@ class Test {
   }
 }
 module.exports = Test;
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"MethodDefinition":true}}]
+// Options: [{"publicOnly":true,"require":{"MethodDefinition":true}}]
 
 /**
  *
@@ -4057,8 +4035,7 @@ module.exports = Test;
 export default function quux () {
 
 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 
 /**
  *
@@ -4066,8 +4043,7 @@ export default function quux () {
 export default function quux () {
 
 }
-// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"ancestorsOnly":true},"require":{"FunctionExpression":true}}]
 
 /**
  *
@@ -4076,15 +4052,13 @@ function quux () {
 
 }
 export default quux;
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 
 function quux () {
 
 }
 export default quux;
-// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"ancestorsOnly":true},"require":{"FunctionExpression":true}}]
 
 /**
  *
@@ -4092,8 +4066,7 @@ export default quux;
 export function test() {
 
 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 
 /**
  *
@@ -4101,8 +4074,7 @@ export function test() {
 export function test() {
 
 }
-// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"ancestorsOnly":true},"require":{"FunctionExpression":true}}]
 
 /**
  *
@@ -4112,8 +4084,7 @@ var test = function () {
 }
 var test2 = 2;
 export { test, test2 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 
 /**
  *
@@ -4122,8 +4093,7 @@ var test = function () {
 
 }
 export { test as test2 }
-// Settings: {"jsdoc":{"publicOnly":true}}
-// Options: [{"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":true,"require":{"FunctionExpression":true}}]
 
 /**
  *
@@ -4131,8 +4101,7 @@ export { test as test2 }
 export default class A {
 
 }
-// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
-// Options: [{"require":{"ClassDeclaration":true}}]
+// Options: [{"publicOnly":{"ancestorsOnly":true},"require":{"ClassDeclaration":true}}]
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -3436,7 +3436,7 @@ be checked by the rule.
   - `ancestorsOnly` - Only check node ancestors to check if node is exported
   - `esm` - ESM exports are checked for JSDoc comments (Defaults to `true`)
   - `cjs` - CommonJS exports are checked for JSDoc comments  (Defaults to `true`)
-  - `browserEnv` - Window global exports are checked for JSDoc comments
+  - `window` - Window global exports are checked for JSDoc comments
 
 - `require` - An object with the following optional boolean keys which all
     default to `false` except as noted:
@@ -3699,37 +3699,37 @@ export default class A {
 var test = function () {
 
 }
-// Options: [{"publicOnly":{"browserEnv":true},"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"window":true},"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 window.test = function () {
 
 }
-// Options: [{"publicOnly":{"browserEnv":true},"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"window":true},"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 function test () {
 
 }
-// Options: [{"publicOnly":{"browserEnv":true}}]
+// Options: [{"publicOnly":{"window":true}}]
 // Message: Missing JSDoc comment.
 
 module.exports = function() {
 
 }
-// Options: [{"publicOnly":{"browserEnv":false,"cjs":true,"esm":false},"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"cjs":true,"esm":false,"window":false},"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
 export function someMethod() {
 
 }
-// Options: [{"publicOnly":{"browserEnv":false,"cjs":false,"esm":true},"require":{"FunctionDeclaration":true}}]
+// Options: [{"publicOnly":{"cjs":false,"esm":true,"window":false},"require":{"FunctionDeclaration":true}}]
 // Message: Missing JSDoc comment.
 
 export function someMethod() {
 
 }
-// Options: [{"publicOnly":{"browserEnv":false,"cjs":false,"esm":true},"require":{"FunctionDeclaration":true}}]
+// Options: [{"publicOnly":{"cjs":false,"esm":true,"window":false},"require":{"FunctionDeclaration":true}}]
 // Message: Missing JSDoc comment.
 ````
 
@@ -3971,7 +3971,7 @@ test = function() {
 module.exports = {
   prop: { prop2: test }
 }
-// Options: [{"publicOnly":{"browserEnv":false,"cjs":true,"esm":false},"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"cjs":true,"esm":false,"window":false},"require":{"FunctionExpression":true}}]
 
 /**
  *
@@ -3983,7 +3983,7 @@ test = function() {
 exports.someMethod = {
   prop: { prop2: test }
 }
-// Options: [{"publicOnly":{"browserEnv":false,"cjs":false,"esm":true},"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"cjs":false,"esm":true,"window":false},"require":{"FunctionExpression":true}}]
 
 /**
  *
@@ -4154,27 +4154,27 @@ export default class A {
 var test = function () {
 
 }
-// Options: [{"publicOnly":{"browserEnv":true},"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"window":true},"require":{"FunctionExpression":true}}]
 
 let test = function () {
 
 }
-// Options: [{"publicOnly":{"browserEnv":true},"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"window":true},"require":{"FunctionExpression":true}}]
 
 export function someMethod() {
 
 }
-// Options: [{"publicOnly":{"browserEnv":false,"cjs":true,"esm":false},"require":{"FunctionDeclaration":true}}]
+// Options: [{"publicOnly":{"cjs":true,"esm":false,"window":false},"require":{"FunctionDeclaration":true}}]
 
 export function someMethod() {
 
 }
-// Options: [{"publicOnly":{"browserEnv":false,"cjs":true,"esm":false},"require":{"FunctionDeclaration":true}}]
+// Options: [{"publicOnly":{"cjs":true,"esm":false,"window":false},"require":{"FunctionDeclaration":true}}]
 
 exports.someMethod = function() {
 
 }
-// Options: [{"publicOnly":{"browserEnv":false,"cjs":false,"esm":true},"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"cjs":false,"esm":true,"window":false},"require":{"FunctionExpression":true}}]
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Finally, enable all of the rules that you would like to use.
 
   This setting object supports the following keys:
 
+  - `ancestorsOnly` - Only check node ancestors to check if node is exported
   - `exports` - ESM exports are checked for JSDoc comments
   - `modules` - CommonJS exports are checked for JSDoc comments
   - `browserEnv` - Populates window variable
@@ -3543,6 +3544,13 @@ module.exports = function quux () {
 // Options: [{"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
+module.exports = function quux () {
+
+}
+// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
+// Options: [{"require":{"FunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
 module.exports = {
   method: function() {
 
@@ -3560,6 +3568,17 @@ module.exports = {
   }
 }
 // Settings: {"jsdoc":{"publicOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
+module.exports = {
+  test: {
+    test2: function() {
+
+    }
+  }
+}
+// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
 // Options: [{"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
@@ -3619,6 +3638,13 @@ export default function quux () {
 // Options: [{"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
+export default function quux () {
+
+}
+// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
+// Options: [{"require":{"FunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
 function quux () {
 
 }
@@ -3631,6 +3657,13 @@ export function test() {
 
 }
 // Settings: {"jsdoc":{"publicOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
+export function test() {
+
+}
+// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
 // Options: [{"require":{"FunctionExpression":true}}]
 // Message: Missing JSDoc comment.
 
@@ -3655,6 +3688,13 @@ export default class A {
 
 }
 // Settings: {"jsdoc":{"publicOnly":true}}
+// Options: [{"require":{"ClassDeclaration":true}}]
+// Message: Missing JSDoc comment.
+
+export default class A {
+
+}
+// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
 // Options: [{"require":{"ClassDeclaration":true}}]
 // Message: Missing JSDoc comment.
 ````
@@ -3928,6 +3968,15 @@ prop: { prop2: test }
 // Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"ArrowFunctionExpression":true}}]
 
+const test = () => {
+
+}
+module.exports = {
+  prop: { prop2: test }
+}
+// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
+// Options: [{"require":{"ArrowFunctionExpression":true}}]
+
 /**
  *
  */
@@ -4014,11 +4063,27 @@ export default function quux () {
 /**
  *
  */
+export default function quux () {
+
+}
+// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
+// Options: [{"require":{"FunctionExpression":true}}]
+
+/**
+ *
+ */
 function quux () {
 
 }
 export default quux;
 // Settings: {"jsdoc":{"publicOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+
+function quux () {
+
+}
+export default quux;
+// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
 // Options: [{"require":{"FunctionExpression":true}}]
 
 /**
@@ -4028,6 +4093,15 @@ export function test() {
 
 }
 // Settings: {"jsdoc":{"publicOnly":true}}
+// Options: [{"require":{"FunctionExpression":true}}]
+
+/**
+ *
+ */
+export function test() {
+
+}
+// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
 // Options: [{"require":{"FunctionExpression":true}}]
 
 /**
@@ -4050,6 +4124,15 @@ var test = function () {
 export { test as test2 }
 // Settings: {"jsdoc":{"publicOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
+
+/**
+ *
+ */
+export default class A {
+
+}
+// Settings: {"jsdoc":{"publicOnly":{"ancestorsOnly":true}}}
+// Options: [{"require":{"ClassDeclaration":true}}]
 ````
 
 
@@ -4230,7 +4313,6 @@ The following patterns are considered problems:
 function quux (foo) {
 
 }
-// Settings: {"jsdoc":{"allowOverrideWithoutParam":false}}
 // Message: Missing JSDoc @param "foo" declaration.
 
 /**
@@ -4256,7 +4338,7 @@ function quux (foo, bar) {
 function quux (foo) {
 
 }
-// Settings: {"jsdoc":{"allowImplementsWithoutParam":false}}
+// Settings: {"jsdoc":{"allowOverrideWithoutParam":false}}
 // Message: Missing JSDoc @param "foo" declaration.
 
 /**
@@ -4265,6 +4347,7 @@ function quux (foo) {
 function quux (foo) {
 
 }
+// Settings: {"jsdoc":{"allowImplementsWithoutParam":false}}
 // Message: Missing JSDoc @param "foo" declaration.
 
 /**

--- a/README.md
+++ b/README.md
@@ -3434,8 +3434,8 @@ be checked by the rule.
   otherwise noted):
 
   - `ancestorsOnly` - Only check node ancestors to check if node is exported
-  - `exports` - ESM exports are checked for JSDoc comments (Defaults to `true`)
-  - `modules` - CommonJS exports are checked for JSDoc comments  (Defaults to `true`)
+  - `esm` - ESM exports are checked for JSDoc comments (Defaults to `true`)
+  - `cjs` - CommonJS exports are checked for JSDoc comments  (Defaults to `true`)
   - `browserEnv` - Window global exports are checked for JSDoc comments
 
 - `require` - An object with the following optional boolean keys which all
@@ -3713,6 +3713,24 @@ function test () {
 }
 // Options: [{"publicOnly":{"browserEnv":true}}]
 // Message: Missing JSDoc comment.
+
+module.exports = function() {
+
+}
+// Options: [{"publicOnly":{"browserEnv":false,"cjs":true,"esm":false},"require":{"FunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
+export function someMethod() {
+
+}
+// Options: [{"publicOnly":{"browserEnv":false,"cjs":false,"esm":true},"require":{"FunctionDeclaration":true}}]
+// Message: Missing JSDoc comment.
+
+export function someMethod() {
+
+}
+// Options: [{"publicOnly":{"browserEnv":false,"cjs":false,"esm":true},"require":{"FunctionDeclaration":true}}]
+// Message: Missing JSDoc comment.
 ````
 
 The following patterns are not considered problems:
@@ -3953,7 +3971,7 @@ test = function() {
 module.exports = {
   prop: { prop2: test }
 }
-// Options: [{"publicOnly":{"browserEnv":false,"modules":true},"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"browserEnv":false,"cjs":true,"esm":false},"require":{"FunctionExpression":true}}]
 
 /**
  *
@@ -3965,7 +3983,7 @@ test = function() {
 exports.someMethod = {
   prop: { prop2: test }
 }
-// Options: [{"publicOnly":{"browserEnv":false,"exports":true},"require":{"FunctionExpression":true}}]
+// Options: [{"publicOnly":{"browserEnv":false,"cjs":false,"esm":true},"require":{"FunctionExpression":true}}]
 
 /**
  *
@@ -4142,6 +4160,21 @@ let test = function () {
 
 }
 // Options: [{"publicOnly":{"browserEnv":true},"require":{"FunctionExpression":true}}]
+
+export function someMethod() {
+
+}
+// Options: [{"publicOnly":{"browserEnv":false,"cjs":true,"esm":false},"require":{"FunctionDeclaration":true}}]
+
+export function someMethod() {
+
+}
+// Options: [{"publicOnly":{"browserEnv":false,"cjs":true,"esm":false},"require":{"FunctionDeclaration":true}}]
+
+exports.someMethod = function() {
+
+}
+// Options: [{"publicOnly":{"browserEnv":false,"cjs":false,"esm":true},"require":{"FunctionExpression":true}}]
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -177,9 +177,9 @@ Finally, enable all of the rules that you would like to use.
 
   This setting object supports the following keys:
 
-  - `exports`
-  - `modules`
-  - `browserEnv`
+  - `exports` - ESM exports are checked for JSDoc comments
+  - `modules` - CommonJS exports are checked for JSDoc comments
+  - `browserEnv` - Populates window variable
 
 <a name="eslint-plugin-jsdoc-settings-alias-preference"></a>
 ### Alias Preference
@@ -3649,6 +3649,13 @@ var test = function () {
 export { test as test2 }
 // Settings: {"jsdoc":{"publicFunctionsOnly":true}}
 // Options: [{"require":{"FunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
+export default class A {
+
+}
+// Settings: {"jsdoc":{"publicFunctionsOnly":true}}
+// Options: [{"require":{"ClassDeclaration":true}}]
 // Message: Missing JSDoc comment.
 ````
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "dependencies": {
     "comment-parser": "^0.5.4",
+    "debug": "^4.1.1",
     "jsdoctypeparser": "4.0.0",
     "lodash": "^4.17.11"
   },

--- a/src/exportParser.js
+++ b/src/exportParser.js
@@ -1,0 +1,298 @@
+import debugModule from 'debug';
+
+const debug = debugModule('requireExportJsdoc');
+
+const createNode = function () {
+  return {
+    props: {}
+  };
+};
+
+const getSymbolValue = function (symbol) {
+  if (!symbol) {
+    return null;
+  }
+  if (symbol.type === 'literal') {
+    return symbol.value.value;
+  }
+
+  return null;
+};
+
+const getIdentifier = function (node, globals, scope, opts) {
+  if (opts.simpleIdentifier) {
+    // Type is Identier for noncomputed properties
+    const identifierLiteral = createNode();
+    identifierLiteral.type = 'literal';
+    identifierLiteral.value = {value: node.name};
+
+    return identifierLiteral;
+  }
+
+  const block = scope || globals;
+
+  // As scopes are not currently supported, they are not traversed upwards recursively
+  if (block.props[node.name]) {
+    return block.props[node.name];
+  }
+  if (globals.props[node.name]) {
+    return globals.props[node.name];
+  }
+
+  return null;
+};
+
+let createSymbol = null;
+const getSymbol = function (node, globals, scope, opt) {
+  const opts = opt || {};
+  let block = scope;
+  if (node.type === 'Identifier') {
+    return getIdentifier(node, globals, scope, opts);
+  } else if (node.type === 'MemberExpression') {
+    const obj = getSymbol(node.object, globals, scope, opts);
+    const propertySymbol = getSymbol(node.property, globals, scope, {simpleIdentifier: !node.computed});
+    const propertyValue = getSymbolValue(propertySymbol);
+
+    if (obj && propertyValue && obj.props[propertyValue]) {
+      block = obj.props[propertyValue];
+
+      return block;
+    } else if (opts.createMissingProps && propertyValue) {
+      obj.props[propertyValue] = createNode();
+
+      return obj.props[propertyValue];
+    } else {
+      debug('MemberExpression: Missing property ' + node.property.name);
+
+      return null;
+    }
+  } else if (node.type === 'FunctionExpression' || node.type === 'FunctionDeclaration' || node.type === 'ArrowFunctionExpression') {
+    const val = createNode();
+    val.props.prototype = createNode();
+    val.props.prototype.type = 'object';
+    val.type = 'object';
+    val.value = node;
+
+    return val;
+  } else if (node.type === 'AssignmentExpression') {
+    return createSymbol(node.left, globals, node.right, scope, opts);
+  } else if (node.type === 'ClassBody') {
+    const val = createNode();
+    node.body.forEach((method) => {
+      val.props[method.key.name] = createNode();
+      val.props[method.key.name].type = 'object';
+      val.props[method.key.name].value = method.value;
+    });
+    val.type = 'object';
+    val.value = node;
+
+    return val;
+  } else if (node.type === 'ObjectExpression') {
+    const val = createNode();
+    val.type = 'object';
+    node.properties.forEach((prop) => {
+      const propVal = getSymbol(prop.value, globals, scope, opts);
+      if (propVal) {
+        val.props[prop.key.name] = propVal;
+      }
+    });
+
+    return val;
+  } else if (node.type === 'Literal') {
+    const val = createNode();
+    val.type = 'literal';
+    val.value = node;
+
+    return val;
+  }
+
+  return null;
+};
+
+createSymbol = function (node, globals, value, scope) {
+  const block = scope || globals;
+  let symbol;
+  if (node.type === 'Identifier') {
+    if (value) {
+      const valueSymbol = getSymbol(value, globals, block);
+      if (valueSymbol) {
+        block.props[node.name] = valueSymbol;
+
+        return block.props[node.name];
+      } else {
+        debug('Identifier: Missing value symbol for %s', node.name);
+      }
+    } else {
+      block.props[node.name] = createNode();
+
+      return block.props[node.name];
+    }
+  } else if (node.type === 'MemberExpression') {
+    symbol = getSymbol(node.object, globals, block);
+
+    const propertySymbol = getSymbol(node.property, globals, block, {simpleIdentifier: !node.computed});
+    const propertyValue = getSymbolValue(propertySymbol);
+    if (symbol && propertyValue) {
+      symbol.props[propertyValue] = getSymbol(value, globals, block);
+
+      return symbol.props[propertyValue];
+    } else {
+      debug('MemberExpression: Missing symbol: %s', node.property.name);
+    }
+  } else if (node.type === 'FunctionDeclaration') {
+    if (node.id.type === 'Identifier') {
+      return createSymbol(node.id, globals, node, globals);
+    }
+  }
+
+  return null;
+};
+
+// Creates variables from variable definitions
+const initVariables = function (node, globals) {
+  if (node.type === 'Program') {
+    node.body.forEach((childNode) => {
+      initVariables(childNode, globals);
+    });
+  } else if (node.type === 'ExpressionStatement') {
+    initVariables(node.expression, globals);
+  } else if (node.type === 'VariableDeclaration') {
+    node.declarations.forEach((declaration) => {
+      // let and const
+      const symbol = createSymbol(declaration.id, globals, null, globals);
+      if (node.kind === 'var' && globals.props.window) {
+        // If var, also add to window
+        globals.props.window.props[declaration.id.name] = symbol;
+      }
+    });
+  }
+};
+
+// Populates variable maps using AST
+const mapVariables = function (node, globals) {
+  if (node.type === 'Program') {
+    node.body.forEach((childNode) => {
+      mapVariables(childNode, globals);
+    });
+  } else if (node.type === 'ExpressionStatement') {
+    mapVariables(node.expression, globals);
+  } else if (node.type === 'AssignmentExpression') {
+    createSymbol(node.left, globals, node.right);
+  } else if (node.type === 'VariableDeclaration') {
+    node.declarations.forEach((declaration) => {
+      createSymbol(declaration.id, globals, declaration.init);
+    });
+  } else if (node.type === 'FunctionDeclaration') {
+    if (node.id.type === 'Identifier') {
+      createSymbol(node.id, globals, node, globals);
+    }
+  } else if (node.type === 'ExportDefaultDeclaration') {
+    const symbol = createSymbol(node.declaration, globals, node.declaration);
+    symbol.exported = true;
+  } else if (node.type === 'ExportNamedDeclaration') {
+    if (node.declaration) {
+      const symbol = createSymbol(node.declaration, globals, node.declaration);
+      symbol.exported = true;
+    }
+    node.specifiers.forEach((specifier) => {
+      mapVariables(specifier, globals);
+    });
+  } else if (node.type === 'ExportSpecifier') {
+    const symbol = getSymbol(node.local, globals, globals);
+    symbol.exported = true;
+  } else if (node.type === 'ClassDeclaration') {
+    createSymbol(node.id, globals, node.body, globals);
+  }
+};
+
+const findNode = function (node, block, cache) {
+  let blockCache = cache || [];
+  if (blockCache.includes(block)) {
+    return false;
+  }
+  blockCache = blockCache.slice();
+  blockCache.push(block);
+
+  if (block.type === 'object') {
+    if (block.value === node) {
+      return true;
+    }
+  }
+  for (const prop in block.props) {
+    if (Object.prototype.hasOwnProperty.call(block.props, prop)) {
+      const propval = block.props[prop];
+
+      // Only check node if it had resolvable value
+      if (propval && findNode(node, propval, blockCache)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
+const findExportedNode = function (block, node, cache) {
+  const blockCache = cache || [];
+  for (const key in block.props) {
+    if (Object.prototype.hasOwnProperty.call(block.props, key)) {
+      blockCache.push(block.props[key]);
+      if (block.props[key].exported) {
+        if (findNode(node, block)) {
+          return true;
+        }
+      }
+      if (!blockCache.includes(block.props[key]) && findExportedNode(block.props[key], node, blockCache)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
+const isNodeExported = function (node, globals, opt) {
+  if (opt.initModuleExports && globals.props.module && globals.props.module.props.exports) {
+    if (findNode(node, globals.props.module.props.exports)) {
+      return true;
+    }
+  }
+
+  if (opt.exports && findExportedNode(globals, node)) {
+    return true;
+  }
+
+  return false;
+};
+
+const parse = function (ast, opt) {
+  const opts = opt || {
+    exports: true,
+    initModuleExports: true,
+    initWindow: true
+  };
+  const globalVars = createNode();
+  if (opts.initModuleExports) {
+    globalVars.props.module = createNode();
+    globalVars.props.module.props.exports = createNode();
+    globalVars.props.exports = globalVars.props.module.props.exports;
+  }
+  if (opts.initWindow) {
+    globalVars.props.window = globalVars;
+  }
+  initVariables(ast, globalVars);
+  mapVariables(ast, globalVars);
+
+  return {
+    globalVars
+  };
+};
+
+const isExported = function (node, parseResult, opt) {
+  return isNodeExported(node, parseResult.globalVars, opt);
+};
+
+export default {
+  isExported,
+  parse
+};

--- a/src/exportParser.js
+++ b/src/exportParser.js
@@ -159,21 +159,21 @@ createSymbol = function (node, globals, value, scope) {
 };
 
 // Creates variables from variable definitions
-const initVariables = function (node, globals) {
+const initVariables = function (node, globals, opts) {
   switch (node.type) {
   case 'Program': {
     node.body.forEach((childNode) => {
-      initVariables(childNode, globals);
+      initVariables(childNode, globals, opts);
     });
     break;
   } case 'ExpressionStatement': {
-    initVariables(node.expression, globals);
+    initVariables(node.expression, globals, opts);
     break;
   } case 'VariableDeclaration': {
     node.declarations.forEach((declaration) => {
       // let and const
       const symbol = createSymbol(declaration.id, globals, null, globals);
-      if (node.kind === 'var' && globals.props.window) {
+      if (opts.initWindow && node.kind === 'var' && globals.props.window) {
         // If var, also add to window
         globals.props.window.props[declaration.id.name] = symbol;
       }
@@ -315,7 +315,7 @@ const parse = function (ast, opt) {
   if (opts.initWindow) {
     globalVars.props.window = globalVars;
   }
-  initVariables(ast, globalVars);
+  initVariables(ast, globalVars, opts);
   mapVariables(ast, globalVars);
 
   return {

--- a/src/exportParser.js
+++ b/src/exportParser.js
@@ -67,7 +67,7 @@ const getSymbol = function (node, globals, scope, opt) {
     debug('MemberExpression: Missing property ' + node.property.name);
 
     return null;
-  } case 'FunctionExpression': case 'FunctionDeclaration': case 'ArrowFunctionExpression': {
+  } case 'ClassDeclaration': case 'FunctionExpression': case 'FunctionDeclaration': case 'ArrowFunctionExpression': {
     const val = createNode();
     val.props.prototype = createNode();
     val.props.prototype.type = 'object';
@@ -115,7 +115,12 @@ createSymbol = function (node, globals, value, scope) {
   const block = scope || globals;
   let symbol;
   switch (node.type) {
-  case 'Identifier': {
+  case 'ClassDeclaration': {
+    if (node.id.type === 'Identifier') {
+      return createSymbol(node.id, globals, node, globals);
+    }
+    break;
+  } case 'Identifier': {
     if (value) {
       const valueSymbol = getSymbol(value, globals, block);
       if (valueSymbol) {
@@ -204,7 +209,9 @@ const mapVariables = function (node, globals) {
     break;
   } case 'ExportDefaultDeclaration': {
     const symbol = createSymbol(node.declaration, globals, node.declaration);
-    symbol.exported = true;
+    if (symbol) {
+      symbol.exported = true;
+    }
     break;
   } case 'ExportNamedDeclaration': {
     if (node.declaration) {
@@ -217,7 +224,9 @@ const mapVariables = function (node, globals) {
     break;
   } case 'ExportSpecifier': {
     const symbol = getSymbol(node.local, globals, globals);
-    symbol.exported = true;
+    if (symbol) {
+      symbol.exported = true;
+    }
     break;
   } case 'ClassDeclaration': {
     createSymbol(node.id, globals, node.body, globals);

--- a/src/exportParser.js
+++ b/src/exportParser.js
@@ -111,7 +111,7 @@ const getSymbol = function (node, globals, scope, opt) {
   return null;
 };
 
-const createBlockSymbol = function(block, name, value, globals, isGlobal) {
+const createBlockSymbol = function (block, name, value, globals, isGlobal) {
   block.props[name] = value;
   if (isGlobal && globals.props.window && globals.props.window.special) {
     globals.props.window.props[name] = value;
@@ -195,12 +195,12 @@ const mapVariables = function (node, globals, opt) {
   const opts = opt || {};
   switch (node.type) {
   case 'Program': {
-    if (!opts.ancestorsOnly) {
+    if (opts.ancestorsOnly) {
+      return false;
+    } else {
       node.body.forEach((childNode) => {
         mapVariables(childNode, globals, opts);
       });
-    } else {
-      return false;
     }
     break;
   } case 'ExpressionStatement': {

--- a/src/exportParser.js
+++ b/src/exportParser.js
@@ -216,7 +216,9 @@ const mapVariables = function (node, globals) {
   } case 'ExportNamedDeclaration': {
     if (node.declaration) {
       const symbol = createSymbol(node.declaration, globals, node.declaration);
-      symbol.exported = true;
+      if (symbol) {
+        symbol.exported = true;
+      }
     }
     node.specifiers.forEach((specifier) => {
       mapVariables(specifier, globals);
@@ -237,7 +239,7 @@ const mapVariables = function (node, globals) {
 
 const findNode = function (node, block, cache) {
   let blockCache = cache || [];
-  if (blockCache.includes(block)) {
+  if (!block || blockCache.includes(block)) {
     return false;
   }
   blockCache = blockCache.slice();
@@ -263,6 +265,9 @@ const findNode = function (node, block, cache) {
 };
 
 const findExportedNode = function (block, node, cache) {
+  if (block === null) {
+    return false;
+  }
   const blockCache = cache || [];
   for (const key in block.props) {
     if (Object.prototype.hasOwnProperty.call(block.props, key)) {

--- a/src/exportParser.js
+++ b/src/exportParser.js
@@ -188,7 +188,7 @@ const mapVariables = function (node, globals, opt) {
   const opts = opt || {};
   switch (node.type) {
   case 'Program': {
-    if (opts.ancestorsOnly) {
+    if (!opts.ancestorsOnly) {
       node.body.forEach((childNode) => {
         mapVariables(childNode, globals, opts);
       });
@@ -317,7 +317,7 @@ const parseRecursive = function (node, globalVars, opts) {
     }
   }
 
-  return mapVariables(node, globalVars);
+  return mapVariables(node, globalVars, opts);
 };
 
 const parse = function (ast, node, opt) {
@@ -342,7 +342,7 @@ const parse = function (ast, node, opt) {
     parseRecursive(node, globalVars, opts);
   } else {
     initVariables(ast, globalVars, opts);
-    mapVariables(ast, globalVars, {ancestorsOnly: true});
+    mapVariables(ast, globalVars, opts);
   }
 
   return {

--- a/src/exportParser.js
+++ b/src/exportParser.js
@@ -316,7 +316,7 @@ const isNodeExported = function (node, globals, opt) {
     }
   }
 
-  if (opt.exports && findExportedNode(globals, node)) {
+  if (opt.esm && findExportedNode(globals, node)) {
     return true;
   }
 
@@ -337,7 +337,7 @@ const parseRecursive = function (node, globalVars, opts) {
 const parse = function (ast, node, opt) {
   const opts = opt || {
     ancestorsOnly: false,
-    exports: true,
+    esm: true,
     initModuleExports: true,
     initWindow: true
   };

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -103,11 +103,12 @@ export default iterateJsdoc(null, {
       const publicOnly = _.get(context, 'settings.jsdoc.publicOnly');
       if (publicOnly) {
         const opt = {
+          ancestorsOnly: Boolean(_.get(publicOnly, 'ancestorsOnly', false)),
           exports: Boolean(_.get(publicOnly, 'exports', true)),
           initModuleExports: Boolean(_.get(publicOnly, 'modules', true)),
           initWindow: Boolean(_.get(publicOnly, 'browserEnv', false))
         };
-        const parseResult = exportParser.parse(sourceCode.ast, opt);
+        const parseResult = exportParser.parse(sourceCode.ast, node, opt);
         const exported = exportParser.isExported(node, parseResult, opt);
 
         if (exported && !jsDocNode) {

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -24,11 +24,11 @@ const OPTIONS_SCHEMA = {
               default: false,
               type: 'boolean'
             },
-            exports: {
+            cjs: {
               default: true,
               type: 'boolean'
             },
-            modules: {
+            esm: {
               default: true,
               type: 'boolean'
             }
@@ -142,8 +142,8 @@ export default iterateJsdoc(null, {
       if (publicOnly) {
         const opt = {
           ancestorsOnly: publicOnly.ancestorsOnly,
-          exports: publicOnly.exports,
-          initModuleExports: publicOnly.modules,
+          esm: publicOnly.esm,
+          initModuleExports: publicOnly.cjs,
           initWindow: publicOnly.browserEnv
         };
         const parseResult = exportParser.parse(sourceCode.ast, node, opt);

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -20,16 +20,16 @@ const OPTIONS_SCHEMA = {
               default: false,
               type: 'boolean'
             },
-            browserEnv: {
-              default: false,
-              type: 'boolean'
-            },
             cjs: {
               default: true,
               type: 'boolean'
             },
             esm: {
               default: true,
+              type: 'boolean'
+            },
+            window: {
+              default: false,
               type: 'boolean'
             }
           },
@@ -144,7 +144,7 @@ export default iterateJsdoc(null, {
           ancestorsOnly: publicOnly.ancestorsOnly,
           esm: publicOnly.esm,
           initModuleExports: publicOnly.cjs,
-          initWindow: publicOnly.browserEnv
+          initWindow: publicOnly.window
         };
         const parseResult = exportParser.parse(sourceCode.ast, node, opt);
         const exported = exportParser.isExported(node, parseResult, opt);

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -100,12 +100,12 @@ export default iterateJsdoc(null, {
         }
       }
 
-      const publicFunctionsOnly = _.get(context, 'settings.jsdoc.publicFunctionsOnly');
-      if (publicFunctionsOnly) {
+      const publicOnly = _.get(context, 'settings.jsdoc.publicOnly');
+      if (publicOnly) {
         const opt = {
-          exports: Boolean(_.get(publicFunctionsOnly, 'exports', true)),
-          initModuleExports: Boolean(_.get(publicFunctionsOnly, 'modules', true)),
-          initWindow: Boolean(_.get(publicFunctionsOnly, 'browserEnv', false))
+          exports: Boolean(_.get(publicOnly, 'exports', true)),
+          initModuleExports: Boolean(_.get(publicOnly, 'modules', true)),
+          initWindow: Boolean(_.get(publicOnly, 'browserEnv', false))
         };
         const parseResult = exportParser.parse(sourceCode.ast, opt);
         const exported = exportParser.isExported(node, parseResult, opt);

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -246,6 +246,343 @@ export default {
           exemptEmptyFunctions: false
         }
       }
+    },
+    {
+      code: `
+          module.exports = function quux () {
+
+          }
+      `,
+      env: {
+        node: true
+      },
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionExpression'
+      }],
+      options: [{
+        require: {
+          FunctionExpression: true
+        }
+      }],
+      settings: {
+        jsdoc: {
+          publicFunctionsOnly: true
+        }
+      }
+    },
+    {
+      code: `
+          module.exports = {
+            method: function() {
+
+            }
+          }
+      `,
+      env: {
+        node: true
+      },
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionExpression'
+      }],
+      options: [{
+        require: {
+          FunctionExpression: true
+        }
+      }],
+      settings: {
+        jsdoc: {
+          publicFunctionsOnly: true
+        }
+      }
+    },
+    {
+      code: `
+          module.exports = {
+            test: {
+              test2: function() {
+
+              }
+            }
+          }
+      `,
+      env: {
+        node: true
+      },
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionExpression'
+      }],
+      options: [{
+        require: {
+          FunctionExpression: true
+        }
+      }],
+      settings: {
+        jsdoc: {
+          publicFunctionsOnly: true
+        }
+      }
+    },
+    {
+      code: `
+          const test = module.exports = function () {
+
+          }
+      `,
+      env: {
+        node: true
+      },
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionExpression'
+      }],
+      options: [{
+        require: {
+          FunctionExpression: true
+        }
+      }],
+      settings: {
+        jsdoc: {
+          publicFunctionsOnly: true
+        }
+      }
+    },
+    {
+      code: `
+          /**
+          *
+          */
+          const test = module.exports = function () {
+
+          }
+
+          test.prototype.method = function() {}
+      `,
+      env: {
+        node: true
+      },
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionExpression'
+      }],
+      options: [{
+        require: {
+          FunctionExpression: true
+        }
+      }],
+      settings: {
+        jsdoc: {
+          publicFunctionsOnly: true
+        }
+      }
+    },
+    {
+      code: `
+          const test = function () {
+
+          }
+          module.exports = {
+            test: test
+          }
+      `,
+      env: {
+        node: true
+      },
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionExpression'
+      }],
+      options: [{
+        require: {
+          FunctionExpression: true
+        }
+      }],
+      settings: {
+        jsdoc: {
+          publicFunctionsOnly: true
+        }
+      }
+    },
+    {
+      code: `
+          const test = () => {
+
+          }
+          module.exports = {
+            test: test
+          }
+      `,
+      env: {
+        node: true
+      },
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'ArrowFunctionExpression'
+      }],
+      options: [{
+        require: {
+          ArrowFunctionExpression: true
+        }
+      }],
+      settings: {
+        jsdoc: {
+          publicFunctionsOnly: true
+        }
+      }
+    },
+    {
+      code: `
+        class Test {
+            method() {
+
+            }
+        }
+        module.exports = Test;
+      `,
+      env: {
+        node: true
+      },
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionExpression'
+      }],
+      options: [{
+        require: {
+          MethodDefinition: true
+        }
+      }],
+      settings: {
+        jsdoc: {
+          publicFunctionsOnly: true
+        }
+      }
+    },
+    {
+      code: `
+          export default function quux () {
+
+          }
+      `,
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionDeclaration'
+      }],
+      options: [{
+        require: {
+          FunctionExpression: true
+        }
+      }],
+      parserOptions: {
+        sourceType: 'module'
+      },
+      settings: {
+        jsdoc: {
+          publicFunctionsOnly: true
+        }
+      }
+    },
+    {
+      code: `
+          function quux () {
+
+          }
+          export default quux;
+      `,
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionDeclaration'
+      }],
+      options: [{
+        require: {
+          FunctionExpression: true
+        }
+      }],
+      parserOptions: {
+        sourceType: 'module'
+      },
+      settings: {
+        jsdoc: {
+          publicFunctionsOnly: true
+        }
+      }
+    },
+    {
+      code: `
+          export function test() {
+
+          }
+      `,
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionDeclaration'
+      }],
+      options: [{
+        require: {
+          FunctionExpression: true
+        }
+      }],
+      parserOptions: {
+        sourceType: 'module'
+      },
+      settings: {
+        jsdoc: {
+          publicFunctionsOnly: true
+        }
+      }
+    },
+    {
+      code: `
+          var test = function () {
+
+          }
+          var test2 = 2;
+          export { test, test2 }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc comment.'
+        }
+      ],
+      options: [{
+        require: {
+          FunctionExpression: true
+        }
+      }],
+      parserOptions: {
+        sourceType: 'module'
+      },
+      settings: {
+        jsdoc: {
+          publicFunctionsOnly: true
+        }
+      }
+    },
+    {
+      code: `
+          var test = function () {
+
+          }
+          export { test as test2 }
+      `,
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionExpression'
+      }],
+      options: [{
+        require: {
+          FunctionExpression: true
+        }
+      }],
+      parserOptions: {
+        sourceType: 'module'
+      },
+      settings: {
+        jsdoc: {
+          publicFunctionsOnly: true
+        }
+      }
     }
   ],
   valid: [{
@@ -586,6 +923,379 @@ export default {
         exemptEmptyFunctions: true
       }
     }
-  }
-  ]
+  },
+  {
+    code: `
+      const test = {};
+      /**
+       * test
+       */
+       test.method = function () {
+
+      }
+      module.exports = {
+        prop: { prop2: test.method }
+      }
+    `,
+    env: {
+      node: true
+    },
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    settings: {
+      jsdoc: {
+        publicFunctionsOnly: true
+      }
+    }
+  },
+  {
+    code: `
+     /**
+      *
+      */
+      function test() {
+
+      }
+
+      module.exports = {
+      prop: { prop2: test }
+      }
+    `,
+    env: {
+      node: true
+    },
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    settings: {
+      jsdoc: {
+        publicFunctionsOnly: true
+      }
+    }
+  },
+  {
+    code: `
+      /**
+       *
+       */
+      test = function() {
+
+      }
+
+      module.exports = {
+      prop: { prop2: test }
+      }
+    `,
+    env: {
+      node: true
+    },
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    settings: {
+      jsdoc: {
+        publicFunctionsOnly: {
+          browserEnv: false,
+          modules: true
+        }
+      }
+    }
+  },
+  {
+    code: `
+      /**
+       *
+       */
+      const test = () => {
+
+      }
+
+      module.exports = {
+      prop: { prop2: test }
+      }
+    `,
+    env: {
+      node: true
+    },
+    options: [{
+      require: {
+        ArrowFunctionExpression: true
+      }
+    }],
+    settings: {
+      jsdoc: {
+        publicFunctionsOnly: true
+      }
+    }
+  },
+  {
+    code: `
+      /**
+       *
+       */
+      window.test = function() {
+
+      }
+
+      module.exports = {
+      prop: window
+      }
+    `,
+    env: {
+      node: true
+    },
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    settings: {
+      jsdoc: {
+        publicFunctionsOnly: true
+      }
+    }
+  },
+  {
+    code: `
+      test = function() {
+
+      }
+
+      /**
+       *
+       */
+      test = function() {
+
+      }
+
+      module.exports = {
+      prop: { prop2: test }
+      }
+    `,
+    env: {
+      node: true
+    },
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    settings: {
+      jsdoc: {
+        publicFunctionsOnly: true
+      }
+    }
+  },
+  {
+    code: `
+      test = function() {
+
+      }
+
+      test = 2;
+
+      module.exports = {
+      prop: { prop2: test }
+      }
+    `,
+    env: {
+      node: true
+    },
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    settings: {
+      jsdoc: {
+        publicFunctionsOnly: true
+      }
+    }
+  },
+  {
+    code: `
+      /**
+       *
+       */
+      function test() {
+
+      }
+
+      /**
+       *
+       */
+      test.prototype.method = function() {
+
+      }
+
+      module.exports = {
+      prop: { prop2: test }
+      }
+    `,
+    env: {
+      node: true
+    },
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    settings: {
+      jsdoc: {
+        publicFunctionsOnly: true
+      }
+    }
+  },
+  {
+    code: `
+    class Test {
+      /**
+       * Test
+       */
+      method() {
+
+      }
+    }
+    module.exports = Test;
+    `,
+    env: {
+      node: true
+    },
+    options: [{
+      require: {
+        MethodDefinition: true
+      }
+    }],
+    settings: {
+      jsdoc: {
+        publicFunctionsOnly: true
+      }
+    }
+  },
+  {
+    code: `
+      /**
+       *
+       */
+      export default function quux () {
+
+      }
+    `,
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    parserOptions: {
+      sourceType: 'module'
+    },
+    settings: {
+      jsdoc: {
+        publicFunctionsOnly: true
+      }
+    }
+  },
+  {
+    code: `
+      /**
+       *
+       */
+      function quux () {
+
+      }
+      export default quux;
+    `,
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    parserOptions: {
+      sourceType: 'module'
+    },
+    settings: {
+      jsdoc: {
+        publicFunctionsOnly: true
+      }
+    }
+  },
+  {
+    code: `
+      /**
+       *
+       */
+      export function test() {
+
+      }
+    `,
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    parserOptions: {
+      sourceType: 'module'
+    },
+    settings: {
+      jsdoc: {
+        publicFunctionsOnly: true
+      }
+    }
+  },
+  {
+    code: `
+      /**
+       *
+       */
+      var test = function () {
+
+      }
+      var test2 = 2;
+      export { test, test2 }
+    `,
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    parserOptions: {
+      sourceType: 'module'
+    },
+    settings: {
+      jsdoc: {
+        publicFunctionsOnly: true
+      }
+    }
+  },
+  {
+    code: `
+      /**
+       *
+       */
+      var test = function () {
+
+      }
+      export { test as test2 }
+    `,
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    parserOptions: {
+      sourceType: 'module'
+    },
+    settings: {
+      jsdoc: {
+        publicFunctionsOnly: true
+      }
+    }
+  }]
 };

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -988,7 +988,7 @@ export default {
       }
 
       module.exports = {
-      prop: { prop2: test }
+        prop: { prop2: test }
       }
     `,
     env: {
@@ -1004,6 +1004,36 @@ export default {
         publicFunctionsOnly: {
           browserEnv: false,
           modules: true
+        }
+      }
+    }
+  },
+  {
+    code: `
+      /**
+       *
+       */
+      test = function() {
+
+      }
+
+      exports.someMethod = {
+        prop: { prop2: test }
+      }
+    `,
+    env: {
+      node: true
+    },
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    settings: {
+      jsdoc: {
+        publicFunctionsOnly: {
+          browserEnv: false,
+          exports: true
         }
       }
     }

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -678,7 +678,7 @@ export default {
       }],
       options: [{
         publicOnly: {
-          browserEnv: true
+          window: true
         },
         require: {
           FunctionExpression: true
@@ -700,7 +700,7 @@ export default {
       }],
       options: [{
         publicOnly: {
-          browserEnv: true
+          window: true
         },
         require: {
           FunctionExpression: true
@@ -722,7 +722,7 @@ export default {
       }],
       options: [{
         publicOnly: {
-          browserEnv: true
+          window: true
         }
       }],
       parserOptions: {
@@ -744,9 +744,9 @@ export default {
       }],
       options: [{
         publicOnly: {
-          browserEnv: false,
           cjs: true,
-          esm: false
+          esm: false,
+          window: false
         },
         require: {
           FunctionExpression: true
@@ -768,9 +768,9 @@ export default {
       }],
       options: [{
         publicOnly: {
-          browserEnv: false,
           cjs: false,
-          esm: true
+          esm: true,
+          window: false
         },
         require: {
           FunctionDeclaration: true
@@ -796,9 +796,9 @@ export default {
       }],
       options: [{
         publicOnly: {
-          browserEnv: false,
           cjs: false,
-          esm: true
+          esm: true,
+          window: false
         },
         require: {
           FunctionDeclaration: true
@@ -1213,9 +1213,9 @@ export default {
     },
     options: [{
       publicOnly: {
-        browserEnv: false,
         cjs: true,
-        esm: false
+        esm: false,
+        window: false
       },
       require: {
         FunctionExpression: true
@@ -1240,9 +1240,9 @@ export default {
     },
     options: [{
       publicOnly: {
-        browserEnv: false,
         cjs: false,
-        esm: true
+        esm: true,
+        window: false
       },
       require: {
         FunctionExpression: true
@@ -1609,7 +1609,7 @@ export default {
     `,
     options: [{
       publicOnly: {
-        browserEnv: true
+        window: true
       },
       require: {
         FunctionExpression: true
@@ -1627,7 +1627,7 @@ export default {
     `,
     options: [{
       publicOnly: {
-        browserEnv: true
+        window: true
       },
       require: {
         FunctionExpression: true
@@ -1648,9 +1648,9 @@ export default {
     },
     options: [{
       publicOnly: {
-        browserEnv: false,
         cjs: true,
-        esm: false
+        esm: false,
+        window: false
       },
       require: {
         FunctionDeclaration: true
@@ -1671,9 +1671,9 @@ export default {
     },
     options: [{
       publicOnly: {
-        browserEnv: false,
         cjs: true,
-        esm: false
+        esm: false,
+        window: false
       },
       require: {
         FunctionDeclaration: true
@@ -1694,9 +1694,9 @@ export default {
     },
     options: [{
       publicOnly: {
-        browserEnv: false,
         cjs: false,
-        esm: true
+        esm: true,
+        window: false
       },
       require: {
         FunctionExpression: true

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -583,6 +583,30 @@ export default {
           publicFunctionsOnly: true
         }
       }
+    },
+    {
+      code: `
+         export default class A {
+
+         }
+      `,
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'ClassDeclaration'
+      }],
+      options: [{
+        require: {
+          ClassDeclaration: true
+        }
+      }],
+      parserOptions: {
+        sourceType: 'module'
+      },
+      settings: {
+        jsdoc: {
+          publicFunctionsOnly: true
+        }
+      }
     }
   ],
   valid: [{

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -273,6 +273,32 @@ export default {
     },
     {
       code: `
+          module.exports = function quux () {
+
+          }
+      `,
+      env: {
+        node: true
+      },
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionExpression'
+      }],
+      options: [{
+        require: {
+          FunctionExpression: true
+        }
+      }],
+      settings: {
+        jsdoc: {
+          publicOnly: {
+            ancestorsOnly: true
+          }
+        }
+      }
+    },
+    {
+      code: `
           module.exports = {
             method: function() {
 
@@ -322,6 +348,36 @@ export default {
       settings: {
         jsdoc: {
           publicOnly: true
+        }
+      }
+    },
+    {
+      code: `
+          module.exports = {
+            test: {
+              test2: function() {
+
+              }
+            }
+          }
+      `,
+      env: {
+        node: true
+      },
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionExpression'
+      }],
+      options: [{
+        require: {
+          FunctionExpression: true
+        }
+      }],
+      settings: {
+        jsdoc: {
+          publicOnly: {
+            ancestorsOnly: true
+          }
         }
       }
     },
@@ -485,6 +541,32 @@ export default {
     },
     {
       code: `
+          export default function quux () {
+
+          }
+      `,
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionDeclaration'
+      }],
+      options: [{
+        require: {
+          FunctionExpression: true
+        }
+      }],
+      parserOptions: {
+        sourceType: 'module'
+      },
+      settings: {
+        jsdoc: {
+          publicOnly: {
+            ancestorsOnly: true
+          }
+        }
+      }
+    },
+    {
+      code: `
           function quux () {
 
           }
@@ -529,6 +611,32 @@ export default {
       settings: {
         jsdoc: {
           publicOnly: true
+        }
+      }
+    },
+    {
+      code: `
+          export function test() {
+
+          }
+      `,
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionDeclaration'
+      }],
+      options: [{
+        require: {
+          FunctionExpression: true
+        }
+      }],
+      parserOptions: {
+        sourceType: 'module'
+      },
+      settings: {
+        jsdoc: {
+          publicOnly: {
+            ancestorsOnly: true
+          }
         }
       }
     },
@@ -605,6 +713,32 @@ export default {
       settings: {
         jsdoc: {
           publicOnly: true
+        }
+      }
+    },
+    {
+      code: `
+         export default class A {
+
+         }
+      `,
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'ClassDeclaration'
+      }],
+      options: [{
+        require: {
+          ClassDeclaration: true
+        }
+      }],
+      parserOptions: {
+        sourceType: 'module'
+      },
+      settings: {
+        jsdoc: {
+          publicOnly: {
+            ancestorsOnly: true
+          }
         }
       }
     }
@@ -1091,6 +1225,31 @@ export default {
   },
   {
     code: `
+      const test = () => {
+
+      }
+      module.exports = {
+        prop: { prop2: test }
+      }
+    `,
+    env: {
+      node: true
+    },
+    options: [{
+      require: {
+        ArrowFunctionExpression: true
+      }
+    }],
+    settings: {
+      jsdoc: {
+        publicOnly: {
+          ancestorsOnly: true
+        }
+      }
+    }
+  },
+  {
+    code: `
       /**
        *
        */
@@ -1261,10 +1420,81 @@ export default {
       /**
        *
        */
+      export default function quux () {
+
+      }
+    `,
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    parserOptions: {
+      sourceType: 'module'
+    },
+    settings: {
+      jsdoc: {
+        publicOnly: {
+          ancestorsOnly: true
+        }
+      }
+    }
+  },
+  {
+    code: `
+      /**
+       *
+       */
       function quux () {
 
       }
       export default quux;
+    `,
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    parserOptions: {
+      sourceType: 'module'
+    },
+    settings: {
+      jsdoc: {
+        publicOnly: true
+      }
+    }
+  },
+  {
+    code: `
+      function quux () {
+
+      }
+      export default quux;
+    `,
+    options: [{
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    parserOptions: {
+      sourceType: 'module'
+    },
+    settings: {
+      jsdoc: {
+        publicOnly: {
+          ancestorsOnly: true
+        }
+      }
+    }
+  },
+  {
+    code: `
+      /**
+       *
+       */
+      export function test() {
+
+      }
     `,
     options: [{
       require: {
@@ -1299,7 +1529,9 @@ export default {
     },
     settings: {
       jsdoc: {
-        publicOnly: true
+        publicOnly: {
+          ancestorsOnly: true
+        }
       }
     }
   },
@@ -1349,6 +1581,31 @@ export default {
     settings: {
       jsdoc: {
         publicOnly: true
+      }
+    }
+  },
+  {
+    code: `
+      /**
+       *
+       */
+      export default class A {
+
+      }
+    `,
+    options: [{
+      require: {
+        ClassDeclaration: true
+      }
+    }],
+    parserOptions: {
+      sourceType: 'module'
+    },
+    settings: {
+      jsdoc: {
+        publicOnly: {
+          ancestorsOnly: true
+        }
       }
     }
   }]

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -261,15 +261,11 @@ export default {
         type: 'FunctionExpression'
       }],
       options: [{
+        publicOnly: true,
         require: {
           FunctionExpression: true
         }
-      }],
-      settings: {
-        jsdoc: {
-          publicOnly: true
-        }
-      }
+      }]
     },
     {
       code: `
@@ -285,17 +281,13 @@ export default {
         type: 'FunctionExpression'
       }],
       options: [{
+        publicOnly: {
+          ancestorsOnly: true
+        },
         require: {
           FunctionExpression: true
         }
-      }],
-      settings: {
-        jsdoc: {
-          publicOnly: {
-            ancestorsOnly: true
-          }
-        }
-      }
+      }]
     },
     {
       code: `
@@ -313,15 +305,11 @@ export default {
         type: 'FunctionExpression'
       }],
       options: [{
+        publicOnly: true,
         require: {
           FunctionExpression: true
         }
-      }],
-      settings: {
-        jsdoc: {
-          publicOnly: true
-        }
-      }
+      }]
     },
     {
       code: `
@@ -341,15 +329,11 @@ export default {
         type: 'FunctionExpression'
       }],
       options: [{
+        publicOnly: true,
         require: {
           FunctionExpression: true
         }
-      }],
-      settings: {
-        jsdoc: {
-          publicOnly: true
-        }
-      }
+      }]
     },
     {
       code: `
@@ -369,17 +353,13 @@ export default {
         type: 'FunctionExpression'
       }],
       options: [{
+        publicOnly: {
+          ancestorsOnly: true
+        },
         require: {
           FunctionExpression: true
         }
-      }],
-      settings: {
-        jsdoc: {
-          publicOnly: {
-            ancestorsOnly: true
-          }
-        }
-      }
+      }]
     },
     {
       code: `
@@ -395,15 +375,11 @@ export default {
         type: 'FunctionExpression'
       }],
       options: [{
+        publicOnly: true,
         require: {
           FunctionExpression: true
         }
-      }],
-      settings: {
-        jsdoc: {
-          publicOnly: true
-        }
-      }
+      }]
     },
     {
       code: `
@@ -424,15 +400,11 @@ export default {
         type: 'FunctionExpression'
       }],
       options: [{
+        publicOnly: true,
         require: {
           FunctionExpression: true
         }
-      }],
-      settings: {
-        jsdoc: {
-          publicOnly: true
-        }
-      }
+      }]
     },
     {
       code: `
@@ -451,15 +423,11 @@ export default {
         type: 'FunctionExpression'
       }],
       options: [{
+        publicOnly: true,
         require: {
           FunctionExpression: true
         }
-      }],
-      settings: {
-        jsdoc: {
-          publicOnly: true
-        }
-      }
+      }]
     },
     {
       code: `
@@ -478,15 +446,11 @@ export default {
         type: 'ArrowFunctionExpression'
       }],
       options: [{
+        publicOnly: true,
         require: {
           ArrowFunctionExpression: true
         }
-      }],
-      settings: {
-        jsdoc: {
-          publicOnly: true
-        }
-      }
+      }]
     },
     {
       code: `
@@ -505,14 +469,30 @@ export default {
         type: 'FunctionExpression'
       }],
       options: [{
+        publicOnly: true,
         require: {
           MethodDefinition: true
         }
+      }]
+    },
+    {
+      code: `
+          export default function quux () {
+
+          }
+      `,
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionDeclaration'
       }],
-      settings: {
-        jsdoc: {
-          publicOnly: true
+      options: [{
+        publicOnly: true,
+        require: {
+          FunctionExpression: true
         }
+      }],
+      parserOptions: {
+        sourceType: 'module'
       }
     },
     {
@@ -526,43 +506,15 @@ export default {
         type: 'FunctionDeclaration'
       }],
       options: [{
+        publicOnly: {
+          ancestorsOnly: true
+        },
         require: {
           FunctionExpression: true
         }
       }],
       parserOptions: {
         sourceType: 'module'
-      },
-      settings: {
-        jsdoc: {
-          publicOnly: true
-        }
-      }
-    },
-    {
-      code: `
-          export default function quux () {
-
-          }
-      `,
-      errors: [{
-        message: 'Missing JSDoc comment.',
-        type: 'FunctionDeclaration'
-      }],
-      options: [{
-        require: {
-          FunctionExpression: true
-        }
-      }],
-      parserOptions: {
-        sourceType: 'module'
-      },
-      settings: {
-        jsdoc: {
-          publicOnly: {
-            ancestorsOnly: true
-          }
-        }
       }
     },
     {
@@ -577,17 +529,13 @@ export default {
         type: 'FunctionDeclaration'
       }],
       options: [{
+        publicOnly: true,
         require: {
           FunctionExpression: true
         }
       }],
       parserOptions: {
         sourceType: 'module'
-      },
-      settings: {
-        jsdoc: {
-          publicOnly: true
-        }
       }
     },
     {
@@ -601,17 +549,13 @@ export default {
         type: 'FunctionDeclaration'
       }],
       options: [{
+        publicOnly: true,
         require: {
           FunctionExpression: true
         }
       }],
       parserOptions: {
         sourceType: 'module'
-      },
-      settings: {
-        jsdoc: {
-          publicOnly: true
-        }
       }
     },
     {
@@ -625,19 +569,15 @@ export default {
         type: 'FunctionDeclaration'
       }],
       options: [{
+        publicOnly: {
+          ancestorsOnly: true
+        },
         require: {
           FunctionExpression: true
         }
       }],
       parserOptions: {
         sourceType: 'module'
-      },
-      settings: {
-        jsdoc: {
-          publicOnly: {
-            ancestorsOnly: true
-          }
-        }
       }
     },
     {
@@ -654,17 +594,13 @@ export default {
         }
       ],
       options: [{
+        publicOnly: true,
         require: {
           FunctionExpression: true
         }
       }],
       parserOptions: {
         sourceType: 'module'
-      },
-      settings: {
-        jsdoc: {
-          publicOnly: true
-        }
       }
     },
     {
@@ -679,17 +615,13 @@ export default {
         type: 'FunctionExpression'
       }],
       options: [{
+        publicOnly: true,
         require: {
           FunctionExpression: true
         }
       }],
       parserOptions: {
         sourceType: 'module'
-      },
-      settings: {
-        jsdoc: {
-          publicOnly: true
-        }
       }
     },
     {
@@ -703,17 +635,13 @@ export default {
         type: 'ClassDeclaration'
       }],
       options: [{
+        publicOnly: true,
         require: {
           ClassDeclaration: true
         }
       }],
       parserOptions: {
         sourceType: 'module'
-      },
-      settings: {
-        jsdoc: {
-          publicOnly: true
-        }
       }
     },
     {
@@ -727,19 +655,15 @@ export default {
         type: 'ClassDeclaration'
       }],
       options: [{
+        publicOnly: {
+          ancestorsOnly: true
+        },
         require: {
           ClassDeclaration: true
         }
       }],
       parserOptions: {
         sourceType: 'module'
-      },
-      settings: {
-        jsdoc: {
-          publicOnly: {
-            ancestorsOnly: true
-          }
-        }
       }
     }
   ],
@@ -1099,15 +1023,11 @@ export default {
       node: true
     },
     options: [{
+      publicOnly: true,
       require: {
         FunctionExpression: true
       }
-    }],
-    settings: {
-      jsdoc: {
-        publicOnly: true
-      }
-    }
+    }]
   },
   {
     code: `
@@ -1126,15 +1046,11 @@ export default {
       node: true
     },
     options: [{
+      publicOnly: true,
       require: {
         FunctionExpression: true
       }
-    }],
-    settings: {
-      jsdoc: {
-        publicOnly: true
-      }
-    }
+    }]
   },
   {
     code: `
@@ -1153,18 +1069,14 @@ export default {
       node: true
     },
     options: [{
+      publicOnly: {
+        browserEnv: false,
+        modules: true
+      },
       require: {
         FunctionExpression: true
       }
-    }],
-    settings: {
-      jsdoc: {
-        publicOnly: {
-          browserEnv: false,
-          modules: true
-        }
-      }
-    }
+    }]
   },
   {
     code: `
@@ -1183,18 +1095,14 @@ export default {
       node: true
     },
     options: [{
+      publicOnly: {
+        browserEnv: false,
+        exports: true
+      },
       require: {
         FunctionExpression: true
       }
-    }],
-    settings: {
-      jsdoc: {
-        publicOnly: {
-          browserEnv: false,
-          exports: true
-        }
-      }
-    }
+    }]
   },
   {
     code: `
@@ -1213,15 +1121,11 @@ export default {
       node: true
     },
     options: [{
+      publicOnly: true,
       require: {
         ArrowFunctionExpression: true
       }
-    }],
-    settings: {
-      jsdoc: {
-        publicOnly: true
-      }
-    }
+    }]
   },
   {
     code: `
@@ -1236,17 +1140,13 @@ export default {
       node: true
     },
     options: [{
+      publicOnly: {
+        ancestorsOnly: true
+      },
       require: {
         ArrowFunctionExpression: true
       }
-    }],
-    settings: {
-      jsdoc: {
-        publicOnly: {
-          ancestorsOnly: true
-        }
-      }
-    }
+    }]
   },
   {
     code: `
@@ -1265,15 +1165,11 @@ export default {
       node: true
     },
     options: [{
+      publicOnly: true,
       require: {
         FunctionExpression: true
       }
-    }],
-    settings: {
-      jsdoc: {
-        publicOnly: true
-      }
-    }
+    }]
   },
   {
     code: `
@@ -1296,15 +1192,11 @@ export default {
       node: true
     },
     options: [{
+      publicOnly: true,
       require: {
         FunctionExpression: true
       }
-    }],
-    settings: {
-      jsdoc: {
-        publicOnly: true
-      }
-    }
+    }]
   },
   {
     code: `
@@ -1322,15 +1214,11 @@ export default {
       node: true
     },
     options: [{
+      publicOnly: true,
       require: {
         FunctionExpression: true
       }
-    }],
-    settings: {
-      jsdoc: {
-        publicOnly: true
-      }
-    }
+    }]
   },
   {
     code: `
@@ -1356,15 +1244,11 @@ export default {
       node: true
     },
     options: [{
+      publicOnly: true,
       require: {
         FunctionExpression: true
       }
-    }],
-    settings: {
-      jsdoc: {
-        publicOnly: true
-      }
-    }
+    }]
   },
   {
     code: `
@@ -1382,14 +1266,29 @@ export default {
       node: true
     },
     options: [{
+      publicOnly: true,
       require: {
         MethodDefinition: true
       }
-    }],
-    settings: {
-      jsdoc: {
-        publicOnly: true
+    }]
+  },
+  {
+    code: `
+      /**
+       *
+       */
+      export default function quux () {
+
       }
+    `,
+    options: [{
+      publicOnly: true,
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    parserOptions: {
+      sourceType: 'module'
     }
   },
   {
@@ -1402,42 +1301,15 @@ export default {
       }
     `,
     options: [{
+      publicOnly: {
+        ancestorsOnly: true
+      },
       require: {
         FunctionExpression: true
       }
     }],
     parserOptions: {
       sourceType: 'module'
-    },
-    settings: {
-      jsdoc: {
-        publicOnly: true
-      }
-    }
-  },
-  {
-    code: `
-      /**
-       *
-       */
-      export default function quux () {
-
-      }
-    `,
-    options: [{
-      require: {
-        FunctionExpression: true
-      }
-    }],
-    parserOptions: {
-      sourceType: 'module'
-    },
-    settings: {
-      jsdoc: {
-        publicOnly: {
-          ancestorsOnly: true
-        }
-      }
     }
   },
   {
@@ -1451,17 +1323,13 @@ export default {
       export default quux;
     `,
     options: [{
+      publicOnly: true,
       require: {
         FunctionExpression: true
       }
     }],
     parserOptions: {
       sourceType: 'module'
-    },
-    settings: {
-      jsdoc: {
-        publicOnly: true
-      }
     }
   },
   {
@@ -1472,19 +1340,15 @@ export default {
       export default quux;
     `,
     options: [{
+      publicOnly: {
+        ancestorsOnly: true
+      },
       require: {
         FunctionExpression: true
       }
     }],
     parserOptions: {
       sourceType: 'module'
-    },
-    settings: {
-      jsdoc: {
-        publicOnly: {
-          ancestorsOnly: true
-        }
-      }
     }
   },
   {
@@ -1497,17 +1361,13 @@ export default {
       }
     `,
     options: [{
+      publicOnly: true,
       require: {
         FunctionExpression: true
       }
     }],
     parserOptions: {
       sourceType: 'module'
-    },
-    settings: {
-      jsdoc: {
-        publicOnly: true
-      }
     }
   },
   {
@@ -1520,19 +1380,15 @@ export default {
       }
     `,
     options: [{
+      publicOnly: {
+        ancestorsOnly: true
+      },
       require: {
         FunctionExpression: true
       }
     }],
     parserOptions: {
       sourceType: 'module'
-    },
-    settings: {
-      jsdoc: {
-        publicOnly: {
-          ancestorsOnly: true
-        }
-      }
     }
   },
   {
@@ -1547,17 +1403,13 @@ export default {
       export { test, test2 }
     `,
     options: [{
+      publicOnly: true,
       require: {
         FunctionExpression: true
       }
     }],
     parserOptions: {
       sourceType: 'module'
-    },
-    settings: {
-      jsdoc: {
-        publicOnly: true
-      }
     }
   },
   {
@@ -1571,17 +1423,13 @@ export default {
       export { test as test2 }
     `,
     options: [{
+      publicOnly: true,
       require: {
         FunctionExpression: true
       }
     }],
     parserOptions: {
       sourceType: 'module'
-    },
-    settings: {
-      jsdoc: {
-        publicOnly: true
-      }
     }
   },
   {
@@ -1594,19 +1442,15 @@ export default {
       }
     `,
     options: [{
+      publicOnly: {
+        ancestorsOnly: true
+      },
       require: {
         ClassDeclaration: true
       }
     }],
     parserOptions: {
       sourceType: 'module'
-    },
-    settings: {
-      jsdoc: {
-        publicOnly: {
-          ancestorsOnly: true
-        }
-      }
     }
   }]
 };

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -665,6 +665,69 @@ export default {
       parserOptions: {
         sourceType: 'module'
       }
+    },
+    {
+      code: `
+          var test = function () {
+
+          }
+      `,
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionExpression'
+      }],
+      options: [{
+        publicOnly: {
+          browserEnv: true
+        },
+        require: {
+          FunctionExpression: true
+        }
+      }],
+      parserOptions: {
+        sourceType: 'module'
+      }
+    },
+    {
+      code: `
+          window.test = function () {
+
+          }
+      `,
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionExpression'
+      }],
+      options: [{
+        publicOnly: {
+          browserEnv: true
+        },
+        require: {
+          FunctionExpression: true
+        }
+      }],
+      parserOptions: {
+        sourceType: 'module'
+      }
+    },
+    {
+      code: `
+          function test () {
+
+          }
+      `,
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionDeclaration'
+      }],
+      options: [{
+        publicOnly: {
+          browserEnv: true
+        }
+      }],
+      parserOptions: {
+        sourceType: 'module'
+      }
     }
   ],
   valid: [{
@@ -1447,6 +1510,45 @@ export default {
       },
       require: {
         ClassDeclaration: true
+      }
+    }],
+    parserOptions: {
+      sourceType: 'module'
+    }
+  },
+  {
+    code: `
+      /**
+       *
+       */
+      var test = function () {
+
+      }
+    `,
+    options: [{
+      publicOnly: {
+        browserEnv: true
+      },
+      require: {
+        FunctionExpression: true
+      }
+    }],
+    parserOptions: {
+      sourceType: 'module'
+    }
+  },
+  {
+    code: `
+      let test = function () {
+
+      }
+    `,
+    options: [{
+      publicOnly: {
+        browserEnv: true
+      },
+      require: {
+        FunctionExpression: true
       }
     }],
     parserOptions: {

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -728,6 +728,86 @@ export default {
       parserOptions: {
         sourceType: 'module'
       }
+    },
+    {
+      code: `
+        module.exports = function() {
+
+        }
+      `,
+      env: {
+        node: true
+      },
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionExpression'
+      }],
+      options: [{
+        publicOnly: {
+          browserEnv: false,
+          cjs: true,
+          esm: false
+        },
+        require: {
+          FunctionExpression: true
+        }
+      }]
+    },
+    {
+      code: `
+        export function someMethod() {
+
+        }
+      `,
+      env: {
+        node: true
+      },
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionDeclaration'
+      }],
+      options: [{
+        publicOnly: {
+          browserEnv: false,
+          cjs: false,
+          esm: true
+        },
+        require: {
+          FunctionDeclaration: true
+        }
+      }],
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      }
+    },
+    {
+      code: `
+        export function someMethod() {
+
+        }
+      `,
+      env: {
+        node: true
+      },
+      errors: [{
+        message: 'Missing JSDoc comment.',
+        type: 'FunctionDeclaration'
+      }],
+      options: [{
+        publicOnly: {
+          browserEnv: false,
+          cjs: false,
+          esm: true
+        },
+        require: {
+          FunctionDeclaration: true
+        }
+      }],
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      }
     }
   ],
   valid: [{
@@ -1134,7 +1214,8 @@ export default {
     options: [{
       publicOnly: {
         browserEnv: false,
-        modules: true
+        cjs: true,
+        esm: false
       },
       require: {
         FunctionExpression: true
@@ -1160,7 +1241,8 @@ export default {
     options: [{
       publicOnly: {
         browserEnv: false,
-        exports: true
+        cjs: false,
+        esm: true
       },
       require: {
         FunctionExpression: true
@@ -1554,5 +1636,71 @@ export default {
     parserOptions: {
       sourceType: 'module'
     }
+  },
+  {
+    code: `
+      export function someMethod() {
+
+      }
+    `,
+    env: {
+      node: true
+    },
+    options: [{
+      publicOnly: {
+        browserEnv: false,
+        cjs: true,
+        esm: false
+      },
+      require: {
+        FunctionDeclaration: true
+      }
+    }],
+    parserOptions: {
+      ecmaVersion: 6,
+      sourceType: 'module'
+    }
+  }, {
+    code: `
+      export function someMethod() {
+
+      }
+    `,
+    env: {
+      node: true
+    },
+    options: [{
+      publicOnly: {
+        browserEnv: false,
+        cjs: true,
+        esm: false
+      },
+      require: {
+        FunctionDeclaration: true
+      }
+    }],
+    parserOptions: {
+      ecmaVersion: 6,
+      sourceType: 'module'
+    }
+  }, {
+    code: `
+      exports.someMethod = function() {
+
+      }
+    `,
+    env: {
+      node: true
+    },
+    options: [{
+      publicOnly: {
+        browserEnv: false,
+        cjs: false,
+        esm: true
+      },
+      require: {
+        FunctionExpression: true
+      }
+    }]
   }]
 };

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -267,7 +267,7 @@ export default {
       }],
       settings: {
         jsdoc: {
-          publicFunctionsOnly: true
+          publicOnly: true
         }
       }
     },
@@ -293,7 +293,7 @@ export default {
       }],
       settings: {
         jsdoc: {
-          publicFunctionsOnly: true
+          publicOnly: true
         }
       }
     },
@@ -321,7 +321,7 @@ export default {
       }],
       settings: {
         jsdoc: {
-          publicFunctionsOnly: true
+          publicOnly: true
         }
       }
     },
@@ -345,7 +345,7 @@ export default {
       }],
       settings: {
         jsdoc: {
-          publicFunctionsOnly: true
+          publicOnly: true
         }
       }
     },
@@ -374,7 +374,7 @@ export default {
       }],
       settings: {
         jsdoc: {
-          publicFunctionsOnly: true
+          publicOnly: true
         }
       }
     },
@@ -401,7 +401,7 @@ export default {
       }],
       settings: {
         jsdoc: {
-          publicFunctionsOnly: true
+          publicOnly: true
         }
       }
     },
@@ -428,7 +428,7 @@ export default {
       }],
       settings: {
         jsdoc: {
-          publicFunctionsOnly: true
+          publicOnly: true
         }
       }
     },
@@ -455,7 +455,7 @@ export default {
       }],
       settings: {
         jsdoc: {
-          publicFunctionsOnly: true
+          publicOnly: true
         }
       }
     },
@@ -479,7 +479,7 @@ export default {
       },
       settings: {
         jsdoc: {
-          publicFunctionsOnly: true
+          publicOnly: true
         }
       }
     },
@@ -504,7 +504,7 @@ export default {
       },
       settings: {
         jsdoc: {
-          publicFunctionsOnly: true
+          publicOnly: true
         }
       }
     },
@@ -528,7 +528,7 @@ export default {
       },
       settings: {
         jsdoc: {
-          publicFunctionsOnly: true
+          publicOnly: true
         }
       }
     },
@@ -555,7 +555,7 @@ export default {
       },
       settings: {
         jsdoc: {
-          publicFunctionsOnly: true
+          publicOnly: true
         }
       }
     },
@@ -580,7 +580,7 @@ export default {
       },
       settings: {
         jsdoc: {
-          publicFunctionsOnly: true
+          publicOnly: true
         }
       }
     },
@@ -604,7 +604,7 @@ export default {
       },
       settings: {
         jsdoc: {
-          publicFunctionsOnly: true
+          publicOnly: true
         }
       }
     }
@@ -971,7 +971,7 @@ export default {
     }],
     settings: {
       jsdoc: {
-        publicFunctionsOnly: true
+        publicOnly: true
       }
     }
   },
@@ -998,7 +998,7 @@ export default {
     }],
     settings: {
       jsdoc: {
-        publicFunctionsOnly: true
+        publicOnly: true
       }
     }
   },
@@ -1025,7 +1025,7 @@ export default {
     }],
     settings: {
       jsdoc: {
-        publicFunctionsOnly: {
+        publicOnly: {
           browserEnv: false,
           modules: true
         }
@@ -1055,7 +1055,7 @@ export default {
     }],
     settings: {
       jsdoc: {
-        publicFunctionsOnly: {
+        publicOnly: {
           browserEnv: false,
           exports: true
         }
@@ -1085,7 +1085,7 @@ export default {
     }],
     settings: {
       jsdoc: {
-        publicFunctionsOnly: true
+        publicOnly: true
       }
     }
   },
@@ -1112,7 +1112,7 @@ export default {
     }],
     settings: {
       jsdoc: {
-        publicFunctionsOnly: true
+        publicOnly: true
       }
     }
   },
@@ -1143,7 +1143,7 @@ export default {
     }],
     settings: {
       jsdoc: {
-        publicFunctionsOnly: true
+        publicOnly: true
       }
     }
   },
@@ -1169,7 +1169,7 @@ export default {
     }],
     settings: {
       jsdoc: {
-        publicFunctionsOnly: true
+        publicOnly: true
       }
     }
   },
@@ -1203,7 +1203,7 @@ export default {
     }],
     settings: {
       jsdoc: {
-        publicFunctionsOnly: true
+        publicOnly: true
       }
     }
   },
@@ -1229,7 +1229,7 @@ export default {
     }],
     settings: {
       jsdoc: {
-        publicFunctionsOnly: true
+        publicOnly: true
       }
     }
   },
@@ -1252,7 +1252,7 @@ export default {
     },
     settings: {
       jsdoc: {
-        publicFunctionsOnly: true
+        publicOnly: true
       }
     }
   },
@@ -1276,7 +1276,7 @@ export default {
     },
     settings: {
       jsdoc: {
-        publicFunctionsOnly: true
+        publicOnly: true
       }
     }
   },
@@ -1299,7 +1299,7 @@ export default {
     },
     settings: {
       jsdoc: {
-        publicFunctionsOnly: true
+        publicOnly: true
       }
     }
   },
@@ -1324,7 +1324,7 @@ export default {
     },
     settings: {
       jsdoc: {
-        publicFunctionsOnly: true
+        publicOnly: true
       }
     }
   },
@@ -1348,7 +1348,7 @@ export default {
     },
     settings: {
       jsdoc: {
-        publicFunctionsOnly: true
+        publicOnly: true
       }
     }
   }]


### PR DESCRIPTION
This PR adds support for configuring require-jsdoc rule to require JSDoc comments for exported function bodies only. There are options for configuring the export checks for CommonJS and ES6 exports.
Fixes #192