### PR TITLE
match-description options

### DIFF
--- a/.README/rules/match-description.md
+++ b/.README/rules/match-description.md
@@ -71,7 +71,7 @@ it by setting it to `false`.
 
 ##### `contexts`
 
-Set this to a string or array of strings representing the AST context
+Set this to an array of strings representing the AST context
 where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
 Overrides the defaults.
 

--- a/.README/rules/match-description.md
+++ b/.README/rules/match-description.md
@@ -6,7 +6,7 @@ The default is this basic expression to match English sentences (Support
 for Unicode upper case may be added in a future version when it can be handled
 by our supported Node versions):
 
-``^([A-Z]|[`\\d_])([\\s\\S]*[.?!`])?$``
+``^([A-Z]|[`\\d_])[\\s\\S]*[.?!`]$``
 
 #### Options
 

--- a/.README/rules/match-description.md
+++ b/.README/rules/match-description.md
@@ -51,19 +51,21 @@ tag should be linted with the `matchDescription` value (or the default).
 ```
 
 If you wish to override the main function description without changing the
-default `mainDescription`, you may use `tags` with `main description`:
+default `match-description`, you may use `mainDescription`:
 
 ```js
 {
-  'jsdoc/match-description': ['error', {tags: {
-    'main description': '[A-Z].*\\.',
-    param: true,
-    returns: true
-  }}]
+  'jsdoc/match-description': ['error', {
+    mainDescription: '[A-Z].*\\.',
+    tags: {
+      param: true,
+      returns: true
+    }
+  }]
 }
 ```
 
-There is no need to add `"main description": true`, as by default, the main
+There is no need to add `mainDescription: true`, as by default, the main
 function (and only the main function) is linted, though you may disable checking
 it by setting it to `false`.
 

--- a/.README/rules/match-description.md
+++ b/.README/rules/match-description.md
@@ -50,14 +50,39 @@ tag should be linted with the `matchDescription` value (or the default).
 }
 ```
 
+If you wish to override the main function description without changing the
+default `mainDescription`, you may use `tags` with `main description`:
 
-By default, only the main function description is linted.
+```js
+{
+  'jsdoc/match-description': ['error', {tags: {
+    'main description': '[A-Z].*\\.',
+    param: true,
+    returns: true
+  }}]
+}
+```
+
+There is no need to add `"main description": true`, as by default, the main
+function (and only the main function) is linted, though you may disable checking
+it by setting it to `false`.
+
+##### `contexts`
+
+Set this to a string or array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+
+##### `noDefaults`
+
+By default, `contexts` will permit `ArrowFunctionExpression`,
+`FunctionDeclaration`, and `FunctionExpression`. Set this instead to `true` to
+have `contexts` override these.
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|N/A by default but see `tags` options|
 |Settings||
-|Options|`tags` (allows for 'param', 'arg', 'argument', 'returns', 'return'), `matchDescription`|
+|Options|`contexts`, `noDefaults`, `tags` (allows for 'param', 'arg', 'argument', 'returns', 'return'), `matchDescription`|
 
 <!-- assertions matchDescription -->

--- a/.README/rules/match-description.md
+++ b/.README/rules/match-description.md
@@ -73,18 +73,13 @@ it by setting it to `false`.
 
 Set this to a string or array of strings representing the AST context
 where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
-
-##### `noDefaults`
-
-By default, `contexts` will permit `ArrowFunctionExpression`,
-`FunctionDeclaration`, and `FunctionExpression`. Set this instead to `true` to
-have `contexts` override these.
+Overrides the defaults.
 
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|N/A by default but see `tags` options|
 |Settings||
-|Options|`contexts`, `noDefaults`, `tags` (allows for 'param', 'arg', 'argument', 'returns', 'return'), `matchDescription`|
+|Options|`contexts`, `tags` (allows for 'param', 'arg', 'argument', 'returns', 'return'), `matchDescription`|
 
 <!-- assertions matchDescription -->

--- a/.README/rules/require-description.md
+++ b/.README/rules/require-description.md
@@ -9,19 +9,17 @@ Requires that all functions have a description.
 
 An options object may have any of the following properties:
 
-- `contexts` - Set to a string or array of strings representing the AST context
+- `contexts` - Set to an array of strings representing the AST context
   where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+  Overrides the defaults.
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
     block avoids the need for a `@description`.
-- `noDefaults` - By default, `contexts` will permit `ArrowFunctionExpression`,
-  `FunctionDeclaration`, and `FunctionExpression`. Set this instead to `true` to
-  have `contexts` override these.
 
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`description`|
 |Aliases|`desc`|
-|Options|`contexts`, `exemptedBy`, `noDefaults`|
+|Options|`contexts`, `exemptedBy`|
 
 <!-- assertions requireDescription -->

--- a/.README/rules/require-jsdoc.md
+++ b/.README/rules/require-jsdoc.md
@@ -34,6 +34,11 @@ be checked by the rule.
   - `FunctionExpression`
   - `MethodDefinition`
 
+- `contexts` - Set this to a string or array of strings representing the additional
+  AST context where you wish the rule to be applied (e.g., `Property` for properties).
+  Note that unlike `require-description` and `match-description`, this rule has no
+  `noDefaults` option because its defaults are instead set up by `require`.
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `ClassDeclaration`, `ClassExpression`, `FunctionDeclaration`, `FunctionExpression`|

--- a/.README/rules/require-jsdoc.md
+++ b/.README/rules/require-jsdoc.md
@@ -36,8 +36,6 @@ be checked by the rule.
 
 - `contexts` - Set this to a string or array of strings representing the additional
   AST context where you wish the rule to be applied (e.g., `Property` for properties).
-  Note that unlike `require-description` and `match-description`, this rule has no
-  `noDefaults` option because its defaults are instead set up by `require`.
 
 |||
 |---|---|

--- a/.README/rules/require-jsdoc.md
+++ b/.README/rules/require-jsdoc.md
@@ -34,7 +34,7 @@ be checked by the rule.
   - `FunctionExpression`
   - `MethodDefinition`
 
-- `contexts` - Set this to a string or array of strings representing the additional
+- `contexts` - Set this to an array of strings representing the additional
   AST context where you wish the rule to be applied (e.g., `Property` for properties).
 
 |||

--- a/README.md
+++ b/README.md
@@ -2332,15 +2332,42 @@ tag should be linted with the `matchDescription` value (or the default).
 }
 ```
 
+If you wish to override the main function description without changing the
+default `mainDescription`, you may use `tags` with `main description`:
 
-By default, only the main function description is linted.
+```js
+{
+  'jsdoc/match-description': ['error', {tags: {
+    'main description': '[A-Z].*\\.',
+    param: true,
+    returns: true
+  }}]
+}
+```
+
+There is no need to add `"main description": true`, as by default, the main
+function (and only the main function) is linted, though you may disable checking
+it by setting it to `false`.
+
+<a name="eslint-plugin-jsdoc-rules-match-description-options-1-contexts"></a>
+##### <code>contexts</code>
+
+Set this to a string or array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+
+<a name="eslint-plugin-jsdoc-rules-match-description-options-1-nodefaults"></a>
+##### <code>noDefaults</code>
+
+By default, `contexts` will permit `ArrowFunctionExpression`,
+`FunctionDeclaration`, and `FunctionExpression`. Set this instead to `true` to
+have `contexts` override these.
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|N/A by default but see `tags` options|
 |Settings||
-|Options|`tags` (allows for 'param', 'arg', 'argument', 'returns', 'return'), `matchDescription`|
+|Options|`contexts`, `noDefaults`, `tags` (allows for 'param', 'arg', 'argument', 'returns', 'return'), `matchDescription`|
 
 The following patterns are considered problems:
 
@@ -2368,6 +2395,18 @@ function quux () {
 
 }
 // Options: [{"matchDescription":"[А-Я][А-я]+\\."}]
+<<<<<<< HEAD
+=======
+// Message: JSDoc description does not satisfy the regex pattern.
+
+/**
+ * тест.
+ */
+function quux () {
+
+}
+// Options: [{"tags":{"main description":"[А-Я][А-я]+\\.","param":true}}]
+>>>>>>> feat(match-description): allow `main description: string|boolean` to override or disable main description separate from default
 // Message: JSDoc description does not satisfy the regex pattern.
 
 /**
@@ -2387,6 +2426,28 @@ function quux (foo) {
 
 }
 // Options: [{"tags":{"param":true}}]
+// Message: JSDoc description does not satisfy the regex pattern.
+
+/**
+ * Foo
+ *
+ * @param foo foo.
+ */
+function quux (foo) {
+
+}
+// Options: [{"tags":{"main description":"^[a-zA-Z]*$","param":true}}]
+// Message: JSDoc description does not satisfy the regex pattern.
+
+/**
+ * Foo
+ *
+ * @param foo foo.
+ */
+function quux (foo) {
+
+}
+// Options: [{"tags":{"main description":false,"param":true}}]
 // Message: JSDoc description does not satisfy the regex pattern.
 
 /**
@@ -2489,6 +2550,18 @@ function quux () {
 
 }
 // Options: [{"tags":{"param":"[А-Я][А-я]+\\."}}]
+<<<<<<< HEAD
+=======
+// Message: JSDoc description does not satisfy the regex pattern.
+
+/**
+ * foo.
+ */
+class quux {
+
+}
+// Options: [{"contexts":["ClassDeclaration"],"noDefaults":true}]
+>>>>>>> feat(match-description): allow `main description: string|boolean` to override or disable main description separate from default
 // Message: JSDoc description does not satisfy the regex pattern.
 ````
 
@@ -2618,6 +2691,30 @@ function quux () {
 function quux () {
 
 }
+
+/**
+ * foo.
+ */
+function quux () {
+
+}
+// Options: [{"tags":{"main description":false}}]
+
+/**
+ * foo.
+ */
+class quux {
+
+}
+// Message: JSDoc description does not satisfy the regex pattern.
+
+/**
+ * foo.
+ */
+class quux {
+
+}
+// Options: [{"tags":{"main description":true}}]
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -2285,7 +2285,7 @@ The default is this basic expression to match English sentences (Support
 for Unicode upper case may be added in a future version when it can be handled
 by our supported Node versions):
 
-``^([A-Z]|[`\\d_])([\\s\\S]*[.?!`])?$``
+``^([A-Z]|[`\\d_])[\\s\\S]*[.?!`]$``
 
 <a name="eslint-plugin-jsdoc-rules-match-description-options-1"></a>
 #### Options
@@ -2400,7 +2400,7 @@ function quux () {
 // Message: JSDoc description does not satisfy the regex pattern.
 
 /**
- * тест.
+ * Abc.
  */
 function quux () {
 
@@ -2563,6 +2563,33 @@ class quux {
 // Options: [{"contexts":["ClassDeclaration"],"noDefaults":true}]
 >>>>>>> feat(match-description): allow `main description: string|boolean` to override or disable main description separate from default
 // Message: JSDoc description does not satisfy the regex pattern.
+
+class MyClass {
+  /**
+   * Abc
+   */
+  myClassField = 1
+}
+// Options: [{"contexts":["ClassProperty"],"noDefaults":true}]
+// Message: JSDoc description does not satisfy the regex pattern.
+
+/**
+ * foo.
+ */
+interface quux {
+
+}
+// Options: [{"contexts":["TSInterfaceDeclaration"],"noDefaults":true}]
+// Message: JSDoc description does not satisfy the regex pattern.
+
+const myObject = {
+  /**
+   * Bad description
+   */
+  myProp: true
+};
+// Options: [{"contexts":["Property"],"noDefaults":true}]
+// Message: JSDoc description does not satisfy the regex pattern.
 ````
 
 The following patterns are not considered problems:
@@ -2715,6 +2742,30 @@ class quux {
 
 }
 // Options: [{"tags":{"main description":true}}]
+
+class MyClass {
+  /**
+   * Abc.
+   */
+  myClassField = 1
+}
+// Options: [{"contexts":["ClassProperty"],"noDefaults":true}]
+
+/**
+ * Foo.
+ */
+interface quux {
+
+}
+// Options: [{"contexts":["TSInterfaceDeclaration"],"noDefaults":true}]
+
+const myObject = {
+  /**
+   * Bad description
+   */
+  myProp: true
+};
+// Options: [{"contexts":[],"noDefaults":true}]
 ````
 
 
@@ -3523,6 +3574,7 @@ interface quux {
 }
 // Options: [{"contexts":["TSInterfaceDeclaration"],"noDefaults":true}]
 // Message: Missing JSDoc @description declaration.
+<<<<<<< HEAD
 
 /**
  *
@@ -3541,6 +3593,8 @@ var quux = {
 };
 // Options: [{"contexts":["ObjectExpression"]}]
 // Message: Missing JSDoc @description declaration.
+=======
+>>>>>>> fix(match-description): tighten default regex to require punctuation at the end even if only a single character
 ````
 
 The following patterns are not considered problems:
@@ -3602,6 +3656,7 @@ function quux () {
 interface quux {
 
 }
+<<<<<<< HEAD
 
 /**
  *
@@ -3616,6 +3671,9 @@ var quux = class {
 var quux = {
 
 };
+=======
+// Message: Missing JSDoc @description declaration.
+>>>>>>> fix(match-description): tighten default regex to require punctuation at the end even if only a single character
 ````
 
 
@@ -3882,6 +3940,11 @@ be checked by the rule.
   - `FunctionDeclaration` (defaults to `true`)
   - `FunctionExpression`
   - `MethodDefinition`
+
+- `contexts` - Set this to a string or array of strings representing the additional
+  AST context where you wish the rule to be applied (e.g., `Property` for properties).
+  Note that unlike `require-description` and `match-description`, this rule has no
+  `noDefaults` option because its defaults are instead set up by `require`.
 
 |||
 |---|---|
@@ -4213,6 +4276,12 @@ export function someMethod() {
 
 }
 // Options: [{"publicOnly":{"cjs":false,"esm":true,"window":false},"require":{"FunctionDeclaration":true}}]
+// Message: Missing JSDoc comment.
+
+const myObject = {
+  myProp: true
+};
+// Options: [{"contexts":["Property"]}]
 // Message: Missing JSDoc comment.
 ````
 
@@ -4683,6 +4752,11 @@ exports.someMethod = function() {
 
 }
 // Options: [{"publicOnly":{"cjs":false,"esm":true,"window":false},"require":{"FunctionExpression":true}}]
+
+const myObject = {
+  myProp: true
+};
+// Options: [{"contexts":[]}]
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -2333,45 +2333,59 @@ tag should be linted with the `matchDescription` value (or the default).
 ```
 
 If you wish to override the main function description without changing the
-default `mainDescription`, you may use `tags` with `main description`:
+default `match-description`, you may use `mainDescription`:
 
 ```js
 {
-  'jsdoc/match-description': ['error', {tags: {
-    'main description': '[A-Z].*\\.',
-    param: true,
-    returns: true
-  }}]
+  'jsdoc/match-description': ['error', {
+    mainDescription: '[A-Z].*\\.',
+    tags: {
+      param: true,
+      returns: true
+    }
+  }]
 }
 ```
 
-There is no need to add `"main description": true`, as by default, the main
+There is no need to add `mainDescription: true`, as by default, the main
 function (and only the main function) is linted, though you may disable checking
 it by setting it to `false`.
 
 <a name="eslint-plugin-jsdoc-rules-match-description-options-1-contexts"></a>
 ##### <code>contexts</code>
 
-Set this to a string or array of strings representing the AST context
+Set this to an array of strings representing the AST context
 where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
-
-<a name="eslint-plugin-jsdoc-rules-match-description-options-1-nodefaults"></a>
-##### <code>noDefaults</code>
-
-By default, `contexts` will permit `ArrowFunctionExpression`,
-`FunctionDeclaration`, and `FunctionExpression`. Set this instead to `true` to
-have `contexts` override these.
+Overrides the defaults.
 
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|N/A by default but see `tags` options|
 |Settings||
-|Options|`contexts`, `noDefaults`, `tags` (allows for 'param', 'arg', 'argument', 'returns', 'return'), `matchDescription`|
+|Options|`contexts`, `tags` (allows for 'param', 'arg', 'argument', 'returns', 'return'), `matchDescription`|
 
 The following patterns are considered problems:
 
 ````js
+/**
+ * foo.
+ */
+const q = class {
+
+}
+// Options: [{"contexts":["ClassExpression"]}]
+// Message: JSDoc description does not satisfy the regex pattern.
+
+/**
+ * foo.
+ */
+const q = {
+
+};
+// Options: [{"contexts":["ObjectExpression"]}]
+// Message: JSDoc description does not satisfy the regex pattern.
+
 /**
  * foo.
  */
@@ -2395,8 +2409,6 @@ function quux () {
 
 }
 // Options: [{"matchDescription":"[А-Я][А-я]+\\."}]
-<<<<<<< HEAD
-=======
 // Message: JSDoc description does not satisfy the regex pattern.
 
 /**
@@ -2405,8 +2417,7 @@ function quux () {
 function quux () {
 
 }
-// Options: [{"tags":{"main description":"[А-Я][А-я]+\\.","param":true}}]
->>>>>>> feat(match-description): allow `main description: string|boolean` to override or disable main description separate from default
+// Options: [{"mainDescription":"[А-Я][А-я]+\\.","tags":{"param":true}}]
 // Message: JSDoc description does not satisfy the regex pattern.
 
 /**
@@ -2436,7 +2447,7 @@ function quux (foo) {
 function quux (foo) {
 
 }
-// Options: [{"tags":{"main description":"^[a-zA-Z]*$","param":true}}]
+// Options: [{"mainDescription":"^[a-zA-Z]*$","tags":{"param":true}}]
 // Message: JSDoc description does not satisfy the regex pattern.
 
 /**
@@ -2447,7 +2458,7 @@ function quux (foo) {
 function quux (foo) {
 
 }
-// Options: [{"tags":{"main description":false,"param":true}}]
+// Options: [{"mainDescription":false,"tags":{"param":true}}]
 // Message: JSDoc description does not satisfy the regex pattern.
 
 /**
@@ -2550,8 +2561,6 @@ function quux () {
 
 }
 // Options: [{"tags":{"param":"[А-Я][А-я]+\\."}}]
-<<<<<<< HEAD
-=======
 // Message: JSDoc description does not satisfy the regex pattern.
 
 /**
@@ -2560,8 +2569,7 @@ function quux () {
 class quux {
 
 }
-// Options: [{"contexts":["ClassDeclaration"],"noDefaults":true}]
->>>>>>> feat(match-description): allow `main description: string|boolean` to override or disable main description separate from default
+// Options: [{"contexts":["ClassDeclaration"]}]
 // Message: JSDoc description does not satisfy the regex pattern.
 
 class MyClass {
@@ -2570,7 +2578,7 @@ class MyClass {
    */
   myClassField = 1
 }
