### PR TITLE
fix: make options schemas effective

### DIFF
--- a/src/rules/newlineAfterDescription.js
+++ b/src/rules/newlineAfterDescription.js
@@ -56,12 +56,12 @@ export default iterateJsdoc(({
 }, {
   meta: {
     fixable: 'whitespace',
+    schema: [
+      {
+        enum: ['always', 'never'],
+        type: 'string'
+      }
+    ],
     type: 'layout'
-  },
-  schema: [
-    {
-      enum: ['always'],
-      type: 'string'
-    }
-  ]
+  }
 });

--- a/src/rules/requireDescription.js
+++ b/src/rules/requireDescription.js
@@ -31,6 +31,36 @@ export default iterateJsdoc(({
   });
 }, {
   meta: {
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          contexts: {
+            oneOf: [
+              {
+                items: {
+                  type: 'string'
+                },
+                type: 'array'
+              },
+              {
+                type: 'string'
+              }
+            ]
+          },
+          exemptedBy: {
+            items: {
+              type: 'string'
+            },
+            type: 'array'
+          },
+          noDefaults: {
+            type: 'boolean'
+          }
+        },
+        type: 'object'
+      }
+    ],
     type: 'suggestion'
   },
   returns (context) {
@@ -50,35 +80,6 @@ export default iterateJsdoc(({
     return noDefaults ?
       contexts :
       [...new Set([...defaultContexts, ...contexts])];
-  },
-  schema: [
-    {
-      additionalProperties: false,
-      properties: {
-        contexts: {
-          oneOf: [
-            {
-              items: {
-                type: 'string'
-              },
-              type: 'array'
-            },
-            {
-              type: 'string'
-            }
-          ]
-        },
-        exemptedBy: {
-          items: {
-            type: 'string'
-          },
-          type: 'array'
-        },
-        noDefaults: {
-          type: 'boolean'
-        }
-      },
-      type: 'object'
-    }
-  ]
+  }
+
 });

--- a/src/rules/requireExample.js
+++ b/src/rules/requireExample.js
@@ -42,20 +42,20 @@ export default iterateJsdoc(({
   });
 }, {
   meta: {
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          exemptedBy: {
+            items: {
+              type: 'string'
+            },
+            type: 'array'
+          }
+        },
+        type: 'object'
+      }
+    ],
     type: 'suggestion'
-  },
-  schema: [
-    {
-      additionalProperties: false,
-      properties: {
-        exemptedBy: {
-          items: {
-            type: 'string'
-          },
-          type: 'array'
-        }
-      },
-      type: 'object'
-    }
-  ]
+  }
 });

--- a/src/rules/requireHyphenBeforeParamDescription.js
+++ b/src/rules/requireHyphenBeforeParamDescription.js
@@ -56,12 +56,12 @@ export default iterateJsdoc(({
 }, {
   meta: {
     fixable: 'code',
+    schema: [
+      {
+        enum: ['always', 'never'],
+        type: 'string'
+      }
+    ],
     type: 'layout'
-  },
-  schema: [
-    {
-      enum: ['always'],
-      type: 'string'
-    }
-  ]
+  }
 });

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -30,20 +30,20 @@ export default iterateJsdoc(({
   });
 }, {
   meta: {
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          exemptedBy: {
+            items: {
+              type: 'string'
+            },
+            type: 'array'
+          }
+        },
+        type: 'object'
+      }
+    ],
     type: 'suggestion'
-  },
-  schema: [
-    {
-      additionalProperties: false,
-      properties: {
-        exemptedBy: {
-          items: {
-            type: 'string'
-          },
-          type: 'array'
-        }
-      },
-      type: 'object'
-    }
-  ]
+  }
 });

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -71,24 +71,24 @@ export default iterateJsdoc(({
   }
 }, {
   meta: {
-    type: 'suggestion'
-  },
-  schema: [
-    {
-      additionalProperties: false,
-      properties: {
-        exemptedBy: {
-          items: {
-            type: 'string'
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          exemptedBy: {
+            items: {
+              type: 'string'
+            },
+            type: 'array'
           },
-          type: 'array'
+          forceReturnsWithAsync: {
+            default: false,
+            type: 'boolean'
+          }
         },
-        forceReturnsWithAsync: {
-          default: false,
-          type: 'boolean'
-        }
-      },
-      type: 'object'
-    }
-  ]
+        type: 'object'
+      }
+    ],
+    type: 'suggestion'
+  }
 });


### PR DESCRIPTION
This pr moves misplaced `schema`s to inside of `meta`. Otherwise these schemas are ineffective, that is, eslint engine does not validate options.