### PR TITLE
fix: false positive with optional chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -3902,6 +3902,10 @@ function quux (foo) {
 
 }
 // Settings: {"jsdoc":{"ignorePrivate":true}}
+
+// issue 182: optional chaining
+/** @const {boolean} test */
+const test = something?.find(_ => _)
 ````
 
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@babel/plugin-transform-flow-strip-types": "^7.4.4",
     "@babel/preset-env": "^7.4.5",
     "@babel/register": "^7.4.4",
+    "babel-eslint": "^10.0.1",
     "babel-plugin-add-module-exports": "^1.0.2",
     "babel-plugin-istanbul": "^5.1.4",
     "chai": "^4.2.0",

--- a/src/eslint/getJSDocComment.js
+++ b/src/eslint/getJSDocComment.js
@@ -71,7 +71,11 @@ const getJSDocComment = function (sourceCode, node) {
 
   case 'ArrowFunctionExpression':
   case 'FunctionExpression':
-    if (parent.type !== 'CallExpression' && parent.type !== 'NewExpression') {
+    if (
+      parent.type !== 'CallExpression' &&
+      parent.type !== 'OptionalCallExpression' &&
+      parent.type !== 'NewExpression'
+    ) {
       while (
         !sourceCode.getCommentsBefore(parent).length &&
         !/Function/u.test(parent.type) &&

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -559,6 +559,14 @@ export default {
           ignorePrivate: true
         }
       }
+    },
+    {
+      code: `
+          // issue 182: optional chaining
+          /** @const {boolean} test */
+          const test = something?.find(_ => _)
+      `,
+      parser: 'babel-eslint'
     }
   ]
 };


### PR DESCRIPTION
fixes #182

This commit introduces `babel-eslint` as a dependency, otherwise optional chaining cannot be tested.