### PR TITLE
feat: make some rules work on non-functions

### DIFF
--- a/.README/rules/check-indentation.md
+++ b/.README/rules/check-indentation.md
@@ -4,7 +4,7 @@ Reports invalid padding inside JSDoc block.
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|everywhere|
 |Tags|N/A|
 
 <!-- assertions checkIndentation -->

--- a/.README/rules/check-syntax.md
+++ b/.README/rules/check-syntax.md
@@ -4,7 +4,7 @@ Reports against Google Closure Compiler syntax.
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|everywhere|
 |Tags|N/A|
 
 <!-- assertions checkSyntax -->

--- a/.README/rules/check-tag-names.md
+++ b/.README/rules/check-tag-names.md
@@ -77,7 +77,7 @@ yields
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|everywhere|
 |Tags|N/A|
 |Settings|`tagNamePreference`, `additionalTagNames`|
 

--- a/.README/rules/check-types.md
+++ b/.README/rules/check-types.md
@@ -82,7 +82,7 @@ String | **string** | **string** | `("test") instanceof String` -> **`false`**
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|everywhere|
 |Tags|`class`, `constant`, `enum`, `implements`, `member`, `module`, `namespace`, `param`, `property`, `returns`, `throws`, `type`, `typedef`, `yields`|
 |Aliases|`constructor`, `const`, `var`, `arg`, `argument`, `prop`, `return`, `exception`|
 |Closure-only|`package`, `private`, `protected`, `public`, `static`|

--- a/.README/rules/newline-after-description.md
+++ b/.README/rules/newline-after-description.md
@@ -6,7 +6,7 @@ This rule takes one argument. If it is `"always"` then a problem is raised when 
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|everywhere|
 |Tags|N/A|
 
 <!-- assertions newlineAfterDescription -->

--- a/.README/rules/no-undefined-types.md
+++ b/.README/rules/no-undefined-types.md
@@ -32,7 +32,7 @@ An option object may have the following keys:
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|everywhere|
 |Tags|`class`, `constant`, `enum`, `implements`, `member`, `module`, `namespace`, `param`, `property`, `returns`, `throws`, `type`, `typedef`, `yields`|
 |Aliases|`constructor`, `const`, `var`, `arg`, `argument`, `prop`, `return`, `exception`, `yield`|
 |Closure-only|`package`, `private`, `protected`, `public`, `static`|

--- a/.README/rules/require-description-complete-sentence.md
+++ b/.README/rules/require-description-complete-sentence.md
@@ -9,7 +9,7 @@ Requires that block description and tag description are written in complete sent
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|everywhere|
 |Tags|`param`, `returns`|
 |Aliases|`arg`, `argument`, `return`|
 

--- a/.README/rules/require-hyphen-before-param-description.md
+++ b/.README/rules/require-hyphen-before-param-description.md
@@ -6,7 +6,7 @@ This rule takes one argument. If it is `"always"` then a problem is raised when 
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|everywhere|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
 

--- a/.README/rules/valid-types.md
+++ b/.README/rules/valid-types.md
@@ -33,7 +33,7 @@ Also impacts behaviors on namepath (or event)-defining and pointing tags:
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|everywhere|
 |Tags|For name only unless otherwise stated: `alias`, `augments`, `borrows`, `callback`, `class` (for name and type), `constant` (for name and type), `enum` (for type), `event`, `external`, `fires`, `function`, `implements` (for type), `interface`, `lends`, `listens`, `member` (for name and type),  `memberof`, `memberof!`, `mixes`, `mixin`, `module` (for name and type), `name`, `namespace` (for name and type), `param` (for name and type), `property` (for name and type), `returns` (for type), `this`, `throws` (for type), `type` (for type), `typedef` (for name and type), `yields` (for type)|
 |Aliases|`extends`, `constructor`, `const`, `host`, `emits`, `func`, `method`, `var`, `arg`, `argument`, `prop`, `return`, `exception`, `yield`|
 |Closure-only|For type only: `package`, `private`, `protected`, `public`, `static`|

--- a/README.md
+++ b/README.md
@@ -511,6 +511,20 @@ function quux (foo) {
 
 }
 // Message: Expected JSDoc block to be aligned.
+
+/**
+  * A jsdoc not attached to any node.
+*/
+// Message: Expected JSDoc block to be aligned.
+
+class Foo {
+  /**
+   *  Some method
+    * @param a
+   */
+  quux(a) {}
+}
+// Message: Expected JSDoc block to be aligned.
 ````
 
 The following patterns are not considered problems:
@@ -537,6 +551,11 @@ function quux (foo) {
 function quux (foo) {
 
 }
+
+/*  <- JSDoc must start with 2 stars.
+  *    So this is unchecked.
+ */
+function quux (foo) {}
 ````
 
 
@@ -788,7 +807,7 @@ Reports invalid padding inside JSDoc block.
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|everywhere|
 |Tags|N/A|
 
 The following patterns are considered problems:
@@ -803,6 +822,13 @@ The following patterns are considered problems:
 function quux () {
 
 }
+// Message: There must be no indentation.
+
+/**
+ * Foo
+ *   bar
+ */
+class Moo {}
 // Message: There must be no indentation.
 ````
 
@@ -1048,7 +1074,7 @@ Reports against Google Closure Compiler syntax.
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|everywhere|
 |Tags|N/A|
 
 The following patterns are considered problems:
@@ -1162,13 +1188,17 @@ yields
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|everywhere|
 |Tags|N/A|
 |Settings|`tagNamePreference`, `additionalTagNames`|
 
 The following patterns are considered problems:
 
 ````js
+/** @typoo {string} */
+let a;
+// Message: Invalid JSDoc tag name "typoo".
+
 /**
  * @Param
  */
@@ -1443,7 +1473,7 @@ String | **string** | **string** | `("test") instanceof String` -> **`false`**
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|everywhere|
 |Tags|`class`, `constant`, `enum`, `implements`, `member`, `module`, `namespace`, `param`, `property`, `returns`, `throws`, `type`, `typedef`, `yields`|
 |Aliases|`constructor`, `const`, `var`, `arg`, `argument`, `prop`, `return`, `exception`|
 |Closure-only|`package`, `private`, `protected`, `public`, `static`|
@@ -1958,6 +1988,9 @@ function quux (foo) {
 }
 // Settings: {"jsdoc":{"preferredTypes":{"<>":"[]"}}}
 // Message: Invalid JSDoc @param "foo" type "Array"; prefer: "[]".
+
+/** @typedef {String} foo */
+// Message: Invalid JSDoc @typedef "foo" type "String"; prefer: "string".
 ````
 
 The following patterns are not considered problems:
@@ -2597,7 +2630,7 @@ This rule takes one argument. If it is `"always"` then a problem is raised when 
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|everywhere|
 |Tags|N/A|
 
 The following patterns are considered problems:
@@ -2762,7 +2795,7 @@ An option object may have the following keys:
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|everywhere|
 |Tags|`class`, `constant`, `enum`, `implements`, `member`, `module`, `namespace`, `param`, `property`, `returns`, `throws`, `type`, `typedef`, `yields`|
 |Aliases|`constructor`, `const`, `var`, `arg`, `argument`, `prop`, `return`, `exception`, `yield`|
 |Closure-only|`package`, `private`, `protected`, `public`, `static`|
@@ -3050,7 +3083,7 @@ Requires that block description and tag description are written in complete sent
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|everywhere|
 |Tags|`param`, `returns`|
 |Aliases|`arg`, `argument`, `return`|
 
@@ -3632,7 +3665,7 @@ This rule takes one argument. If it is `"always"` then a problem is raised when 
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|everywhere|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
 
@@ -6040,7 +6073,7 @@ Also impacts behaviors on namepath (or event)-defining and pointing tags:
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|everywhere|
 |Tags|For name only unless otherwise stated: `alias`, `augments`, `borrows`, `callback`, `class` (for name and type), `constant` (for name and type), `enum` (for type), `event`, `external`, `fires`, `function`, `implements` (for type), `interface`, `lends`, `listens`, `member` (for name and type),  `memberof`, `memberof!`, `mixes`, `mixin`, `module` (for name and type), `name`, `namespace` (for name and type), `param` (for name and type), `property` (for name and type), `returns` (for type), `this`, `throws` (for type), `type` (for type), `typedef` (for name and type), `yields` (for type)|
 |Aliases|`extends`, `constructor`, `const`, `host`, `emits`, `func`, `method`, `var`, `arg`, `argument`, `prop`, `return`, `exception`, `yield`|
 |Closure-only|For type only: `package`, `private`, `protected`, `public`, `static`|

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -325,8 +325,8 @@ const makeReport = (context, commentNode) => {
  */
 
 /**
- * Create a eslint rule that iterate over all JSDocs, regardless of whether
- * it is attached to a function-like node.
+ * Create an eslint rule that iterates over all JSDocs, regardless of whether
+ * they are attached to a function-like node.
  *
  * @param {JsdocVisitor} iterator
  * @param {{meta: any}} ruleConfig

--- a/src/rules/checkAlignment.js
+++ b/src/rules/checkAlignment.js
@@ -38,6 +38,7 @@ export default iterateJsdoc(({
     }
   }
 }, {
+  iterateAllJsdocs: true,
   meta: {
     fixable: 'code',
     type: 'layout'

--- a/src/rules/checkIndentation.js
+++ b/src/rules/checkIndentation.js
@@ -12,6 +12,7 @@ export default iterateJsdoc(({
     report('There must be no indentation.');
   }
 }, {
+  iterateAllJsdocs: true,
   meta: {
     type: 'layout'
   }

--- a/src/rules/checkSyntax.js
+++ b/src/rules/checkSyntax.js
@@ -15,6 +15,7 @@ export default iterateJsdoc(({
     }
   }
 }, {
+  iterateAllJsdocs: true,
   meta: {
     type: 'suggestion'
   }

--- a/src/rules/checkTagNames.js
+++ b/src/rules/checkTagNames.js
@@ -26,6 +26,7 @@ export default iterateJsdoc(({
     }
   });
 }, {
+  iterateAllJsdocs: true,
   meta: {
     fixable: 'code',
     type: 'suggestion'

--- a/src/rules/checkTypes.js
+++ b/src/rules/checkTypes.js
@@ -217,6 +217,7 @@ export default iterateJsdoc(({
     }
   });
 }, {
+  iterateAllJsdocs: true,
   meta: {
     fixable: 'code',
     type: 'suggestion'

--- a/src/rules/newlineAfterDescription.js
+++ b/src/rules/newlineAfterDescription.js
@@ -54,6 +54,7 @@ export default iterateJsdoc(({
     });
   }
 }, {
+  iterateAllJsdocs: true,
   meta: {
     fixable: 'whitespace',
     schema: [

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -129,6 +129,7 @@ export default iterateJsdoc(({
     return validateDescription(description, report, jsdocNode, sourceCode, tag.tag);
   });
 }, {
+  iterateAllJsdocs: true,
   meta: {
     fixable: 'code',
     type: 'suggestion'

--- a/src/rules/requireHyphenBeforeParamDescription.js
+++ b/src/rules/requireHyphenBeforeParamDescription.js
@@ -54,6 +54,7 @@ export default iterateJsdoc(({
     }
   });
 }, {
+  iterateAllJsdocs: true,
   meta: {
     fixable: 'code',
     schema: [

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -64,6 +64,7 @@ export default iterateJsdoc(({
     }
   });
 }, {
+  iterateAllJsdocs: true,
   meta: {
     type: 'suggestion'
   }

--- a/test/rules/assertions/checkAlignment.js
+++ b/test/rules/assertions/checkAlignment.js
@@ -114,6 +114,30 @@ export default {
 
         }
       `
+    },
+    {
+      code: `
+        /**
+           * A jsdoc not attached to any node.
+         */
+      `,
+      errors: [
+        {message: 'Expected JSDoc block to be aligned.'}
+      ]
+    },
+    {
+      code: `
+        class Foo {
+          /**
+           *  Some method
+            * @param a
+           */
+          quux(a) {}
+        }
+      `,
+      errors: [
+        {message: 'Expected JSDoc block to be aligned.'}
+      ]
     }
   ],
   valid: [
@@ -143,6 +167,14 @@ export default {
         function quux (foo) {
 
         }
+      `
+    },
+    {
+      code: `
+        /*  <- JSDoc must start with 2 stars.
+          *    So this is unchecked.
+         */
+        function quux (foo) {}
       `
     }
   ]