-// Options: [{"contexts":["ClassProperty"],"noDefaults":true}]
+// Options: [{"contexts":["ClassProperty"]}]
 // Message: JSDoc description does not satisfy the regex pattern.
 
 /**
@@ -2579,7 +2587,7 @@ class MyClass {
 interface quux {
 
 }
-// Options: [{"contexts":["TSInterfaceDeclaration"],"noDefaults":true}]
+// Options: [{"contexts":["TSInterfaceDeclaration"]}]
 // Message: JSDoc description does not satisfy the regex pattern.
 
 const myObject = {
@@ -2588,7 +2596,7 @@ const myObject = {
    */
   myProp: true
 };
-// Options: [{"contexts":["Property"],"noDefaults":true}]
+// Options: [{"contexts":["Property"]}]
 // Message: JSDoc description does not satisfy the regex pattern.
 ````
 
@@ -2725,7 +2733,7 @@ function quux () {
 function quux () {
 
 }
-// Options: [{"tags":{"main description":false}}]
+// Options: [{"mainDescription":false}]
 
 /**
  * foo.
@@ -2733,7 +2741,6 @@ function quux () {
 class quux {
 
 }
-// Message: JSDoc description does not satisfy the regex pattern.
 
 /**
  * foo.
@@ -2741,7 +2748,7 @@ class quux {
 class quux {
 
 }
-// Options: [{"tags":{"main description":true}}]
+// Options: [{"mainDescription":true}]
 
 class MyClass {
   /**
@@ -2749,7 +2756,7 @@ class MyClass {
    */
   myClassField = 1
 }
