### PR TITLE
`check-types`: Distinguish `.<>` from `<>`; support `[]`; check/fix nested array/object types

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -226,12 +226,37 @@ but restricted to `@param`. These settings are now deprecated.
 - `settings.jsdoc.preferredTypes` An option map to indicate preferred
   or forbidden types (if default types are indicated here, these will
   have precedence over the default recommendations for `check-types`).
-  The keys of this map are the types to be replaced (or forbidden) and
-  can include the "ANY" type, `*`.
+  The keys of this map are the types to be replaced (or forbidden).
+  These keys may include:
+  1. The "ANY" type, `*`
+  1. The pseudo-type `[]` which we use to denote the parent (array)
+    types used in the syntax `string[]`, `number[]`, etc.
+  1. The pseudo-type `.<>` (or `.`) to represent the format `Array.<value>`
+    or `Object.<key, value>`
+  1. The pseudo-type `<>` to represent the format `Array<value>` or
+    `Object<key, value>`
+  1. A plain string type, e.g., `MyType`
+  1. A plain string type followed by one of the above pseudo-types (except
+    for `[]` which is always assumed to be an `Array`), e.g., `Array.`, or
+    `SpecialObject<>`.
+
+  If a bare pseudo-type is used, it will match all parent types of that form.
+  If a pseudo-type prefixed with a type name is used, it will only match
+  parent types of that form and type name.
+
   The values can be:
   - `false` to forbid the type
   - a string to indicate the type that should be preferred in its place
-    (and which `fix` mode can replace)
+    (and which `fix` mode can replace); this can be one of the formats
+    of the keys described above. Note that the format will not be changed
+    unless you use a pseudo-type in the replacement (e.g.,
+    `'Array.<>': 'MyArray'` will change `Array.<string>` to `MyArray.<string>`,
+    preserving the dot; to get rid of the dot, you must use the pseudo-type:
+    `'Array.<>': 'MyArray<>'` which will change `Array.<string>` to
+    `MyArray<string>`). If you use a bare pseudo-type in the replacement,
+    e.g., `'MyArray.<>': '<>'`, the type will be converted to the format
+    of the pseudo-type without changing the type name, i.e., `MyArray.<string>`
+    will become `MyArray<string>` but `Array.<string>` will not be modified.
   - an object with the key `message` to provide a specific error message
     when encountering the discouraged type and, if a type is to be preferred
     in its place, the key `replacement` to indicate the type that should be
@@ -247,9 +272,9 @@ If `no-undefined-types` has the option key `preferredTypesDefined` set to
 map will be assumed to be defined.
 
 See the option of `check-types`, `unifyParentAndChildTypeChecks`, for
-how the keys of `preferredTypes` may have `<>` appended and its bearing
-on whether types are checked as parents/children only (e.g., to match `Array`
-if the type is `Array` vs. `Array.<string>`).
+how the keys of `preferredTypes` may have `<>` or `.<>` (or just `.`)
+appended and its bearing on whether types are checked as parents/children
+only (e.g., to match `Array` if the type is `Array` vs. `Array.<string>`).
 
 ### Settings to Configure `valid-types`
 

--- a/.README/rules/check-types.md
+++ b/.README/rules/check-types.md
@@ -25,16 +25,24 @@ RegExp
   - with the key `noDefaults` to insist that only the supplied option type
     map is to be used, and that the default preferences (such as "string"
     over "String") will not be enforced.
-  - with the key `unifyParentAndChildTypeChecks` to treat
-    `settings.jsdoc.preferredTypes` keys the same whether they are of the form
-    `SomeType` or `SomeType<>`. If this is `false` or unset, the former
-    will only apply to types which are not parent types/unions whereas the
-    latter will only apply for parent types/unions.
+  - with the key `unifyParentAndChildTypeChecks` which will treat
+    `settings.jsdoc.preferredTypes` keys such as `SomeType` as matching
+    not only child types such as an unadorned `SomeType` but also
+    `SomeType<aChildType>`, `SomeType.<aChildType>`, or if `SomeType` is
+    `Array` (or `[]`), it will match `aChildType[]`. If this is `false` or
+    unset, the former format will only apply to types which are not parent
+    types/unions whereas the latter formats will only apply for parent
+    types/unions. The special types `[]`, `.<>` (or `.`), and `<>`
+    act only as parent types (and will not match a bare child type such as
+    `Array` even when unified, though, as mentioned, `Array` will match
+    say `string[]` or `Array.<string>` when unified). The special type
+    `*` is only a child type. Note that there is no detection of parent
+    and child type together, e.g., you cannot specify preferences for
+    `string[]` specifically as distinct from say `number[]`, but you can
+    target both with `[]` or the child types `number` or `string`.
 
 See also the documentation on `settings.jsdoc.preferredTypes` which impacts
 the behavior of `check-types`.
