### PR TITLE
fix: Stop warning missing param and returns tags if `@type` is present

### DIFF
--- a/README.md
+++ b/README.md
@@ -4252,6 +4252,9 @@ function quux (foo) {
 // issue 182: optional chaining
 /** @const {boolean} test */
 const test = something?.find(_ => _)
+
+/** @type {RequestHandler} */
+function foo(req, res, next) {}
 ````
 
 
@@ -4856,6 +4859,11 @@ function quux () {
   return;
 }
 // Settings: {"jsdoc":{"forceRequireReturn":true}}
+
+/** @type {RequestHandler} */
+function quux (req, res , next) {
+  return;
+}
 
 /** foo class */
 class foo {

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -12,6 +12,11 @@ export default iterateJsdoc(({
     return;
   }
 
+  // Param type is specified by type in @type
+  if (utils.hasTag('type')) {
+    return;
+  }
+
   functionParameterNames.some((functionParameterName, index) => {
     const jsdocParameterName = jsdocParameterNames[index];
 

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -26,6 +26,9 @@ const canSkip = (utils) => {
     'class',
     'constructor',
 
+    // Return type is specified by type in @type
+    'type',
+
     // This seems to imply a class as well
     'interface'
   ]) ||

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -567,6 +567,12 @@ export default {
           const test = something?.find(_ => _)
       `,
       parser: 'babel-eslint'
+    },
+    {
+      code: `
+          /** @type {RequestHandler} */
+          function foo(req, res, next) {}
+      `
     }
   ]
 };

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -489,6 +489,14 @@ export default {
     },
     {
       code: `
+          /** @type {RequestHandler} */
+          function quux (req, res , next) {
+            return;
+          }
+      `
+    },
+    {
+      code: `
       /** foo class */
       class foo {
         /** foo constructor */


### PR DESCRIPTION
fixes #268 