### PR TITLE
chore: move utils.<someSetting> to settings.<someSetting>

### DIFF
--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -25,28 +25,30 @@ const parseComment = (commentNode, indent) => {
 const curryUtils = (
   node,
   jsdoc,
-  tagNamePreference,
-  exampleCodeRegex,
-  rejectExampleCodeRegex,
-  additionalTagNames,
-  baseConfig,
-  configFile,
-  captionRequired,
-  matchingFileName,
-  eslintrcForExamples,
-  allowInlineConfig,
-  allowEmptyNamepaths,
-  reportUnusedDisableDirectives,
-  noDefaultExampleRules,
-  overrideReplacesDocs,
-  implementsReplacesDocs,
-  augmentsExtendsReplacesDocs,
-  allowOverrideWithoutParam,
-  allowImplementsWithoutParam,
-  allowAugmentsExtendsWithoutParam,
-  checkSeesForNamepaths,
-  forceRequireReturn,
-  avoidExampleOnConstructors,
+  {
+    tagNamePreference,
+    exampleCodeRegex,
+    rejectExampleCodeRegex,
+    additionalTagNames,
+    baseConfig,
+    configFile,
+    captionRequired,
+    matchingFileName,
+    eslintrcForExamples,
+    allowInlineConfig,
+    allowEmptyNamepaths,
+    reportUnusedDisableDirectives,
+    noDefaultExampleRules,
+    overrideReplacesDocs,
+    implementsReplacesDocs,
+    augmentsExtendsReplacesDocs,
+    allowOverrideWithoutParam,
+    allowImplementsWithoutParam,
+    allowAugmentsExtendsWithoutParam,
+    checkSeesForNamepaths,
+    forceRequireReturn,
+    avoidExampleOnConstructors
+  },
   ancestors,
   sourceCode,
   context
@@ -257,6 +259,53 @@ const curryUtils = (
   return utils;
 };
 
+const getSettings = (context) => {
+  const settings = {};
+
+  // All rules
+  settings.ignorePrivate = Boolean(_.get(context, 'settings.jsdoc.ignorePrivate'));
+
+  // `check-tag-names` and many require/param rules
+  settings.tagNamePreference = _.get(context, 'settings.jsdoc.tagNamePreference') || {};
+
+  // `check-tag-names` only
+  settings.additionalTagNames = _.get(context, 'settings.jsdoc.additionalTagNames') || {};
+
+  // `check-examples` only
+  settings.exampleCodeRegex = _.get(context, 'settings.jsdoc.exampleCodeRegex') || null;
+  settings.rejectExampleCodeRegex = _.get(context, 'settings.jsdoc.rejectExampleCodeRegex') || null;
+  settings.matchingFileName = _.get(context, 'settings.jsdoc.matchingFileName') || null;
+  settings.baseConfig = _.get(context, 'settings.jsdoc.baseConfig') || {};
+  settings.configFile = _.get(context, 'settings.jsdoc.configFile');
+  settings.eslintrcForExamples = _.get(context, 'settings.jsdoc.eslintrcForExamples') !== false;
+  settings.allowInlineConfig = _.get(context, 'settings.jsdoc.allowInlineConfig') !== false;
+  settings.reportUnusedDisableDirectives = _.get(context, 'settings.jsdoc.reportUnusedDisableDirectives') !== false;
+  settings.captionRequired = Boolean(_.get(context, 'settings.jsdoc.captionRequired'));
+  settings.noDefaultExampleRules = Boolean(_.get(context, 'settings.jsdoc.noDefaultExampleRules'));
+
+  // `require-param`, `require-description`, `require-example`, `require-returns`
+  settings.overrideReplacesDocs = _.get(context, 'settings.jsdoc.overrideReplacesDocs');
+  settings.implementsReplacesDocs = _.get(context, 'settings.jsdoc.implementsReplacesDocs');
+  settings.augmentsExtendsReplacesDocs = _.get(context, 'settings.jsdoc.augmentsExtendsReplacesDocs');
+
+  // `require-param` only (deprecated)
+  settings.allowOverrideWithoutParam = _.get(context, 'settings.jsdoc.allowOverrideWithoutParam');
+  settings.allowImplementsWithoutParam = _.get(context, 'settings.jsdoc.allowImplementsWithoutParam');
+  settings.allowAugmentsExtendsWithoutParam = _.get(context, 'settings.jsdoc.allowAugmentsExtendsWithoutParam');
+
+  // `valid-types` only
+  settings.allowEmptyNamepaths = _.get(context, 'settings.jsdoc.allowEmptyNamepaths') !== false;
+  settings.checkSeesForNamepaths = Boolean(_.get(context, 'settings.jsdoc.checkSeesForNamepaths'));
+
+  // `require-returns` only
+  settings.forceRequireReturn = Boolean(_.get(context, 'settings.jsdoc.forceRequireReturn'));
+
+  // `require-example` only
+  settings.avoidExampleOnConstructors = Boolean(_.get(context, 'settings.jsdoc.avoidExampleOnConstructors'));
+
+  return settings;
+};
+
 export {
   parseComment
 };
@@ -275,46 +324,7 @@ export default (iterator, opts = {}) => {
     create (context) {
       const sourceCode = context.getSourceCode();
 
-      // All rules
-      const ignorePrivate = Boolean(_.get(context, 'settings.jsdoc.ignorePrivate'));
-
-      // `check-tag-names` and many require/param rules
-      const tagNamePreference = _.get(context, 'settings.jsdoc.tagNamePreference') || {};
-
-      // `check-tag-names` only
-      const additionalTagNames = _.get(context, 'settings.jsdoc.additionalTagNames') || {};
-
-      // `check-examples` only
-      const exampleCodeRegex = _.get(context, 'settings.jsdoc.exampleCodeRegex') || null;
-      const rejectExampleCodeRegex = _.get(context, 'settings.jsdoc.rejectExampleCodeRegex') || null;
-      const matchingFileName = _.get(context, 'settings.jsdoc.matchingFileName') || null;
-      const baseConfig = _.get(context, 'settings.jsdoc.baseConfig') || {};
-      const configFile = _.get(context, 'settings.jsdoc.configFile');
-      const eslintrcForExamples = _.get(context, 'settings.jsdoc.eslintrcForExamples') !== false;
-      const allowInlineConfig = _.get(context, 'settings.jsdoc.allowInlineConfig') !== false;
-      const reportUnusedDisableDirectives = _.get(context, 'settings.jsdoc.reportUnusedDisableDirectives') !== false;
-      const captionRequired = Boolean(_.get(context, 'settings.jsdoc.captionRequired'));
-      const noDefaultExampleRules = Boolean(_.get(context, 'settings.jsdoc.noDefaultExampleRules'));
-
-      // `require-param`, `require-description`, `require-example`, `require-returns`
-      const overrideReplacesDocs = _.get(context, 'settings.jsdoc.overrideReplacesDocs');
-      const implementsReplacesDocs = _.get(context, 'settings.jsdoc.implementsReplacesDocs');
-      const augmentsExtendsReplacesDocs = _.get(context, 'settings.jsdoc.augmentsExtendsReplacesDocs');
-
-      // `require-param` only (deprecated)
-      const allowOverrideWithoutParam = _.get(context, 'settings.jsdoc.allowOverrideWithoutParam');
-      const allowImplementsWithoutParam = _.get(context, 'settings.jsdoc.allowImplementsWithoutParam');
-      const allowAugmentsExtendsWithoutParam = _.get(context, 'settings.jsdoc.allowAugmentsExtendsWithoutParam');
-
-      // `valid-types` only
-      const allowEmptyNamepaths = _.get(context, 'settings.jsdoc.allowEmptyNamepaths') !== false;
-      const checkSeesForNamepaths = Boolean(_.get(context, 'settings.jsdoc.checkSeesForNamepaths'));
-
-      // `require-returns` only
-      const forceRequireReturn = Boolean(_.get(context, 'settings.jsdoc.forceRequireReturn'));
-
-      // `require-example` only
-      const avoidExampleOnConstructors = Boolean(_.get(context, 'settings.jsdoc.avoidExampleOnConstructors'));
+      const settings = getSettings(context);
 
       const checkJsdoc = (node) => {
         const jsdocNode = getJSDocComment(sourceCode, node);
@@ -367,34 +377,13 @@ export default (iterator, opts = {}) => {
         const utils = curryUtils(
           node,
           jsdoc,
-          tagNamePreference,
-          exampleCodeRegex,
-          rejectExampleCodeRegex,
-          additionalTagNames,
-          baseConfig,
-          configFile,
-          captionRequired,
-          matchingFileName,
-          eslintrcForExamples,
-          allowInlineConfig,
-          allowEmptyNamepaths,
-          reportUnusedDisableDirectives,
-          noDefaultExampleRules,
-          overrideReplacesDocs,
-          implementsReplacesDocs,
-          augmentsExtendsReplacesDocs,
-          allowOverrideWithoutParam,
-          allowImplementsWithoutParam,
-          allowAugmentsExtendsWithoutParam,
-          checkSeesForNamepaths,
-          forceRequireReturn,
-          avoidExampleOnConstructors,
+          settings,
           ancestors,
           sourceCode
         );
 
         if (
-          ignorePrivate &&
+          settings.ignorePrivate &&
           utils.hasTag('private')
         ) {
           return;

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -27,27 +27,15 @@ const curryUtils = (
   jsdoc,
   {
     tagNamePreference,
-    exampleCodeRegex,
-    rejectExampleCodeRegex,
     additionalTagNames,
-    baseConfig,
-    configFile,
-    captionRequired,
-    matchingFileName,
-    eslintrcForExamples,
-    allowInlineConfig,
     allowEmptyNamepaths,
-    reportUnusedDisableDirectives,
-    noDefaultExampleRules,
     overrideReplacesDocs,
     implementsReplacesDocs,
     augmentsExtendsReplacesDocs,
     allowOverrideWithoutParam,
     allowImplementsWithoutParam,
     allowAugmentsExtendsWithoutParam,
-    checkSeesForNamepaths,
-    forceRequireReturn,
-    avoidExampleOnConstructors
+    checkSeesForNamepaths
   },
   ancestors,
   sourceCode,
@@ -83,18 +71,6 @@ const curryUtils = (
     return jsdocUtils.getPreferredTagName(name, tagNamePreference);
   };
 
-  utils.getExampleCodeRegex = () => {
-    return exampleCodeRegex;
-  };
-
-  utils.getRejectExampleCodeRegex = () => {
-    return rejectExampleCodeRegex;
-  };
-
-  utils.getMatchingFileName = () => {
-    return matchingFileName;
-  };
-
   utils.isValidTag = (name) => {
     return jsdocUtils.isValidTag(name, additionalTagNames);
   };
@@ -105,34 +81,6 @@ const curryUtils = (
 
   utils.hasTag = (name) => {
     return jsdocUtils.hasTag(jsdoc, name);
-  };
-
-  utils.useEslintrcForExamples = () => {
-    return eslintrcForExamples;
-  };
-
-  utils.allowInlineConfig = () => {
-    return allowInlineConfig;
-  };
-
-  utils.reportUnusedDisableDirectives = () => {
-    return reportUnusedDisableDirectives;
-  };
-
-  utils.hasNoDefaultExampleRules = () => {
-    return noDefaultExampleRules;
-  };
-
-  utils.getBaseConfig = () => {
-    return baseConfig;
-  };
-
-  utils.getConfigFile = () => {
-    return configFile;
-  };
-
-  utils.isCaptionRequired = () => {
-    return captionRequired;
   };
 
   // These settings are deprecated and may be removed in the future along with this method.
@@ -188,10 +136,6 @@ const curryUtils = (
     return jsdocUtils.isTagWithType(tagName);
   };
 
-  utils.avoidExampleOnConstructors = () => {
-    return avoidExampleOnConstructors;
-  };
-
   utils.passesEmptyNamepathCheck = (tag) => {
     return !tag.name && allowEmptyNamepaths &&
       jsdocUtils.isPotentiallyEmptyNamepathTag(tag.tag);
@@ -209,10 +153,6 @@ const curryUtils = (
     return utils.filterTags((item) => {
       return item.tag === tagName;
     });
-  };
-
-  utils.isForceRequireReturn = () => {
-    return forceRequireReturn;
   };
 
   utils.filterTags = (filter) => {
@@ -310,7 +250,14 @@ export {
   parseComment
 };
 
-export default (iterator, opts = {}) => {
+/**
+ * @typedef {ReturnType<typeof curryUtils>} Utils
+ * @typedef {ReturnType<typeof getSettings>} Settings
+ *
+ * @param {(arg: {utils: Utils, settings: Settings}) => any} iterator
+ * @param {{returns?: any}} opts
+ */
+export default function iterateJsdoc (iterator, opts = {}) {
   return {
     /**
      * The entrypoint for the JSDoc rule.
@@ -396,6 +343,7 @@ export default (iterator, opts = {}) => {
           jsdocNode,
           node,
           report,
+          settings,
           sourceCode,
           utils
         });
@@ -424,4 +372,4 @@ export default (iterator, opts = {}) => {
     },
     meta: opts.meta
   };
-};
+}

--- a/src/rules/checkExamples.js
+++ b/src/rules/checkExamples.js
@@ -15,17 +15,19 @@ const countChars = (str, ch) => {
 
 export default iterateJsdoc(({
   report,
-  utils
+  utils,
+  settings
 }) => {
-  let exampleCodeRegex = utils.getExampleCodeRegex();
-  let rejectExampleCodeRegex = utils.getRejectExampleCodeRegex();
-  const noDefaultExampleRules = utils.hasNoDefaultExampleRules();
-  const eslintrcForExamples = utils.useEslintrcForExamples();
-  const filename = utils.getMatchingFileName();
-  const baseConfig = utils.getBaseConfig();
-  const configFile = utils.getConfigFile();
-  const allowInlineConfig = utils.allowInlineConfig();
-  const reportUnusedDisableDirectives = utils.reportUnusedDisableDirectives();
+  let {exampleCodeRegex, rejectExampleCodeRegex} = settings;
+  const {
+    noDefaultExampleRules,
+    eslintrcForExamples,
+    matchingFileName: filename,
+    baseConfig,
+    configFile,
+    allowInlineConfig,
+    reportUnusedDisableDirectives
+  } = settings;
 
   // Make this configurable?
   const rulePaths = [];
@@ -69,7 +71,7 @@ export default iterateJsdoc(({
     let source = tag.source.slice(initialTagLength);
     const match = source.match(hasCaptionRegex);
 
-    if (utils.isCaptionRequired() && !match) {
+    if (settings.captionRequired && !match) {
       report('Caption is expected for examples.', null, tag);
     }
 

--- a/src/rules/requireExample.js
+++ b/src/rules/requireExample.js
@@ -4,7 +4,8 @@ import iterateJsdoc from '../iterateJsdoc';
 export default iterateJsdoc(({
   jsdoc,
   report,
-  utils
+  utils,
+  settings
 }) => {
   if (utils.avoidDocs()) {
     return;
@@ -16,7 +17,7 @@ export default iterateJsdoc(({
     tag: targetTagName
   });
 
-  if (utils.avoidExampleOnConstructors() && (
+  if (settings.avoidExampleOnConstructors && (
     utils.hasATag([
       'class',
       'constructor'

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -39,7 +39,8 @@ const canSkip = (utils) => {
 
 export default iterateJsdoc(({
   report,
-  utils
+  utils,
+  settings
 }) => {
   // A preflight check. We do not need to run a deep check
   // in case the @returns comment is optional or undefined.
@@ -58,7 +59,7 @@ export default iterateJsdoc(({
   const [tag] = tags;
   const missingReturnTag = typeof tag === 'undefined' || tag === null;
   if (missingReturnTag &&
-    (utils.hasReturnValue() || utils.isForceRequireReturn())
+    (utils.hasReturnValue() || settings.forceRequireReturn)
   ) {
     report('Missing JSDoc @' + tagName + ' declaration.');
   }


### PR DESCRIPTION
Settings are now accessed from `settings.<thing>` instead of `utils.<thing>()`.