-// Options: [{"contexts":["ClassProperty"],"noDefaults":true}]
+// Options: [{"contexts":["ClassProperty"]}]
 
 /**
  * Foo.
@@ -2757,7 +2764,7 @@ class MyClass {
 interface quux {
 
 }
-// Options: [{"contexts":["TSInterfaceDeclaration"],"noDefaults":true}]
+// Options: [{"contexts":["TSInterfaceDeclaration"]}]
 
 const myObject = {
   /**
@@ -2765,7 +2772,23 @@ const myObject = {
    */
   myProp: true
 };
-// Options: [{"contexts":[],"noDefaults":true}]
+// Options: [{"contexts":[]}]
+
+/**
+ * foo.
+ */
+const q = class {
+
+}
+// Options: [{"contexts":[]}]
+
+/**
+ * foo.
+ */
+const q = {
+
+};
+// Options: [{"contexts":[]}]
 ````
 
 
@@ -3505,20 +3528,18 @@ Requires that all functions have a description.
 
 An options object may have any of the following properties:
 
-- `contexts` - Set to a string or array of strings representing the AST context
+- `contexts` - Set to an array of strings representing the AST context
   where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+  Overrides the defaults.
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
     block avoids the need for a `@description`.
-- `noDefaults` - By default, `contexts` will permit `ArrowFunctionExpression`,
-  `FunctionDeclaration`, and `FunctionExpression`. Set this instead to `true` to
-  have `contexts` override these.
 
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`description`|
 |Aliases|`desc`|
