### PR TITLE
Fix fixer for require-hyphen-before-param-description

### DIFF
--- a/README.md
+++ b/README.md
@@ -3033,8 +3033,19 @@ function quux () {
 // Message: There must be no hyphen before @param description.
 
 /**
- * @param foo - Foo.
- * @param bar Foo.
+ * @param foo - foo
+ * @param foo foo
+ */
+function quux () {
+
+}
+// Options: ["always"]
+// Message: There must be a hyphen before @param description.
+
+/**
+ * @param foo foo
+ * bar
+ * @param bar - bar
  */
 function quux () {
 

--- a/src/rules/requireHyphenBeforeParamDescription.js
+++ b/src/rules/requireHyphenBeforeParamDescription.js
@@ -28,8 +28,13 @@ export default iterateJsdoc(({
         report('There must be a hyphen before @' + targetTagName + ' description.', (fixer) => {
           const lineIndex = jsdocTag.line;
           const sourceLines = sourceCode.getText(jsdocNode).split('\n');
+
+          // Get start index of description, accounting for multi-line descriptions
+          const description = jsdocTag.description.split('\n')[0];
+          const descriptionIndex = sourceLines[lineIndex].lastIndexOf(description);
+
           const replacementLine = sourceLines[lineIndex]
-            .replace(jsdocTag.description, '- ' + jsdocTag.description);
+            .substring(0, descriptionIndex) + '- ' + description;
           sourceLines.splice(lineIndex, 1, replacementLine);
           const replacement = sourceLines.join('\n');
 

--- a/test/rules/assertions/requireHyphenBeforeParamDescription.js
+++ b/test/rules/assertions/requireHyphenBeforeParamDescription.js
@@ -57,8 +57,8 @@ export default {
     {
       code: `
           /**
-           * @param foo - Foo.
-           * @param bar Foo.
+           * @param foo - foo
+           * @param foo foo
            */
           function quux () {
 
@@ -75,8 +75,39 @@ export default {
       ],
       output: `
           /**
-           * @param foo - Foo.
-           * @param bar - Foo.
+           * @param foo - foo
+           * @param foo - foo
+           */
+          function quux () {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @param foo foo
+           * bar
+           * @param bar - bar
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'There must be a hyphen before @param description.'
+        }
+      ],
+      options: [
+        'always'
+      ],
+      output: `
+          /**
+           * @param foo - foo
+           * bar
+           * @param bar - bar
            */
           function quux () {
 


### PR DESCRIPTION
Thank you for the quick response to #265, but it appears I haven't tested thoroughly. Sincerest apologies!

This PR fixes hyphen insertion for the following cases:

* Parameter name and description are equal
```
/*
 *@param foo foo
 */
function () {}
```
by replacing the *last* occurrence in a line, not the *first*.
* Multiline descriptions
```
/*
 * @param foo single line
 * another line
 */
 function () {}
```
by replacing the (last occurrence of (the first line of the description)) in a line.

That's a mouthful :/
Hopefully this will have covered all cases. Please let me know if I've missed anything.