### PR TITLE
ESLint 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ package-lock.json
 !.npmignore
 !.README
 !.travis.yml
+!.ncurc.js

--- a/.ncurc.js
+++ b/.ncurc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  // Whitelist all for checking besides `peer` which indicates
+  //   somewhat older versions of `eslint` we still support even
+  //   while our devDeps point to a more recent version
+  "dep": "prod,dev,optional,bundle"
+};

--- a/.ncurc.js
+++ b/.ncurc.js
@@ -1,6 +1,0 @@
-module.exports = {
-  // Whitelist all for checking besides `peer` which indicates
-  //   somewhat older versions of `eslint` we still support even
-  //   while our devDeps point to a more recent version
-  "dep": "prod,dev,optional,bundle"
-};

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
   - node
+  - 10
   - 8
-  - 6
 before_install:
   - npm config set depth 0
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,32 @@
 language: node_js
 node_js:
-  - node
+  - 12
   - 10
   - 8
+  - 6
 before_install:
   - npm config set depth 0
+before_script:
+  - 'if [ -n "${ESLINT-}" ]; then npm install --no-save "eslint@${ESLINT}" ; fi'
 notifications:
   email: false
 sudo: false
 script:
   - npm run test
-  - npm run lint
+  - 'if [ -n "${LINT-}" ]; then npm run lint; fi'
   - npm run build
+env:
+  matrix:
+    - ESLINT=6
+    - ESLINT=5
+matrix:
+  fast_finish: true
+  include:
+    - node_js: 'lts/*'
+      env: LINT=true
+  exclude:
+    - node_js: 6
+      env: ESLINT=6
 after_success:
   - export NODE_ENV=production
   - npm run build

--- a/README.md
+++ b/README.md
@@ -678,7 +678,7 @@ function quux () {}
 function quux2 () {
 
 }
-// Settings: {"jsdoc":{"matchingFileName":"test/jsdocUtils.js"}}
+// Settings: {"jsdoc":{"matchingFileName":"/Users/brett/eslint-plugin-jsdoc/test/rules/data/test.js"}}
 // Message: @example error (semi): Missing semicolon.
 
 /**

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "main": "./dist/index.js",
   "name": "eslint-plugin-jsdoc",
   "peerDependencies": {
-    "eslint": ">=6.0.0"
+    "eslint": "^5.0.0 || ^6.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "main": "./dist/index.js",
   "name": "eslint-plugin-jsdoc",
   "peerDependencies": {
-    "eslint": ">=5.16.0"
+    "eslint": ">=6.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-plugin-add-module-exports": "^1.0.2",
     "babel-plugin-istanbul": "^5.1.4",
     "chai": "^4.2.0",
-    "eslint": "^5.14.1",
+    "eslint": "^6.0.0",
     "eslint-config-canonical": "^17.1.1",
     "gitdown": "^2.5.8",
     "glob": "^7.1.4",
@@ -64,8 +64,8 @@
     "build": "rm -fr ./dist && NODE_ENV=production babel ./src --out-dir ./dist --copy-files --source-maps",
     "create-readme": "gitdown ./.README/README.md --output-file ./README.md && npm run add-assertions",
     "lint": "eslint ./src ./test",
-    "test-cov": "BABEL_ENV=test nyc mocha --recursive --require @babel/register --reporter progress --timeout 7000",
-    "test": "BABEL_ENV=test nyc --reporter text-summary mocha --recursive --require @babel/register --reporter progress --timeout 7000"
+    "test-cov": "BABEL_ENV=test nyc mocha --recursive --require @babel/register --reporter progress",
+    "test": "BABEL_ENV=test nyc --reporter text-summary mocha --recursive --require @babel/register --reporter progress"
   },
   "nyc": {
     "require": [

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -18,19 +18,15 @@ const OPTIONS_SCHEMA = {
           default: {},
           properties: {
             ancestorsOnly: {
-              default: false,
               type: 'boolean'
             },
             cjs: {
-              default: true,
               type: 'boolean'
             },
             esm: {
-              default: true,
               type: 'boolean'
             },
             window: {
-              default: false,
               type: 'boolean'
             }
           },
@@ -142,10 +138,10 @@ export default iterateJsdoc(null, {
 
       if (publicOnly) {
         const opt = {
-          ancestorsOnly: publicOnly.ancestorsOnly,
-          esm: publicOnly.esm,
-          initModuleExports: publicOnly.cjs,
-          initWindow: publicOnly.window
+          ancestorsOnly: Boolean(_.get(publicOnly, 'ancestorsOnly', false)),
+          esm: Boolean(_.get(publicOnly, 'esm', true)),
+          initModuleExports: Boolean(_.get(publicOnly, 'cjs', true)),
+          initWindow: Boolean(_.get(publicOnly, 'window', false))
         };
         const parseResult = exportParser.parse(sourceCode.ast, node, opt);
         const exported = exportParser.isExported(node, parseResult, opt);

--- a/test/rules/assertions/checkExamples.js
+++ b/test/rules/assertions/checkExamples.js
@@ -1,5 +1,12 @@
 /* eslint-disable no-restricted-syntax */
 
+// After `importMeta` no longer experimental, we can use this ESM
+//   approach over `__dirname`?
+// import {fileURLToPath} from 'url';
+// import {join, dirname} from 'path';
+// join(dirname(fileURLToPath(import.meta.url)), 'babel-eslint')
+import {join} from 'path';
+
 export default {
   invalid: [
     {
@@ -314,7 +321,7 @@ export default {
       ],
       settings: {
         jsdoc: {
-          matchingFileName: 'test/jsdocUtils.js'
+          matchingFileName: join(__dirname, '../', 'data/test.js')
         }
       }
     },

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -1,3 +1,10 @@
+// After `importMeta` no longer experimental, we can use this ESM
+//   approach over `__dirname`?
+// import {fileURLToPath} from 'url';
+// import {join, dirname} from 'path';
+// join(dirname(fileURLToPath(import.meta.url)), 'babel-eslint')
+import {join} from 'path';
+
 export default {
   invalid: [
     {
@@ -636,7 +643,7 @@ export default {
           /** @const {boolean} test */
           const test = something?.find(_ => _)
       `,
-      parser: 'babel-eslint'
+      parser: join(__dirname, '../../../node_modules', 'babel-eslint')
     },
     {
       code: `

--- a/test/rules/data/.eslintrc.json
+++ b/test/rules/data/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "root": true,
+  "rules": {
+    "semi": ["error", "always"]
+  }
+}

--- a/test/rules/data/test.js
+++ b/test/rules/data/test.js
@@ -1,0 +1,2 @@
+// Just a plain JavaScript file which can be targeted by a
+//   test for ESLint rule matching


### PR DESCRIPTION
- fix(require-jsdoc): with eslint 6, we can't use schema for defaults, so revert to old approach
- chore(linting): update eslint devDep
- testing: avoid timeout (not an issue anymore with eslint 6)
- testing(check-examples): use absolute paths with `matchingFileName` (used with `getConfigForFile`/`Linter`) per eslint 6
- testing(check-examples): use a simple `matchingFileName` file which doesn't have problem with loading `babel-eslint` in eslint 6 as does our config
- testing(require-param): use absolute paths with `parser` per eslint 6