-|Options|`contexts`, `exemptedBy`, `noDefaults`|
+|Options|`contexts`, `exemptedBy`|
 
 The following patterns are considered problems:
 
@@ -3537,7 +3558,7 @@ function quux () {
 class quux {
 
 }
-// Options: [{"contexts":"ClassDeclaration"}]
+// Options: [{"contexts":["ClassDeclaration"]}]
 // Message: Missing JSDoc @description declaration.
 
 /**
@@ -3546,7 +3567,7 @@ class quux {
 class quux {
 
 }
-// Options: [{"contexts":"ClassDeclaration","noDefaults":true}]
+// Options: [{"contexts":["ClassDeclaration"]}]
 // Message: Missing JSDoc @description declaration.
 
 /**
@@ -3572,9 +3593,8 @@ function quux () {
 interface quux {
 
 }
-// Options: [{"contexts":["TSInterfaceDeclaration"],"noDefaults":true}]
+// Options: [{"contexts":["TSInterfaceDeclaration"]}]
 // Message: Missing JSDoc @description declaration.
-<<<<<<< HEAD
 
 /**
  *
@@ -3593,8 +3613,6 @@ var quux = {
 };
 // Options: [{"contexts":["ObjectExpression"]}]
 // Message: Missing JSDoc @description declaration.
-=======
->>>>>>> fix(match-description): tighten default regex to require punctuation at the end even if only a single character
 ````
 
 The following patterns are not considered problems:
@@ -3640,7 +3658,7 @@ class quux {
 function quux () {
 
 }
-// Options: [{"noDefaults":true}]
+// Options: [{"contexts":["ClassDeclaration"]}]
 
 /**
  * @type {MyCallback}
@@ -3656,7 +3674,6 @@ function quux () {
 interface quux {
 
 }
-<<<<<<< HEAD
 
 /**
  *
@@ -3671,9 +3688,6 @@ var quux = class {
 var quux = {
 
 };
-=======
-// Message: Missing JSDoc @description declaration.
->>>>>>> fix(match-description): tighten default regex to require punctuation at the end even if only a single character
 ````
 
 
@@ -3941,10 +3955,8 @@ be checked by the rule.
   - `FunctionExpression`
   - `MethodDefinition`
 
-- `contexts` - Set this to a string or array of strings representing the additional
+- `contexts` - Set this to an array of strings representing the additional
   AST context where you wish the rule to be applied (e.g., `Property` for properties).
-  Note that unlike `require-description` and `match-description`, this rule has no
-  `noDefaults` option because its defaults are instead set up by `require`.
 
 |||
 |---|---|

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -464,11 +464,7 @@ export default function iterateJsdoc (iterator, ruleConfig) {
         };
       }
 
-      return contexts.reduce((obj, prop) => {
-        obj[prop] = checkJsdoc;
-
-        return obj;
-      }, {});
+      return jsdocUtils.getContextObject(contexts, checkJsdoc);
     },
     meta: ruleConfig.meta
   };

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -511,8 +511,17 @@ const enforcedContexts = (context, defaultContexts) => {
     [...new Set([...defltContexts, ...contexts])];
 };
 
+const getContextObject = (contexts, checkJsdoc) => {
+  return contexts.reduce((obj, prop) => {
+    obj[prop] = checkJsdoc;
+
+    return obj;
+  }, {});
+};
+
 export default {
   enforcedContexts,
+  getContextObject,
   getFunctionParameterNames,
   getJsdocParameterNames,
   getJsdocParameterNamesDeep,

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -493,22 +493,16 @@ const parseClosureTemplateTag = (tag) => {
  * @returns {string[]}
  */
 const enforcedContexts = (context, defaultContexts) => {
-  /* istanbul ignore next */
-  const defltContexts = defaultContexts === true ? [
-    'ArrowFunctionExpression',
-    'FunctionDeclaration',
-    'FunctionExpression'
-  ] : defaultContexts;
   const {
-    noDefaults,
-    contexts: ctxts = []
+    /* istanbul ignore next */
+    contexts = defaultContexts === true ? [
+      'ArrowFunctionExpression',
+      'FunctionDeclaration',
+      'FunctionExpression'
+    ] : defaultContexts
   } = context.options[0] || {};
 
-  const contexts = typeof ctxts === 'string' ? [ctxts] : ctxts;
-
-  return noDefaults ?
-    contexts :
-    [...new Set([...defltContexts, ...contexts])];
+  return contexts;
 };
 
 const getContextObject = (contexts, checkJsdoc) => {

--- a/src/rules/matchDescription.js
+++ b/src/rules/matchDescription.js
@@ -23,7 +23,7 @@ export default iterateJsdoc(({
 
       // If supporting Node >= 10, we could loosen to this for the
       //   initial letter: \\p{Upper}
-      ) || '^[A-Z`\\d_](?:[\\s\\S]*[.?!`])?$',
+      ) || '^[A-Z`\\d_][\\s\\S]*[.?!`]$',
       'u'
     );
 

--- a/src/rules/matchDescription.js
+++ b/src/rules/matchDescription.js
@@ -71,17 +71,10 @@ export default iterateJsdoc(({
         additionalProperties: false,
         properties: {
           contexts: {
-            oneOf: [
-              {
-                items: {
-                  type: 'string'
-                },
-                type: 'array'
-              },
-              {
-                type: 'string'
-              }
-            ]
+            items: {
+              type: 'string'
+            },
+            type: 'array'
           },
           mainDescription: {
             oneOf: [

--- a/src/rules/matchDescription.js
+++ b/src/rules/matchDescription.js
@@ -98,10 +98,6 @@ export default iterateJsdoc(({
             format: 'regex',
             type: 'string'
           },
-          noDefaults: {
-            default: false,
-            type: 'boolean'
-          },
           tags: {
             patternProperties: {
               '.*': {

--- a/src/rules/requireDescription.js
+++ b/src/rules/requireDescription.js
@@ -37,26 +37,16 @@ export default iterateJsdoc(({
         additionalProperties: false,
         properties: {
           contexts: {
-            oneOf: [
-              {
-                items: {
-                  type: 'string'
-                },
-                type: 'array'
-              },
-              {
-                type: 'string'
-              }
-            ]
+            items: {
+              type: 'string'
+            },
+            type: 'array'
           },
           exemptedBy: {
             items: {
               type: 'string'
             },
             type: 'array'
-          },
-          noDefaults: {
-            type: 'boolean'
           }
         },
         type: 'object'

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -7,6 +7,19 @@ import getJSDocComment from '../eslint/getJSDocComment';
 const OPTIONS_SCHEMA = {
   additionalProperties: false,
   properties: {
+    contexts: {
+      oneOf: [
+        {
+          items: {
+            type: 'string'
+          },
+          type: 'array'
+        },
+        {
+          type: 'string'
+        }
+      ]
+    },
     publicOnly: {
       oneOf: [
         {
@@ -164,60 +177,64 @@ export default iterateJsdoc(null, {
       }
     };
 
-    return {
-      ArrowFunctionExpression (node) {
-        if (!requireOption.ArrowFunctionExpression) {
-          return;
-        }
+    // eslint-disable-next-line fp/no-mutating-assign
+    return Object.assign(
+      jsdocUtils.getContextObject(jsdocUtils.enforcedContexts(context, []), checkJsDoc),
+      {
+        ArrowFunctionExpression (node) {
+          if (!requireOption.ArrowFunctionExpression) {
+            return;
+          }
 
-        if (!['VariableDeclarator', 'ExportDefaultDeclaration'].includes(node.parent.type)) {
-          return;
-        }
+          if (!['VariableDeclarator', 'ExportDefaultDeclaration'].includes(node.parent.type)) {
+            return;
+          }
 
-        checkJsDoc(node);
-      },
-
-      ClassDeclaration (node) {
-        if (!requireOption.ClassDeclaration) {
-          return;
-        }
-
-        checkJsDoc(node);
-      },
-
-      ClassExpression (node) {
-        if (!requireOption.ClassExpression) {
-          return;
-        }
-
-        checkJsDoc(node);
-      },
-
-      FunctionDeclaration (node) {
-        if (!requireOption.FunctionDeclaration) {
-          return;
-        }
-
-        checkJsDoc(node);
-      },
-
-      FunctionExpression (node) {
-        if (requireOption.MethodDefinition && node.parent.type === 'MethodDefinition') {
           checkJsDoc(node);
+        },
 
-          return;
-        }
+        ClassDeclaration (node) {
+          if (!requireOption.ClassDeclaration) {
+            return;
+          }
 
-        if (!requireOption.FunctionExpression) {
-          return;
-        }
-
-        if (['VariableDeclarator', 'AssignmentExpression', 'ExportDefaultDeclaration'].includes(node.parent.type)) {
           checkJsDoc(node);
-        } else if (node.parent.type === 'Property' && node === node.parent.value) {
+        },
+
+        ClassExpression (node) {
+          if (!requireOption.ClassExpression) {
+            return;
+          }
+
           checkJsDoc(node);
+        },
+
+        FunctionDeclaration (node) {
+          if (!requireOption.FunctionDeclaration) {
+            return;
+          }
+
+          checkJsDoc(node);
+        },
+
+        FunctionExpression (node) {
+          if (requireOption.MethodDefinition && node.parent.type === 'MethodDefinition') {
+            checkJsDoc(node);
+
+            return;
+          }
+
+          if (!requireOption.FunctionExpression) {
+            return;
+          }
+
+          if (['VariableDeclarator', 'AssignmentExpression', 'ExportDefaultDeclaration'].includes(node.parent.type)) {
+            checkJsDoc(node);
+          } else if (node.parent.type === 'Property' && node === node.parent.value) {
+            checkJsDoc(node);
+          }
         }
       }
-    };
+    );
   }
 });

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -8,17 +8,10 @@ const OPTIONS_SCHEMA = {
   additionalProperties: false,
   properties: {
     contexts: {
-      oneOf: [
-        {
-          items: {
-            type: 'string'
-          },
-          type: 'array'
-        },
-        {
-          type: 'string'
-        }
-      ]
+      items: {
+        type: 'string'
+      },
+      type: 'array'
     },
     publicOnly: {
       oneOf: [

--- a/test/rules/assertions/matchDescription.js
+++ b/test/rules/assertions/matchDescription.js
@@ -459,8 +459,7 @@ export default {
         {
           contexts: [
             'ClassDeclaration'
-          ],
-          noDefaults: true
+          ]
         }
       ]
     },
@@ -483,8 +482,7 @@ export default {
         {
           contexts: [
             'ClassProperty'
-          ],
-          noDefaults: true
+          ]
         }
       ],
       parser: require.resolve('@typescript-eslint/parser')
@@ -508,8 +506,7 @@ export default {
         {
           contexts: [
             'TSInterfaceDeclaration'
-          ],
-          noDefaults: true
+          ]
         }
       ],
       parser: require.resolve('@typescript-eslint/parser')
@@ -533,8 +530,7 @@ export default {
         {
           contexts: [
             'Property'
-          ],
-          noDefaults: true
+          ]
         }
       ]
     }
@@ -776,8 +772,7 @@ export default {
         {
           contexts: [
             'ClassProperty'
-          ],
-          noDefaults: true
+          ]
         }
       ],
       parser: require.resolve('@typescript-eslint/parser')
@@ -795,8 +790,7 @@ export default {
         {
           contexts: [
             'TSInterfaceDeclaration'
-          ],
-          noDefaults: true
+          ]
         }
       ],
       parser: require.resolve('@typescript-eslint/parser')
@@ -813,8 +807,7 @@ export default {
       options: [
         {
           contexts: [
-          ],
-          noDefaults: true
+          ]
         }
       ]
     },

--- a/test/rules/assertions/matchDescription.js
+++ b/test/rules/assertions/matchDescription.js
@@ -5,6 +5,52 @@ export default {
           /**
            * foo.
            */
+          const q = class {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'JSDoc description does not satisfy the regex pattern.'
+        }
+      ],
+      options: [
+        {
+          contexts: [
+            'ClassExpression'
+          ]
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * foo.
+           */
+          const q = {
+
+          };
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'JSDoc description does not satisfy the regex pattern.'
+        }
+      ],
+      options: [
+        {
+          contexts: [
+            'ObjectExpression'
+          ]
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * foo.
+           */
           function quux () {
 
           }
@@ -769,6 +815,38 @@ export default {
           contexts: [
           ],
           noDefaults: true
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * foo.
+           */
+          const q = class {
+
+          }
+      `,
+      options: [
+        {
+          contexts: [
+          ]
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * foo.
+           */
+          const q = {
+
+          };
+      `,
+      options: [
+        {
+          contexts: [
+          ]
         }
       ]
     }

--- a/test/rules/assertions/matchDescription.js
+++ b/test/rules/assertions/matchDescription.js
@@ -54,6 +54,28 @@ export default {
     {
       code: `
           /**
+           * Abc.
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'JSDoc description does not satisfy the regex pattern.'
+        }
+      ],
+      options: [{
+        mainDescription: '[\u0410-\u042F][\u0410-\u044F]+\\.',
+        tags: {
+          param: true
+        }
+      }]
+    },
+    {
+      code: `
+          /**
            * Foo
            */
           function quux () {
@@ -111,8 +133,8 @@ export default {
       ],
       options: [
         {
+          mainDescription: '^[a-zA-Z]*$',
           tags: {
-            'main description': '^[a-zA-Z]*$',
             param: true
           }
         }
@@ -137,8 +159,8 @@ export default {
       ],
       options: [
         {
+          mainDescription: false,
           tags: {
-            'main description': false,
             param: true
           }
         }
@@ -669,9 +691,7 @@ export default {
           }
       `,
       options: [
-        {tags: {
-          'main description': false
-        }}
+        {mainDescription: false}
       ]
     },
     {
@@ -694,9 +714,7 @@ export default {
           }
       `,
       options: [
-        {tags: {
-          'main description': true
-        }}
+        {mainDescription: true}
       ]
     },
     {

--- a/test/rules/assertions/matchDescription.js
+++ b/test/rules/assertions/matchDescription.js
@@ -11,6 +11,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'JSDoc description does not satisfy the regex pattern.'
         }
       ]
@@ -26,6 +27,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'JSDoc description does not satisfy the regex pattern.'
         }
       ]
@@ -41,6 +43,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'JSDoc description does not satisfy the regex pattern.'
         }
       ],
@@ -59,6 +62,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'JSDoc description does not satisfy the regex pattern.'
         }
       ]
@@ -76,12 +80,65 @@ export default {
       `,
       errors: [
         {
+          line: 5,
           message: 'JSDoc description does not satisfy the regex pattern.'
         }
       ],
       options: [
         {
           tags: {
+            param: true
+          }
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * Foo
+           *
+           * @param foo foo.
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 5,
+          message: 'JSDoc description does not satisfy the regex pattern.'
+        }
+      ],
+      options: [
+        {
+          tags: {
+            'main description': '^[a-zA-Z]*$',
+            param: true
+          }
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * Foo
+           *
+           * @param foo foo.
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 5,
+          message: 'JSDoc description does not satisfy the regex pattern.'
+        }
+      ],
+      options: [
+        {
+          tags: {
+            'main description': false,
             param: true
           }
         }
@@ -100,6 +157,7 @@ export default {
       `,
       errors: [
         {
+          line: 5,
           message: 'JSDoc description does not satisfy the regex pattern.'
         }
       ],
@@ -122,6 +180,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'JSDoc description does not satisfy the regex pattern.'
         }
       ]
@@ -139,6 +198,7 @@ export default {
       `,
       errors: [
         {
+          line: 5,
           message: 'JSDoc description does not satisfy the regex pattern.'
         }
       ],
@@ -163,6 +223,7 @@ export default {
       `,
       errors: [
         {
+          line: 5,
           message: 'JSDoc description does not satisfy the regex pattern.'
         }
       ],
@@ -190,6 +251,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'JSDoc description does not satisfy the regex pattern.'
         }
       ]
@@ -205,6 +267,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'JSDoc description does not satisfy the regex pattern.'
         }
       ],
@@ -227,6 +290,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'JSDoc description does not satisfy the regex pattern.'
         }
       ],
@@ -249,6 +313,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'JSDoc description does not satisfy the regex pattern.'
         }
       ],
@@ -273,6 +338,7 @@ export default {
       `,
       errors: [
         {
+          line: 5,
           message: 'JSDoc description does not satisfy the regex pattern.'
         }
       ],
@@ -296,6 +362,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'JSDoc description does not satisfy the regex pattern.'
         }
       ],
@@ -304,6 +371,30 @@ export default {
           param: '[\u0410-\u042F][\u0410-\u044F]+\\.'
         }
       }]
+    },
+    {
+      code: `
+          /**
+           * foo.
+           */
+          class quux {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'JSDoc description does not satisfy the regex pattern.'
+        }
+      ],
+      options: [
+        {
+          contexts: [
+            'ClassDeclaration'
+          ],
+          noDefaults: true
+        }
+      ]
     }
   ],
   valid: [
@@ -493,6 +584,46 @@ export default {
 
           }
       `
+    },
+    {
+      code: `
+          /**
+           * foo.
+           */
+          function quux () {
+
+          }
+      `,
+      options: [
+        {tags: {
+          'main description': false
+        }}
+      ]
+    },
+    {
+      code: `
+          /**
+           * foo.
+           */
+          class quux {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * foo.
+           */
+          class quux {
+
+          }
+      `,
+      options: [
+        {tags: {
+          'main description': true
+        }}
+      ]
     }
   ]
 };

--- a/test/rules/assertions/matchDescription.js
+++ b/test/rules/assertions/matchDescription.js
@@ -395,6 +395,80 @@ export default {
           noDefaults: true
         }
       ]
+    },
+    {
+      code: `
+      class MyClass {
+        /**
+         * Abc
+         */
+        myClassField = 1
+      }
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'JSDoc description does not satisfy the regex pattern.'
+        }
+      ],
+      options: [
+        {
+          contexts: [
+            'ClassProperty'
+          ],
+          noDefaults: true
+        }
+      ],
+      parser: require.resolve('@typescript-eslint/parser')
+    },
+    {
+      code: `
+          /**
+           * foo.
+           */
+          interface quux {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'JSDoc description does not satisfy the regex pattern.'
+        }
+      ],
+      options: [
+        {
+          contexts: [
+            'TSInterfaceDeclaration'
+          ],
+          noDefaults: true
+        }
+      ],
+      parser: require.resolve('@typescript-eslint/parser')
+    },
+    {
+      code: `
+          const myObject = {
+            /**
+             * Bad description
+             */
+            myProp: true
+          };
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'JSDoc description does not satisfy the regex pattern.'
+        }
+      ],
+      options: [
+        {
+          contexts: [
+            'Property'
+          ],
+          noDefaults: true
+        }
+      ]
     }
   ],
   valid: [
@@ -623,6 +697,61 @@ export default {
         {tags: {
           'main description': true
         }}
+      ]
+    },
+    {
+      code: `
+      class MyClass {
+        /**
+         * Abc.
+         */
+        myClassField = 1
+      }
+      `,
+      options: [
+        {
+          contexts: [
+            'ClassProperty'
+          ],
+          noDefaults: true
+        }
+      ],
+      parser: require.resolve('@typescript-eslint/parser')
+    },
+    {
+      code: `
+          /**
+           * Foo.
+           */
+          interface quux {
+
+          }
+      `,
+      options: [
+        {
+          contexts: [
+            'TSInterfaceDeclaration'
+          ],
+          noDefaults: true
+        }
+      ],
+      parser: require.resolve('@typescript-eslint/parser')
+    },
+    {
+      code: `
+          const myObject = {
+            /**
+             * Bad description
+             */
+            myProp: true
+          };
+      `,
+      options: [
+        {
+          contexts: [
+          ],
+          noDefaults: true
+        }
       ]
     }
   ]

