### PR TITLE
Fix fixer for `require-hyphen-before-param-description`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3031,6 +3031,16 @@ function quux () {
 }
 // Options: ["never"]
 // Message: There must be no hyphen before @param description.
+
+/**
+ * @param foo - Foo.
+ * @param foo Foo.
+ */
+function quux () {
+
+}
+// Options: ["always"]
+// Message: There must be a hyphen before @param description.
 ````
 
 The following patterns are not considered problems:

--- a/src/rules/requireHyphenBeforeParamDescription.js
+++ b/src/rules/requireHyphenBeforeParamDescription.js
@@ -26,7 +26,12 @@ export default iterateJsdoc(({
     if (always) {
       if (!jsdocTag.description.startsWith('-')) {
         report('There must be a hyphen before @' + targetTagName + ' description.', (fixer) => {
-          const replacement = sourceCode.getText(jsdocNode).replace(jsdocTag.description, '- ' + jsdocTag.description);
+          const lineIndex = jsdocTag.line;
+          const sourceLines = sourceCode.getText(jsdocNode).split('\n');
+          const replacementLine = sourceLines[lineIndex]
+            .replace(jsdocTag.description, '- ' + jsdocTag.description);
+          sourceLines.splice(lineIndex, 1, replacementLine);
+          const replacement = sourceLines.join('\n');
 
           return fixer.replaceText(jsdocNode, replacement);
         }, jsdocTag);

--- a/test/rules/assertions/requireHyphenBeforeParamDescription.js
+++ b/test/rules/assertions/requireHyphenBeforeParamDescription.js
@@ -53,6 +53,35 @@ export default {
 
           }
       `
+    },
+    {
+      code: `
+          /**
+           * @param foo - Foo.
+           * @param foo Foo.
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'There must be a hyphen before @param description.'
+        }
+      ],
+      options: [
+        'always'
+      ],
+      output: `
+          /**
+           * @param foo - Foo.
+           * @param foo - Foo.
+           */
+          function quux () {
+
+          }
+      `
     }
   ],
   valid: [


### PR DESCRIPTION
* fixes fixer for `require-hyphen-before-param-description`: reads the actual line of the problematic jsdocTag and inserts a hyphen before the description.

Hopefully closes #176.