-
-
 
 #### Why not capital case everything?
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "comment-parser": "^0.5.4",
-    "jsdoctypeparser": "3.1.0",
+    "jsdoctypeparser": "4.0.0",
     "lodash": "^4.17.11"
   },
   "description": "JSDoc linting rules for ESLint.",
@@ -26,11 +26,12 @@
     "gitdown": "^2.5.7",
     "glob": "^7.1.4",
     "globby": "^9.2.0",
-    "husky": "^2.3.0",
+    "husky": "^2.4.0",
     "marked": "^0.6.2",
     "mocha": "^6.1.4",
     "nyc": "^14.1.1",
-    "semantic-release": "^15.13.14"
+    "semantic-release": "^15.13.16",
+    "typescript": "^3.5.1"
   },
   "engines": {
     "node": ">=6"

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -10,13 +10,16 @@ const extraTypes = [
   'Array', 'Object', 'RegExp', 'Date', 'Function'
 ];
 
+const stripPseudoTypes = (str) => {
+  return str && str.replace(/(?:\.|<>|\.<>|\[])$/, '');
+};
+
 export default iterateJsdoc(({
   context,
   report,
-  sourceCode,
+  sourceCode: {scopeManager},
   utils
 }) => {
-  const {scopeManager} = sourceCode;
   const {globalScope} = scopeManager;
 
   const {preferredTypesDefined, definedTypes = []} = context.options[0] || {};
@@ -28,13 +31,14 @@ export default iterateJsdoc(({
       // Replace `_.values` with `Object.values` when we may start requiring Node 7+
       definedPreferredTypes = _.values(preferredTypes).map((preferredType) => {
         if (typeof preferredType === 'string') {
-          return preferredType;
+          // May become an empty string but will be filtered out below
+          return stripPseudoTypes(preferredType);
         }
         if (!preferredType || typeof preferredType !== 'object') {
           return undefined;
         }
 
-        return preferredType.replacement;
+        return stripPseudoTypes(preferredType.replacement);
       }).filter((preferredType) => {
         return preferredType;
       });

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -100,7 +100,7 @@ export default {
     {
       code: `
           /**
-           * @param {Array<Number|String>} foo
+           * @param {Array.<Number|String>} foo
            */
           function quux (foo, bar, baz) {
 
@@ -118,7 +118,35 @@ export default {
       ],
       output: `
           /**
-           * @param {Array<number|string>} foo
+           * @param {Array.<number|string>} foo
+           */
+          function quux (foo, bar, baz) {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @param {(Number|String)[]} foo
+           */
+          function quux (foo, bar, baz) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @param "foo" type "Number"; prefer: "number".'
+        },
+        {
+          line: 3,
+          message: 'Invalid JSDoc @param "foo" type "String"; prefer: "string".'
+        }
+      ],
+      output: `
+          /**
+           * @param {(number|string)[]} foo
            */
           function quux (foo, bar, baz) {
 
@@ -139,6 +167,13 @@ export default {
           message: 'Invalid JSDoc @param "foo" type "abc"; prefer: "Abc".'
         }
       ],
+      output: `
+          /**
+           * @param {Abc} foo
+           */
+          function qux(foo) {
+          }
+      `,
       settings: {
         jsdoc: {
           preferredTypes: {
@@ -162,6 +197,13 @@ export default {
           message: 'Invalid JSDoc @param "foo" type "abc"; prefer: "Abc".'
         }
       ],
+      output: `
+          /**
+           * @param {Abc} foo
+           */
+          function qux(foo) {
+          }
+      `,
       settings: {
         jsdoc: {
           preferredTypes: {
@@ -187,6 +229,13 @@ export default {
           message: 'Messed up JSDoc @param "foo" type "abc"; prefer: "Abc".'
         }
       ],
+      output: `
+          /**
+           * @param {Abc} foo
+           */
+          function qux(foo) {
+          }
+      `,
       settings: {
         jsdoc: {
           preferredTypes: {
@@ -308,6 +357,14 @@ export default {
       options: [{
         noDefaults: true
       }],
+      output: `
+          /**
+           * @param {Abc} foo
+           * @param {Number} bar
+           */
+          function qux(foo, bar) {
+          }
+      `,
       settings: {
         jsdoc: {
           preferredTypes: {
@@ -502,6 +559,14 @@ export default {
           message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "GenericArray".'
         }
       ],
+      output: `
+      /**
+       * @param {GenericArray} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
       settings: {
         jsdoc: {
           preferredTypes: {
@@ -524,11 +589,19 @@ export default {
           message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "GenericArray".'
         }
       ],
+      output: `
+      /**
+       * @param {GenericArray} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
       settings: {
         jsdoc: {
           preferredTypes: {
             Array: 'GenericArray',
-            'Array<>': 'GenericArray'
+            'Array.<>': 'GenericArray'
           }
         }
       }
@@ -547,6 +620,44 @@ export default {
           message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "GenericArray".'
         }
       ],
+      output: `
+      /**
+       * @param {GenericArray.<string>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'Array.<>': 'GenericArray'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {Array<string>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "GenericArray".'
+        }
+      ],
+      output: `
+      /**
+       * @param {GenericArray<string>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
       settings: {
         jsdoc: {
           preferredTypes: {
@@ -566,13 +677,87 @@ export default {
       `,
       errors: [
         {
-          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "GenericArray".'
+          message: 'Invalid JSDoc @param "foo" type "[]"; prefer: "SpecialTypeArray".'
         }
       ],
+      output: `
+      /**
+       * @param {SpecialTypeArray<string>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
       settings: {
         jsdoc: {
           preferredTypes: {
-            'Array<>': 'GenericArray'
+            '[]': 'SpecialTypeArray'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {string[]} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "[]"; prefer: "SpecialTypeArray".'
+        }
+      ],
+      options: [{
+        unifyParentAndChildTypeChecks: true
+      }],
+      output: `
+      /**
+       * @param {SpecialTypeArray<string>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            '[]': 'SpecialTypeArray'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {string[]} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "SpecialTypeArray".'
+        }
+      ],
+      options: [{
+        unifyParentAndChildTypeChecks: true
+      }],
+      output: `
+      /**
+       * @param {SpecialTypeArray<string>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            Array: 'SpecialTypeArray'
           }
         }
       }
@@ -591,6 +776,14 @@ export default {
           message: 'Invalid JSDoc @param "foo" type "object"; prefer: "GenericObject".'
         }
       ],
+      output: `
+      /**
+       * @param {GenericObject} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
       settings: {
         jsdoc: {
           preferredTypes: {
@@ -613,6 +806,45 @@ export default {
           message: 'Invalid JSDoc @param "foo" type "object"; prefer: "GenericObject".'
         }
       ],
+      output: `
+      /**
+       * @param {GenericObject} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            object: 'GenericObject',
+            'object.<>': 'GenericObject'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {object} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "GenericObject".'
+        }
+      ],
+      output: `
+      /**
+       * @param {GenericObject} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
       settings: {
         jsdoc: {
           preferredTypes: {
@@ -636,6 +868,44 @@ export default {
           message: 'Invalid JSDoc @param "foo" type "object"; prefer: "GenericObject".'
         }
       ],
+      output: `
+      /**
+       * @param {GenericObject.<string>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'object.<>': 'GenericObject'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {object<string>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "GenericObject".'
+        }
+      ],
+      output: `
+      /**
+       * @param {GenericObject<string>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
       settings: {
         jsdoc: {
           preferredTypes: {
@@ -658,6 +928,44 @@ export default {
           message: 'Invalid JSDoc @param "foo" type "object"; prefer: "GenericObject".'
         }
       ],
+      output: `
+      /**
+       * @param {GenericObject.<string, number>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'object.<>': 'GenericObject'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {object<string, number>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "GenericObject".'
+        }
+      ],
+      output: `
+      /**
+       * @param {GenericObject<string, number>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
       settings: {
         jsdoc: {
           preferredTypes: {
@@ -683,6 +991,47 @@ export default {
       options: [{
         unifyParentAndChildTypeChecks: true
       }],
+      output: `
+      /**
+       * @param {GenericObject.<string>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            object: 'GenericObject'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {object<string>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "GenericObject".'
+        }
+      ],
+      options: [{
+        unifyParentAndChildTypeChecks: true
+      }],
+      output: `
+      /**
+       * @param {GenericObject<string>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
       settings: {
         jsdoc: {
           preferredTypes: {
@@ -708,6 +1057,14 @@ export default {
       options: [{
         unifyParentAndChildTypeChecks: true
       }],
+      output: `
+      /**
+       * @param {GenericObject} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
       settings: {
         jsdoc: {
           preferredTypes: {
@@ -780,10 +1137,538 @@ export default {
       options: [{
         unifyParentAndChildTypeChecks: true
       }],
+      output: `
+      /**
+       * @param {GenericObject.<string, number>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
       settings: {
         jsdoc: {
           preferredTypes: {
             object: 'GenericObject'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {object<string, number>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "GenericObject".'
+        }
+      ],
+      options: [{
+        unifyParentAndChildTypeChecks: true
+      }],
+      output: `
+      /**
+       * @param {GenericObject<string, number>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            object: 'GenericObject'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       *
+       * @param {string[][]} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "[]"; prefer: "Array.".'
+        },
+        {
+          message: 'Invalid JSDoc @param "foo" type "[]"; prefer: "Array.".'
+        }
+      ],
+      output: `
+      /**
+       *
+       * @param {Array.<Array.<string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            '[]': 'Array.'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       *
+       * @param {string[][]} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "[]"; prefer: "Array.<>".'
+        },
+        {
+          message: 'Invalid JSDoc @param "foo" type "[]"; prefer: "Array.<>".'
+        }
+      ],
+      output: `
+      /**
+       *
+       * @param {Array.<Array.<string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            '[]': 'Array.<>'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       *
+       * @param {string[][]} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "[]"; prefer: "Array<>".'
+        },
+        {
+          message: 'Invalid JSDoc @param "foo" type "[]"; prefer: "Array<>".'
+        }
+      ],
+      output: `
+      /**
+       *
+       * @param {Array<Array<string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            '[]': 'Array<>'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       *
+       * @param {object.<string, object.<string, string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "Object".'
+        },
+        {
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "Object".'
+        }
+      ],
+      output: `
+      /**
+       *
+       * @param {Object.<string, Object.<string, string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'object.': 'Object'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       *
+       * @param {object.<string, object.<string, string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "Object<>".'
+        },
+        {
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "Object<>".'
+        }
+      ],
+      output: `
+      /**
+       *
+       * @param {Object<string, Object<string, string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'object.': 'Object<>'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       *
+       * @param {object<string, object<string, string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "Object.".'
+        },
+        {
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "Object.".'
+        }
+      ],
+      output: `
+      /**
+       *
+       * @param {Object.<string, Object.<string, string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'object<>': 'Object.'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       *
+       * @param {Array.<Array.<string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "[]".'
+        },
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "[]".'
+        }
+      ],
+      output: `
+      /**
+       *
+       * @param {string[][]} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'Array.': '[]'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       *
+       * @param {Array.<Array.<string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "Array<>".'
+        },
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "Array<>".'
+        }
+      ],
+      output: `
+      /**
+       *
+       * @param {Array<Array<string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'Array.': 'Array<>'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       *
+       * @param {Array.<Array.<string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "<>".'
+        },
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "<>".'
+        }
+      ],
+      output: `
+      /**
+       *
+       * @param {Array<Array<string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'Array.': '<>'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       *
+       * @param {Array.<MyArray.<string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "<>".'
+        }
+      ],
+      output: `
+      /**
+       *
+       * @param {Array<MyArray.<string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'Array.': '<>'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       *
+       * @param {Array.<MyArray.<string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "MyArray"; prefer: "<>".'
+        }
+      ],
+      output: `
+      /**
+       *
+       * @param {Array.<MyArray<string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'MyArray.': '<>'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       *
+       * @param {Array<Array<string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "Array.".'
+        },
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "Array.".'
+        }
+      ],
+      output: `
+      /**
+       *
+       * @param {Array.<Array.<string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            '<>': 'Array.'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       *
+       * @param {Array<Array<string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "Array.".'
+        },
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "Array.".'
+        }
+      ],
+      options: [{
+        unifyParentAndChildTypeChecks: true
+      }],
+      output: `
+      /**
+       *
+       * @param {Array.<Array.<string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            Array: 'Array.'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       *
+       * @param {Array<Array<string>>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "[]".'
+        },
+        {
+          message: 'Invalid JSDoc @param "foo" type "Array"; prefer: "[]".'
+        }
+      ],
+      output: `
+      /**
+       *
+       * @param {string[][]} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            '<>': '[]'
           }
         }
       }
@@ -921,7 +1806,7 @@ export default {
     {
       code: `
       /**
-       * @param {string[]} foo
+       * @param {Array<string>} foo
        */
       function quux (foo) {
 
@@ -931,6 +1816,100 @@ export default {
         jsdoc: {
           preferredTypes: {
             Array: 'GenericArray'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {string[]} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            Array: 'SpecialTypeArray',
+            'Array.<>': 'SpecialTypeArray',
+            'Array<>': 'SpecialTypeArray'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {string[]} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      options: [{
+        unifyParentAndChildTypeChecks: true
+      }],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'Array.<>': 'SpecialTypeArray',
+            'Array<>': 'SpecialTypeArray'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {Array} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            '[]': 'SpecialTypeArray'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {Array} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      options: [{
+        unifyParentAndChildTypeChecks: true
+      }],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            '[]': 'SpecialTypeArray'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {Array} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'Array.<>': 'GenericArray'
           }
         }
       }
@@ -982,6 +1961,23 @@ export default {
     {
       code: `
       /**
+       * @param {object<string>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            object: 'GenericObject'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
        * @param {object.<string, number>} foo
        */
       function quux (foo) {
@@ -992,6 +1988,40 @@ export default {
         jsdoc: {
           preferredTypes: {
             object: 'GenericObject'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {object<string, number>} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            object: 'GenericObject'
+          }
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @param {object} foo
+       */
+      function quux (foo) {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            'object.<>': 'GenericObject'
           }
         }
       }

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -300,6 +300,32 @@ export default {
           }
         }
       }
+    },
+    {
+      code: `
+        /**
+         * @param {MyType} foo - Bar.
+         * @param {HisType} bar - Foo.
+         * @param {HerType} baz - Foo.
+         */
+       function quux(foo, bar, baz) {
+
+       }
+      `,
+      options: [{
+        definedTypes: ['MyType'],
+        preferredTypesDefined: true
+      }],
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            hertype: {
+              replacement: 'HerType<>'
+            },
+            histype: 'HisType.<>'
+          }
+        }
+      }
     }
   ]
 };


### PR DESCRIPTION
BREAKING CHANGE: change `<>` to no longer apply to `SomeType.<>` but instead to now support `SomeType<>`
feat: pseudo-type `[]` to catch parent array types of form `string[]`, `number[]`, etc.
feat: support `.<>` as separate type
fix: ensure working with nested type arrays/objects
fix: ensure fixer preserves angle-bracket-dot or square bracket notation for arrays/objects
chore: Update husky, semantic-release devDeps; add `typescript` devDep for `type-fest` peer dep. (used indirectly by husky and semantic-release)

Breaking change through `jsdoctypeparser` update.

----

Also includes a minor adjustment to `no-undefined-types` to be able to recognize types suffixed with the pseudo-types (e.g., `<>`).

~This is currently being blocked by https://github.com/jsdoctypeparser/jsdoctypeparser/pull/60 but once that may be merged and released, this PR should only need to target the new version as its dependency. (And tests failing here should be due to this need.)~ *Now incorporated*