--- a/test/rules/assertions/requireDescription.js
+++ b/test/rules/assertions/requireDescription.js
@@ -31,7 +31,7 @@ export default {
       ],
       options: [
         {
-          contexts: 'ClassDeclaration'
+          contexts: ['ClassDeclaration']
         }
       ]
     },
@@ -51,8 +51,7 @@ export default {
       ],
       options: [
         {
-          contexts: 'ClassDeclaration',
-          noDefaults: true
+          contexts: ['ClassDeclaration']
         }
       ]
     },
@@ -109,8 +108,7 @@ export default {
         {
           contexts: [
             'TSInterfaceDeclaration'
-          ],
-          noDefaults: true
+          ]
         }
       ],
       parser: require.resolve('@typescript-eslint/parser')
@@ -218,7 +216,7 @@ export default {
       `,
       options: [
         {
-          noDefaults: true
+          contexts: ['ClassDeclaration']
         }
       ]
     },

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -1010,6 +1010,26 @@ export default {
         ecmaVersion: 6,
         sourceType: 'module'
       }
+    },
+    {
+      code: `
+          const myObject = {
+            myProp: true
+          };
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc comment.',
+          type: 'Property'
+        }
+      ],
+      options: [
+        {
+          contexts: [
+            'Property'
+          ]
+        }
+      ]
     }
   ],
   valid: [{
@@ -1963,5 +1983,16 @@ export default {
         FunctionExpression: true
       }
     }]
+  }, {
+    code: `
+        const myObject = {
+          myProp: true
+        };
+    `,
+    options: [
+      {
+        contexts: []
+      }
+    ]
   }]
 };


### PR DESCRIPTION
- BREAKING CHANGE(require-description): remove `noDefaults` option and change `contexts` to always override defaults
- feat(match-description): allow `mainDescription: string|boolean` to override or disable main description separate from default
- feat(match-description): add `contexts` options for control on which contexts the rules apply
- feat(match-description): report line number with `match-description`
- feat(match-description): allow reporting multiple errors when main description validation fails
- feat(require-jsdoc): add `contexts` option to allow working with any node type
- fix(match-description, require-description): allow `contexts` to work with any node type
- fix(match-description): tighten default regex to require punctuation at the end even if only a single character
