### PR TITLE
`ClassExpression` with `require`/`pubilcOnly`

### DIFF
--- a/.README/rules/require-jsdoc.md
+++ b/.README/rules/require-jsdoc.md
@@ -29,13 +29,14 @@ be checked by the rule.
 
   - `ArrowFunctionExpression`
   - `ClassDeclaration`
+  - `ClassExpression`
   - `FunctionDeclaration` (defaults to `true`)
   - `FunctionExpression`
   - `MethodDefinition`
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `ClassDeclaration`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `ClassDeclaration`, `ClassExpression`, `FunctionDeclaration`, `FunctionExpression`|
 |Tags|N/A|
 |Options|`publicOnly`|
 |Settings|`exemptEmptyFunctions`|

--- a/README.md
+++ b/README.md
@@ -3659,13 +3659,14 @@ be checked by the rule.
 
   - `ArrowFunctionExpression`
   - `ClassDeclaration`
+  - `ClassExpression`
   - `FunctionDeclaration` (defaults to `true`)
   - `FunctionExpression`
   - `MethodDefinition`
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `ClassDeclaration`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `ClassDeclaration`, `ClassExpression`, `FunctionDeclaration`, `FunctionExpression`|
 |Tags|N/A|
 |Options|`publicOnly`|
 |Settings|`exemptEmptyFunctions`|
@@ -3690,6 +3691,12 @@ export const test = () => {
 
 };
 // Options: [{"publicOnly":true,"require":{"ArrowFunctionExpression":true}}]
+// Message: Missing JSDoc comment.
+
+export let test = class {
+
+};
+// Options: [{"publicOnly":true,"require":{"ClassExpression":true}}]
 // Message: Missing JSDoc comment.
 
 export default function () {}
@@ -4429,6 +4436,19 @@ let test = function () {
 
 }
 // Options: [{"publicOnly":{"window":true},"require":{"FunctionExpression":true}}]
+
+let test = class {
+
+}
+// Options: [{"publicOnly":true,"require":{"ClassExpression":false}}]
+
+/**
+ *
+ */
+let test = class {
+
+}
+// Options: [{"publicOnly":true,"require":{"ClassExpression":true}}]
 
 export function someMethod() {
 

--- a/src/exportParser.js
+++ b/src/exportParser.js
@@ -81,7 +81,7 @@ const getSymbol = function (node, globals, scope, opt) {
 
     /* istanbul ignore next */
     return null;
-  } case 'ClassDeclaration': case 'FunctionExpression': case 'FunctionDeclaration': case 'ArrowFunctionExpression': {
+  } case 'ClassDeclaration': case 'ClassExpression': case 'FunctionExpression': case 'FunctionDeclaration': case 'ArrowFunctionExpression': {
     const val = createNode();
     val.props.prototype = createNode();
     val.props.prototype.type = 'object';

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -46,6 +46,10 @@ const OPTIONS_SCHEMA = {
           default: false,
           type: 'boolean'
         },
+        ClassExpression: {
+          default: false,
+          type: 'boolean'
+        },
         FunctionDeclaration: {
           default: true,
           type: 'boolean'
@@ -175,6 +179,14 @@ export default iterateJsdoc(null, {
 
       ClassDeclaration (node) {
         if (!requireOption.ClassDeclaration) {
+          return;
+        }
+
+        checkJsDoc(node);
+      },
+
+      ClassExpression (node) {
+        if (!requireOption.ClassExpression) {
           return;
         }
 

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -73,6 +73,28 @@ export default {
     },
     {
       code: `
+          export let test = class {
+
+          };
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc comment.',
+          type: 'ClassExpression'
+        }
+      ],
+      options: [{
+        publicOnly: true,
+        require: {
+          ClassExpression: true
+        }
+      }],
+      parserOptions: {
+        sourceType: 'module'
+      }
+    },
+    {
+      code: `
         export default function () {}
       `,
       errors: [
@@ -1846,6 +1868,35 @@ export default {
     parserOptions: {
       sourceType: 'module'
     }
+  },
+  {
+    code: `
+      let test = class {
+
+      }
+    `,
+    options: [{
+      publicOnly: true,
+      require: {
+        ClassExpression: false
+      }
+    }]
+  },
+  {
+    code: `
+      /**
+       *
+       */
+      let test = class {
+
+      }
+    `,
+    options: [{
+      publicOnly: true,
+      require: {
+        ClassExpression: true
+      }
+    }]
   },
   {
     code: `


### PR DESCRIPTION
feat(require-jsdoc): allow `require` to posses `ClassExpression` boolean property

I think this is a harmless option addition, but thought I'd confirm with a PR as it is a new feature...