--- a/test/rules/assertions/checkIndentation.js
+++ b/test/rules/assertions/checkIndentation.js
@@ -17,6 +17,20 @@ export default {
           message: 'There must be no indentation.'
         }
       ]
+    },
+    {
+      code: `
+        /**
+         * Foo
+         *   bar
+         */
+        class Moo {}
+      `,
+      errors: [
+        {
+          message: 'There must be no indentation.'
+        }
+      ]
     }
   ],
   valid: [

--- a/test/rules/assertions/checkTagNames.js
+++ b/test/rules/assertions/checkTagNames.js
@@ -6,6 +6,18 @@ export default {
   invalid: [
     {
       code: `
+        /** @typoo {string} */
+        let a;
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Invalid JSDoc tag name "typoo".'
+        }
+      ]
+    },
+    {
+      code: `
           /**
            * @Param
            */

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -1694,6 +1694,13 @@ export default {
           }
         }
       }
+    },
+    {
+      code: '/** @typedef {String} foo */',
+      errors: [
+        {message: 'Invalid JSDoc @typedef "foo" type "String"; prefer: "string".'}
+      ],
+      output: '/** @typedef {string} foo */'
     }
   ],
   valid: [


### PR DESCRIPTION
BREAKING CHANGE: previously rules mostly works only on function-like
  nodes, now a subset of rules are updated to work on **all** JSDocs.

Fixes #214 
