### PR TITLE
require-returns-check: Skip interface class methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -5054,6 +5054,15 @@ const language = {
   }
 }
 // Message: JSDoc @returns declaration present but return expression not available in function.
+
+class Foo {
+  /**
+   * @returns {string}
+   */
+  bar () {
+  }
+}
+// Message: JSDoc @returns declaration present but return expression not available in function.
 ````
 
 The following patterns are not considered problems:

--- a/README.md
+++ b/README.md
@@ -5143,6 +5143,17 @@ function quux () {
 }
 
 /**
+ * @interface
+ */
+class Foo {
+  /**
+   * @returns {string}
+   */
+  bar () {
+  }
+}
+
+/**
  * @returns {undefined} Foo.
  */
 function quux () {

--- a/src/rules/requireReturnsCheck.js
+++ b/src/rules/requireReturnsCheck.js
@@ -15,7 +15,7 @@ const canSkip = (utils) => {
     'class',
     'constructor',
     'interface'
-  ]) || utils.isConstructor();
+  ]) || utils.isConstructor() || utils.classHasTag('interface');
 };
 
 export default iterateJsdoc(({

--- a/test/rules/assertions/requireReturnsCheck.js
+++ b/test/rules/assertions/requireReturnsCheck.js
@@ -89,6 +89,23 @@ export default {
           message: 'JSDoc @returns declaration present but return expression not available in function.'
         }
       ]
+    },
+    {
+      code: `
+          class Foo {
+            /**
+             * @returns {string}
+             */
+            bar () {
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'JSDoc @returns declaration present but return expression not available in function.'
+        }
+      ]
     }
   ],
   valid: [

--- a/test/rules/assertions/requireReturnsCheck.js
+++ b/test/rules/assertions/requireReturnsCheck.js
@@ -226,6 +226,20 @@ export default {
     {
       code: `
           /**
+           * @interface
+           */
+          class Foo {
+            /**
+             * @returns {string}
+             */
+            bar () {
+            }
+          }
+      `
+    },
+    {
+      code: `
+          /**
            * @returns {undefined} Foo.
            */
           function quux () {


### PR DESCRIPTION
As per jsdoc `@interface` tag [description](https://devdocs.io/jsdoc/tags-interface), class marked with this tag should denote that all members of the class are interface symbols and therefore functions can have `@returns` tag, but no function body with `return` statement.

This pull request makes the following code valid:

```js
/**
 * @interface
 */
class Foo {
    /**
     * @returns {string}
     */
    bar () {}
}
```

While previously `require-returns-check` reported `bar` as missing return value;