### PR TITLE
Allow rejecting normally valid tag names and/or providing custom error messages when suggesting tags to reject or replace

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -159,7 +159,7 @@ The following will report the message `@extends is to be used over @augments as 
         "jsdoc": {
             "tagNamePreference": {
                 "augments": {
-                  "message": "@{{replacement}} is to be used over @{{tagName}} as it is more evocative of classes than @augments",
+                  "message": "@{{replacement}} is to be used over @{{tagName}} as it is more evocative of classes than @{{tagName}}",
                   "replacement": "extends"
                 }
             }

--- a/.README/README.md
+++ b/.README/README.md
@@ -147,7 +147,7 @@ Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a
 }
 ```
 
-One may also use an object with a `message` and `replacement`, with `{{tagName}}` and `{{preferredType}}` (or its alias `{{replacement}}`) as template variables to be
+One may also use an object with a `message` and `replacement`, with `{{tagName}}` and `{{preferredTag}}` (or its alias `{{replacement}}`) as template variables to be
 substituted within `message`.
 
 The following will report the message `@extends is to be used over @augments as it is more evocative of classes than @augments` upon encountering `@augments`.

--- a/.README/README.md
+++ b/.README/README.md
@@ -147,6 +147,60 @@ Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a
 }
 ```
 
+One may also use an object with a `message` and `replacement`, with `{{tagName}}` and `{{preferredType}}` (or its alias `{{replacement}}`) as template variables to be
+substituted within `message`.
+
+The following will report the message `@extends is to be used over @augments as it is more evocative of classes than @augments` upon encountering `@augments`.
+
+```json
+{
+    "rules": {},
+    "settings": {
+        "jsdoc": {
+            "tagNamePreference": {
+                "augments": {
+                  "message": "@{{replacement}} is to be used over @{{tagName}} as it is more evocative of classes than @augments",
+                  "replacement": "extends"
+                }
+            }
+        }
+    }
+}
+```
+
+If one wishes to reject a normally valid tag, e.g., `@todo`, one may set the tag to `false`:
+
+```json
+{
+    "rules": {},
+    "settings": {
+        "jsdoc": {
+            "tagNamePreference": {
+                "todo": false
+            }
+        }
+    }
+}
+```
+
+Or one may set the targeted tag to an object with a custom `message`, but without a `replacement` property:
+
+```json
+{
+    "rules": {},
+    "settings": {
+        "jsdoc": {
+            "tagNamePreference": {
+                "todo": {
+                  "message": "We expect immediate perfection, so don't leave to-dos in your code."
+                }
+            }
+        }
+    }
+}
+```
+
+
 The defaults in `eslint-plugin-jsdoc` (for tags which offer
 aliases) are as follows:
 

--- a/.README/README.md
+++ b/.README/README.md
@@ -147,8 +147,7 @@ Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a
 }
 ```
 
-One may also use an object with a `message` and `replacement`, with `{{tagName}}` and `{{preferredTag}}` (or its alias `{{replacement}}`) as template variables to be
-substituted within `message`.
+One may also use an object with a `message` and `replacement`.
 
 The following will report the message `@extends is to be used over @augments as it is more evocative of classes than @augments` upon encountering `@augments`.
 
@@ -159,7 +158,7 @@ The following will report the message `@extends is to be used over @augments as 
         "jsdoc": {
             "tagNamePreference": {
                 "augments": {
-                  "message": "@{{replacement}} is to be used over @{{tagName}} as it is more evocative of classes than @{{tagName}}",
+                  "message": "@extends is to be used over @augments as it is more evocative of classes than @augments",
                   "replacement": "extends"
                 }
             }

--- a/README.md
+++ b/README.md
@@ -197,6 +197,60 @@ Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a
 }
 ```
 
+One may also use an object with a `message` and `replacement`, with `{{tagName}}` and `{{preferredType}}` (or its alias `{{replacement}}`) as template variables to be
+substituted within `message`.
+
+The following will report the message `@extends is to be used over @augments as it is more evocative of classes than @augments` upon encountering `@augments`.
+
+```json
+{
+    "rules": {},
+    "settings": {
+        "jsdoc": {
+            "tagNamePreference": {
+                "augments": {
+                  "message": "@{{replacement}} is to be used over @{{tagName}} as it is more evocative of classes than @augments",
+                  "replacement": "extends"
+                }
+            }
+        }
+    }
+}
+```
+
+If one wishes to reject a normally valid tag, e.g., `@todo`, one may set the tag to `false`:
+
+```json
+{
+    "rules": {},
+    "settings": {
+        "jsdoc": {
+            "tagNamePreference": {
+                "todo": false
+            }
+        }
+    }
+}
+```
+
+Or one may set the targeted tag to an object with a custom `message`, but without a `replacement` property:
+
+```json
+{
+    "rules": {},
+    "settings": {
+        "jsdoc": {
+            "tagNamePreference": {
+                "todo": {
+                  "message": "We expect immediate perfection, so don't leave to-dos in your code."
+                }
+            }
+        }
+    }
+}
+```
+
+
 The defaults in `eslint-plugin-jsdoc` (for tags which offer
 aliases) are as follows:
 
@@ -955,6 +1009,15 @@ export class SomeClass {
   constructor(private property: string) {}
 }
 // Message: Expected @param names to be "property". Got "prop".
+
+/**
+ * @param foo
+ */
+function quux (foo) {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"param":false}}}
+// Message: Unexpected tag `@param`
 ````
 
 The following patterns are not considered problems:
@@ -1276,6 +1339,42 @@ function quux (foo) {
 }
 // Settings: {"jsdoc":{"additionalTagNames":{"customTags":["bar"]}}}
 // Message: Invalid JSDoc tag name "baz".
+
+/**
+ * @todo
+ */
+function quux () {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"todo":false}}}
+// Message: Blacklisted tag found (`@todo`)
+
+/**
+ * @todo
+ */
+function quux () {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"todo":{"message":"Please resolve to-dos or add to the tracker"}}}}
+// Message: Please resolve to-dos or add to the tracker
+
+/**
+ * @todo
+ */
+function quux () {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"todo":{"message":"Please use {{replacement}} instead of {{tagName}}","replacement":"x-todo"}}}}
+// Message: Please use x-todo instead of todo
+
+/**
+ * @todo
+ */
+function quux () {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"todo":{"message":"Please use {{preferredTagName}} instead of {{tagName}}","replacement":"x-todo"}}}}
+// Message: Please use x-todo instead of todo
 ````
 
 The following patterns are not considered problems:
@@ -1390,6 +1489,13 @@ function quux (foo) {}
  *
  */
 function quux (foo) {
+
+}
+
+/**
+ * @todo
+ */
+function quux () {
 
 }
 ````
@@ -3631,6 +3737,24 @@ var quux = {
 };
 // Options: [{"contexts":["ObjectExpression"]}]
 // Message: Missing JSDoc @description declaration.
+
+/**
+ * @someDesc
+ */
+function quux () {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"description":{"message":"Please avoid `{{tagName}}`; use `{{replacement}}` instead","replacement":"someDesc"}}}}
+// Message: Missing JSDoc @someDesc description.
+
+/**
+ * @description
+ */
+function quux () {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"description":false}}}
+// Message: Unexpected tag `@description`
 ````
 
 The following patterns are not considered problems:
@@ -3905,6 +4029,15 @@ function quux () {
 }
 // Options: ["always"]
 // Message: There must be a hyphen before @param description.
+
+/**
+ * @param foo
+ */
+function quux (foo) {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"param":false}}}
+// Message: Unexpected tag `@param`
 ````
 
 The following patterns are not considered problems:
@@ -4820,6 +4953,15 @@ function quux (foo) {
 }
 // Settings: {"jsdoc":{"tagNamePreference":{"param":"arg"}}}
 // Message: Missing JSDoc @arg "foo" description.
+
+/**
+ * @param foo
+ */
+function quux (foo) {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"param":false}}}
+// Message: Unexpected tag `@param`
 ````
 
 The following patterns are not considered problems:
@@ -4874,6 +5016,15 @@ function quux (foo) {
 
 }
 // Message: There must be an identifier after @param tag.
+
+/**
+ * @param foo
+ */
+function quux (foo) {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"param":false}}}
+// Message: Unexpected tag `@param`
 ````
 
 The following patterns are not considered problems:
@@ -4925,6 +5076,15 @@ function quux (foo) {
 }
 // Settings: {"jsdoc":{"tagNamePreference":{"param":"arg"}}}
 // Message: Missing JSDoc @arg "foo" type.
+
+/**
+ * @param foo
+ */
+function quux (foo) {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"param":false}}}
+// Message: Unexpected tag `@param`
 ````
 
 The following patterns are not considered problems:
@@ -5090,6 +5250,15 @@ export class SomeClass {
   constructor(private property: string, private foo: number) {}
 }
 // Message: Missing JSDoc @param "foo" declaration.
+
+/**
+ *
+ */
+function quux (foo) {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"param":false}}}
+// Message: Unexpected tag `@param`
 ````
 
 The following patterns are not considered problems:
@@ -5471,6 +5640,15 @@ class Foo {
   }
 }
 // Message: JSDoc @returns declaration present but return expression not available in function.
+
+/**
+ * @returns
+ */
+function quux () {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"returns":false}}}
+// Message: Unexpected tag `@returns`
 ````
 
 The following patterns are not considered problems:
@@ -5750,6 +5928,15 @@ function quux (foo) {
 }
 // Settings: {"jsdoc":{"tagNamePreference":{"returns":"return"}}}
 // Message: Missing JSDoc @return description.
+
+/**
+ * @returns
+ */
+function quux () {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"returns":false}}}
+// Message: Unexpected tag `@returns`
 ````
 
 The following patterns are not considered problems:
@@ -5823,6 +6010,15 @@ function quux () {
 }
 // Settings: {"jsdoc":{"tagNamePreference":{"returns":"return"}}}
 // Message: Missing JSDoc @return type.
+
+/**
+ * @returns
+ */
+function quux () {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"returns":false}}}
+// Message: Unexpected tag `@returns`
 ````
 
 The following patterns are not considered problems:
@@ -5967,6 +6163,15 @@ function quux (foo) {
   return foo;
 }
 // Message: Found more than one @returns declaration.
+
+/**
+ * @returns
+ */
+function quux () {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"returns":false}}}
+// Message: Unexpected tag `@returns`
 ````
 
 The following patterns are not considered problems:

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ The following will report the message `@extends is to be used over @augments as 
         "jsdoc": {
             "tagNamePreference": {
                 "augments": {
-                  "message": "@{{replacement}} is to be used over @{{tagName}} as it is more evocative of classes than @augments",
+                  "message": "@{{replacement}} is to be used over @{{tagName}} as it is more evocative of classes than @{{tagName}}",
                   "replacement": "extends"
                 }
             }

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a
 }
 ```
 
-One may also use an object with a `message` and `replacement`, with `{{tagName}}` and `{{preferredType}}` (or its alias `{{replacement}}`) as template variables to be
+One may also use an object with a `message` and `replacement`, with `{{tagName}}` and `{{preferredTag}}` (or its alias `{{replacement}}`) as template variables to be
 substituted within `message`.
 
 The following will report the message `@extends is to be used over @augments as it is more evocative of classes than @augments` upon encountering `@augments`.

--- a/README.md
+++ b/README.md
@@ -197,8 +197,7 @@ Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a
 }
 ```
 
-One may also use an object with a `message` and `replacement`, with `{{tagName}}` and `{{preferredTag}}` (or its alias `{{replacement}}`) as template variables to be
-substituted within `message`.
+One may also use an object with a `message` and `replacement`.
 
 The following will report the message `@extends is to be used over @augments as it is more evocative of classes than @augments` upon encountering `@augments`.
 
@@ -209,7 +208,7 @@ The following will report the message `@extends is to be used over @augments as 
         "jsdoc": {
             "tagNamePreference": {
                 "augments": {
-                  "message": "@{{replacement}} is to be used over @{{tagName}} as it is more evocative of classes than @{{tagName}}",
+                  "message": "@extends is to be used over @augments as it is more evocative of classes than @augments",
                   "replacement": "extends"
                 }
             }
@@ -1364,7 +1363,7 @@ function quux () {
 function quux () {
 
 }
-// Settings: {"jsdoc":{"tagNamePreference":{"todo":{"message":"Please use {{replacement}} instead of {{tagName}}","replacement":"x-todo"}}}}
+// Settings: {"jsdoc":{"tagNamePreference":{"todo":{"message":"Please use x-todo instead of todo","replacement":"x-todo"}}}}
 // Message: Please use x-todo instead of todo
 
 /**
@@ -1373,7 +1372,7 @@ function quux () {
 function quux () {
 
 }
-// Settings: {"jsdoc":{"tagNamePreference":{"todo":{"message":"Please use {{preferredTagName}} instead of {{tagName}}","replacement":"x-todo"}}}}
+// Settings: {"jsdoc":{"tagNamePreference":{"todo":{"message":"Please use x-todo instead of todo","replacement":"x-todo"}}}}
 // Message: Please use x-todo instead of todo
 ````
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-plugin-add-module-exports": "^1.0.2",
     "babel-plugin-istanbul": "^5.1.4",
     "chai": "^4.2.0",
+    "escape-regex-string": "^1.0.6",
     "eslint": "^6.0.1",
     "eslint-config-canonical": "^17.1.1",
     "gitdown": "^2.6.1",

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -76,14 +76,12 @@ const getUtils = (
     return jsdocUtils.getJsdocParameterNames(jsdoc, param);
   };
 
-  utils.getPreferredTagName = (name, allowObjectReturn = false, defaultMessage = 'Unexpected tag `@{{tagName}}`') => {
+  utils.getPreferredTagName = (name, allowObjectReturn = false, defaultMessage = `Unexpected tag \`@${name}\``) => {
     const ret = jsdocUtils.getPreferredTagName(name, tagNamePreference);
     const isObject = ret && typeof ret === 'object';
     if (ret === false || isObject && !ret.replacement) {
       const message = isObject && ret.message || defaultMessage;
-      report(message, null, utils.getTags(name)[0], {
-        tagName: name
-      });
+      report(message, null, utils.getTags(name)[0]);
 
       return false;
     }

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -232,13 +232,17 @@ const getUtils = (
     return classJsdoc && jsdocUtils.hasTag(classJsdoc, tagName);
   };
 
-  utils.forEachTag = (tagName, arrayHandler) => {
+  utils.forEachPreferredTag = (tagName, arrayHandler) => {
+    const targetTagName = utils.getPreferredTagName(tagName);
+    if (!targetTagName) {
+      return;
+    }
     const matchingJsdocTags = _.filter(jsdoc.tags || [], {
-      tag: tagName
+      tag: targetTagName
     });
 
     matchingJsdocTags.forEach((matchingJsdocTag) => {
-      arrayHandler(matchingJsdocTag);
+      arrayHandler(matchingJsdocTag, targetTagName);
     });
   };
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -25,6 +25,7 @@ const parseComment = (commentNode, indent) => {
 const getUtils = (
   node,
   jsdoc,
+  jsdocNode,
   {
     tagNamePreference,
     additionalTagNames,
@@ -37,6 +38,7 @@ const getUtils = (
     allowAugmentsExtendsWithoutParam,
     checkSeesForNamepaths
   },
+  report,
   context
 ) => {
   const ancestors = context.getAncestors();
@@ -57,15 +59,36 @@ const getUtils = (
   };
 
   utils.getJsdocParameterNamesDeep = () => {
-    return jsdocUtils.getJsdocParameterNamesDeep(jsdoc, utils.getPreferredTagName('param'));
+    const param = utils.getPreferredTagName('param');
+    if (!param) {
+      return false;
+    }
+
+    return jsdocUtils.getJsdocParameterNamesDeep(jsdoc, param);
   };
 
   utils.getJsdocParameterNames = () => {
-    return jsdocUtils.getJsdocParameterNames(jsdoc, utils.getPreferredTagName('param'));
+    const param = utils.getPreferredTagName('param');
+    if (!param) {
+      return false;
+    }
+
+    return jsdocUtils.getJsdocParameterNames(jsdoc, param);
   };
 
-  utils.getPreferredTagName = (name) => {
-    return jsdocUtils.getPreferredTagName(name, tagNamePreference);
+  utils.getPreferredTagName = (name, allowObjectReturn = false, defaultMessage = 'Unexpected tag `@{{tagName}}`') => {
+    const ret = jsdocUtils.getPreferredTagName(name, tagNamePreference);
+    const isObject = ret && typeof ret === 'object';
+    if (ret === false || isObject && !ret.replacement) {
+      const message = isObject && ret.message || defaultMessage;
+      report(message, null, utils.getTags(name)[0], {
+        tagName: name
+      });
+
+      return false;
+    }
+
+    return isObject && !allowObjectReturn ? ret.replacement : ret;
   };
 
   utils.isValidTag = (name) => {
@@ -346,17 +369,19 @@ const iterateAllJsdocs = (iterator, ruleConfig) => {
             const indent = _.repeat(' ', comment.loc.start.column);
             const jsdoc = parseComment(comment, indent);
             const settings = getSettings(context);
+            const report = makeReport(context, comment);
+            const jsdocNode = comment;
 
             iterator({
               context,
               indent,
               jsdoc,
-              jsdocNode: comment,
+              jsdocNode,
               node: null,
-              report: makeReport(context, comment),
+              report,
               settings: getSettings(context),
               sourceCode: context.getSourceCode(),
-              utils: getUtils(null, jsdoc, settings, context)
+              utils: getUtils(null, jsdoc, jsdocNode, settings, report, context)
             });
           });
         }
@@ -433,7 +458,9 @@ export default function iterateJsdoc (iterator, ruleConfig) {
         const utils = getUtils(
           node,
           jsdoc,
+          jsdocNode,
           settings,
+          report,
           context
         );
 

--- a/src/rules/checkExamples.js
+++ b/src/rules/checkExamples.js
@@ -1,4 +1,5 @@
 import {CLIEngine, Linter} from 'eslint';
+import escapeRegexString from 'escape-regex-string';
 import iterateJsdoc from '../iterateJsdoc';
 
 const zeroBasedLineIndexAdjust = -1;
@@ -62,9 +63,11 @@ export default iterateJsdoc(({
   exampleCodeRegex = exampleCodeRegex && new RegExp(exampleCodeRegex, '');
   rejectExampleCodeRegex = rejectExampleCodeRegex && new RegExp(rejectExampleCodeRegex, '');
 
-  utils.forEachTag('example', (tag) => {
+  utils.forEachPreferredTag('example', (tag, targetTagName) => {
     // If a space is present, we should ignore it
-    const initialTag = tag.source.match(/^@example ?/);
+    const initialTag = tag.source.match(
+      new RegExp('^@' + escapeRegexString(targetTagName) + ' ?', 'u')
+    );
     const initialTagLength = initialTag[0].length;
     const firstLinePrefixLength = preTagSpaceLength + initialTagLength;
 
@@ -209,7 +212,7 @@ export default iterateJsdoc(({
 
       // Could perhaps make fixable
       report(
-        '@example ' + (severity === 2 ? 'error' : 'warning') +
+        '@' + targetTagName + ' ' + (severity === 2 ? 'error' : 'warning') +
           (ruleId ? ' (' + ruleId + ')' : '') + ': ' +
           message,
         null,

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -92,6 +92,9 @@ export default iterateJsdoc(({
 }) => {
   const functionParameterNames = utils.getFunctionParameterNames();
   const jsdocParameterNamesDeep = utils.getJsdocParameterNamesDeep();
+  if (!jsdocParameterNamesDeep) {
+    return;
+  }
   const targetTagName = utils.getPreferredTagName('param');
   const isError = validateParameterNames(targetTagName, functionParameterNames, jsdoc, report);
 

--- a/src/rules/checkTagNames.js
+++ b/src/rules/checkTagNames.js
@@ -13,12 +13,12 @@ export default iterateJsdoc(({
   jsdoc.tags.forEach((jsdocTag) => {
     const tagName = jsdocTag.tag;
     if (utils.isValidTag(tagName)) {
-      let message = 'Invalid JSDoc tag (preference). Replace "{{tagName}}" JSDoc tag with "{{preferredTagName}}".';
       let preferredTagName = utils.getPreferredTagName(
         tagName,
         true,
-        'Blacklisted tag found (`@{{tagName}}`)'
+        `Blacklisted tag found (\`@${tagName}\`)`
       );
+      let message = `Invalid JSDoc tag (preference). Replace "${tagName}" JSDoc tag with "${preferredTagName}".`;
       if (!preferredTagName) {
         return;
       }
@@ -31,11 +31,7 @@ export default iterateJsdoc(({
           const replacement = sourceCode.getText(jsdocNode).replace('@' + tagName, '@' + preferredTagName);
 
           return fixer.replaceText(jsdocNode, replacement);
-        }, jsdocTag, {
-          preferredTagName,
-          replacement: preferredTagName,
-          tagName
-        });
+        }, jsdocTag);
       }
     } else {
       report('Invalid JSDoc tag name "' + tagName + '".', null, jsdocTag);

--- a/src/rules/checkTagNames.js
+++ b/src/rules/checkTagNames.js
@@ -11,18 +11,34 @@ export default iterateJsdoc(({
     return;
   }
   jsdoc.tags.forEach((jsdocTag) => {
-    if (utils.isValidTag(jsdocTag.tag)) {
-      const preferredTagName = utils.getPreferredTagName(jsdocTag.tag);
+    const tagName = jsdocTag.tag;
+    if (utils.isValidTag(tagName)) {
+      let message = 'Invalid JSDoc tag (preference). Replace "{{tagName}}" JSDoc tag with "{{preferredTagName}}".';
+      let preferredTagName = utils.getPreferredTagName(
+        tagName,
+        true,
+        'Blacklisted tag found (`@{{tagName}}`)'
+      );
+      if (!preferredTagName) {
+        return;
+      }
+      if (preferredTagName && typeof preferredTagName === 'object') {
+        ({message, replacement: preferredTagName} = preferredTagName);
+      }
 
-      if (preferredTagName !== jsdocTag.tag) {
-        report('Invalid JSDoc tag (preference). Replace "' + jsdocTag.tag + '" JSDoc tag with "' + preferredTagName + '".', (fixer) => {
-          const replacement = sourceCode.getText(jsdocNode).replace('@' + jsdocTag.tag, '@' + preferredTagName);
+      if (preferredTagName !== tagName) {
+        report(message, (fixer) => {
+          const replacement = sourceCode.getText(jsdocNode).replace('@' + tagName, '@' + preferredTagName);
 
           return fixer.replaceText(jsdocNode, replacement);
-        }, jsdocTag);
+        }, jsdocTag, {
+          preferredTagName,
+          replacement: preferredTagName,
+          tagName
+        });
       }
     } else {
-      report('Invalid JSDoc tag name "' + jsdocTag.tag + '".', null, jsdocTag);
+      report('Invalid JSDoc tag name "' + tagName + '".', null, jsdocTag);
     }
   });
 }, {

--- a/src/rules/requireDescription.js
+++ b/src/rules/requireDescription.js
@@ -11,6 +11,9 @@ export default iterateJsdoc(({
   }
 
   const targetTagName = utils.getPreferredTagName('description');
+  if (!targetTagName) {
+    return;
+  }
 
   const functionExamples = _.filter(jsdoc.tags, {
     tag: targetTagName

--- a/src/rules/requireHyphenBeforeParamDescription.js
+++ b/src/rules/requireHyphenBeforeParamDescription.js
@@ -9,19 +9,13 @@ export default iterateJsdoc(({
   jsdocNode
 }) => {
   let always;
-
-  const targetTagName = utils.getPreferredTagName('param');
-  if (!targetTagName) {
-    return;
-  }
-
   if (_.has(context.options, 0)) {
     always = context.options[0] === 'always';
   } else {
     always = true;
   }
 
-  utils.forEachTag(targetTagName, (jsdocTag) => {
+  utils.forEachPreferredTag('param', (jsdocTag, targetTagName) => {
     if (!jsdocTag.description) {
       return;
     }

--- a/src/rules/requireHyphenBeforeParamDescription.js
+++ b/src/rules/requireHyphenBeforeParamDescription.js
@@ -11,6 +11,9 @@ export default iterateJsdoc(({
   let always;
 
   const targetTagName = utils.getPreferredTagName('param');
+  if (!targetTagName) {
+    return;
+  }
 
   if (_.has(context.options, 0)) {
     always = context.options[0] === 'always';

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -7,6 +7,9 @@ export default iterateJsdoc(({
 }) => {
   const functionParameterNames = utils.getFunctionParameterNames();
   const jsdocParameterNames = utils.getJsdocParameterNames();
+  if (!jsdocParameterNames) {
+    return;
+  }
 
   if (utils.avoidDocs('param')) {
     return;

--- a/src/rules/requireParamDescription.js
+++ b/src/rules/requireParamDescription.js
@@ -4,12 +4,7 @@ export default iterateJsdoc(({
   report,
   utils
 }) => {
-  const targetTagName = utils.getPreferredTagName('param');
-  if (!targetTagName) {
-    return;
-  }
-
-  utils.forEachTag(targetTagName, (jsdocParameter) => {
+  utils.forEachPreferredTag('param', (jsdocParameter, targetTagName) => {
     if (!jsdocParameter.description) {
       report('Missing JSDoc @' + targetTagName + ' "' + jsdocParameter.name + '" description.', null, jsdocParameter);
     }

--- a/src/rules/requireParamDescription.js
+++ b/src/rules/requireParamDescription.js
@@ -5,6 +5,9 @@ export default iterateJsdoc(({
   utils
 }) => {
   const targetTagName = utils.getPreferredTagName('param');
+  if (!targetTagName) {
+    return;
+  }
 
   utils.forEachTag(targetTagName, (jsdocParameter) => {
     if (!jsdocParameter.description) {

--- a/src/rules/requireParamName.js
+++ b/src/rules/requireParamName.js
@@ -5,6 +5,9 @@ export default iterateJsdoc(({
   utils
 }) => {
   const targetTagName = utils.getPreferredTagName('param');
+  if (!targetTagName) {
+    return;
+  }
 
   utils.forEachTag(targetTagName, (jsdocParameter) => {
     if (jsdocParameter.tag && jsdocParameter.name === '') {

--- a/src/rules/requireParamName.js
+++ b/src/rules/requireParamName.js
@@ -4,14 +4,9 @@ export default iterateJsdoc(({
   report,
   utils
 }) => {
-  const targetTagName = utils.getPreferredTagName('param');
-  if (!targetTagName) {
-    return;
-  }
-
-  utils.forEachTag(targetTagName, (jsdocParameter) => {
+  utils.forEachPreferredTag('param', (jsdocParameter, targetTagName) => {
     if (jsdocParameter.tag && jsdocParameter.name === '') {
-      report('There must be an identifier after @param ' + (jsdocParameter.type === '' ? 'type' : 'tag') + '.', null, jsdocParameter);
+      report('There must be an identifier after @' + targetTagName + ' ' + (jsdocParameter.type === '' ? 'type' : 'tag') + '.', null, jsdocParameter);
     }
   });
 }, {

--- a/src/rules/requireParamType.js
+++ b/src/rules/requireParamType.js
@@ -5,6 +5,9 @@ export default iterateJsdoc(({
   utils
 }) => {
   const targetTagName = utils.getPreferredTagName('param');
+  if (!targetTagName) {
+    return;
+  }
 
   utils.forEachTag(targetTagName, (jsdocParameter) => {
     if (!jsdocParameter.type) {

--- a/src/rules/requireParamType.js
+++ b/src/rules/requireParamType.js
@@ -4,12 +4,7 @@ export default iterateJsdoc(({
   report,
   utils
 }) => {
-  const targetTagName = utils.getPreferredTagName('param');
-  if (!targetTagName) {
-    return;
-  }
-
-  utils.forEachTag(targetTagName, (jsdocParameter) => {
+  utils.forEachPreferredTag('param', (jsdocParameter, targetTagName) => {
     if (!jsdocParameter.type) {
       report('Missing JSDoc @' + targetTagName + ' "' + jsdocParameter.name + '" type.', null, jsdocParameter);
     }

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -55,6 +55,9 @@ export default iterateJsdoc(({
   const options = context.options[0] || {};
 
   const tagName = utils.getPreferredTagName('returns');
+  if (!tagName) {
+    return;
+  }
   const tags = utils.getTags(tagName);
 
   if (tags.length > 1) {

--- a/src/rules/requireReturnsCheck.js
+++ b/src/rules/requireReturnsCheck.js
@@ -27,6 +27,9 @@ export default iterateJsdoc(({
   }
 
   const tagName = utils.getPreferredTagName('returns');
+  if (!tagName) {
+    return;
+  }
   const tags = utils.getTags(tagName);
 
   if (tags.length === 0) {

--- a/src/rules/requireReturnsDescription.js
+++ b/src/rules/requireReturnsDescription.js
@@ -5,6 +5,9 @@ export default iterateJsdoc(({
   utils
 }) => {
   const targetTagName = utils.getPreferredTagName('returns');
+  if (!targetTagName) {
+    return;
+  }
 
   utils.forEachTag(targetTagName, (jsdocTag) => {
     const type = jsdocTag.type && jsdocTag.type.trim();

--- a/src/rules/requireReturnsDescription.js
+++ b/src/rules/requireReturnsDescription.js
@@ -4,12 +4,7 @@ export default iterateJsdoc(({
   report,
   utils
 }) => {
-  const targetTagName = utils.getPreferredTagName('returns');
-  if (!targetTagName) {
-    return;
-  }
-
-  utils.forEachTag(targetTagName, (jsdocTag) => {
+  utils.forEachPreferredTag('returns', (jsdocTag, targetTagName) => {
     const type = jsdocTag.type && jsdocTag.type.trim();
 
     if (type === 'void' || type === 'undefined') {

--- a/src/rules/requireReturnsType.js
+++ b/src/rules/requireReturnsType.js
@@ -5,6 +5,9 @@ export default iterateJsdoc(({
   utils
 }) => {
   const targetTagName = utils.getPreferredTagName('returns');
+  if (!targetTagName) {
+    return;
+  }
 
   utils.forEachTag(targetTagName, (jsdocTag) => {
     if (!jsdocTag.type) {

--- a/src/rules/requireReturnsType.js
+++ b/src/rules/requireReturnsType.js
@@ -4,12 +4,7 @@ export default iterateJsdoc(({
   report,
   utils
 }) => {
-  const targetTagName = utils.getPreferredTagName('returns');
-  if (!targetTagName) {
-    return;
-  }
-
-  utils.forEachTag(targetTagName, (jsdocTag) => {
+  utils.forEachPreferredTag('returns', (jsdocTag, targetTagName) => {
     if (!jsdocTag.type) {
       report('Missing JSDoc @' + targetTagName + ' type.', null, jsdocTag);
     }

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -190,6 +190,28 @@ export default {
       parserOptions: {
         sourceType: 'module'
       }
+    },
+    {
+      code: `
+          /**
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Unexpected tag `@param`'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            param: false
+          }
+        }
+      }
     }
   ],
   valid: [

--- a/test/rules/assertions/checkTagNames.js
+++ b/test/rules/assertions/checkTagNames.js
@@ -195,6 +195,102 @@ export default {
           }
         }
       }
+    },
+    {
+      code: `
+          /**
+           * @todo
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Blacklisted tag found (`@todo`)'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            todo: false
+          }
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @todo
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Please resolve to-dos or add to the tracker'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            todo: {
+              message: 'Please resolve to-dos or add to the tracker'
+            }
+          }
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @todo
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Please use x-todo instead of todo'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            todo: {
+              message: 'Please use {{replacement}} instead of {{tagName}}',
+              replacement: 'x-todo'
+            }
+          }
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @todo
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Please use x-todo instead of todo'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            todo: {
+              message: 'Please use {{preferredTagName}} instead of {{tagName}}',
+              replacement: 'x-todo'
+            }
+          }
+        }
+      }
     }
   ],
   valid: [
@@ -278,6 +374,16 @@ export default {
            *
            */
           function quux (foo) {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @todo
+           */
+          function quux () {
 
           }
       `

--- a/test/rules/assertions/checkTagNames.js
+++ b/test/rules/assertions/checkTagNames.js
@@ -260,7 +260,7 @@ export default {
         jsdoc: {
           tagNamePreference: {
             todo: {
-              message: 'Please use {{replacement}} instead of {{tagName}}',
+              message: 'Please use x-todo instead of todo',
               replacement: 'x-todo'
             }
           }
@@ -285,7 +285,7 @@ export default {
         jsdoc: {
           tagNamePreference: {
             todo: {
-              message: 'Please use {{preferredTagName}} instead of {{tagName}}',
+              message: 'Please use x-todo instead of todo',
               replacement: 'x-todo'
             }
           }

--- a/test/rules/assertions/requireDescription.js
+++ b/test/rules/assertions/requireDescription.js
@@ -156,6 +156,53 @@ export default {
           ]
         }
       ]
+    },
+    {
+      code: `
+          /**
+           * @someDesc
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @someDesc description.'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            description: {
+              message: 'Please avoid `{{tagName}}`; use `{{replacement}}` instead',
+              replacement: 'someDesc'
+            }
+          }
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           * @description
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Unexpected tag `@description`'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            description: false
+          }
+        }
+      }
     }
   ],
   valid: [

--- a/test/rules/assertions/requireHyphenBeforeParamDescription.js
+++ b/test/rules/assertions/requireHyphenBeforeParamDescription.js
@@ -137,6 +137,28 @@ export default {
 
           }
       `
+    },
+    {
+      code: `
+          /**
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Unexpected tag `@param`'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            param: false
+          }
+        }
+      }
     }
   ],
   valid: [

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -236,6 +236,28 @@ export default {
       parserOptions: {
         sourceType: 'module'
       }
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Unexpected tag `@param`'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            param: false
+          }
+        }
+      }
     }
   ],
   valid: [

--- a/test/rules/assertions/requireParamDescription.js
+++ b/test/rules/assertions/requireParamDescription.js
@@ -38,6 +38,28 @@ export default {
           }
         }
       }
+    },
+    {
+      code: `
+          /**
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Unexpected tag `@param`'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            param: false
+          }
+        }
+      }
     }
   ],
   valid: [

--- a/test/rules/assertions/requireParamName.js
+++ b/test/rules/assertions/requireParamName.js
@@ -31,6 +31,28 @@ export default {
           message: 'There must be an identifier after @param tag.'
         }
       ]
+    },
+    {
+      code: `
+          /**
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Unexpected tag `@param`'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            param: false
+          }
+        }
+      }
     }
   ],
   valid: [

--- a/test/rules/assertions/requireParamType.js
+++ b/test/rules/assertions/requireParamType.js
@@ -38,6 +38,28 @@ export default {
           }
         }
       }
+    },
+    {
+      code: `
+          /**
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Unexpected tag `@param`'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            param: false
+          }
+        }
+      }
     }
   ],
   valid: [

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -250,6 +250,28 @@ export default {
           message: 'Found more than one @returns declaration.'
         }
       ]
+    },
+    {
+      code: `
+          /**
+           * @returns
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Unexpected tag `@returns`'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            returns: false
+          }
+        }
+      }
     }
   ],
   valid: [

--- a/test/rules/assertions/requireReturnsCheck.js
+++ b/test/rules/assertions/requireReturnsCheck.js
@@ -106,6 +106,28 @@ export default {
           message: 'JSDoc @returns declaration present but return expression not available in function.'
         }
       ]
+    },
+    {
+      code: `
+          /**
+           * @returns
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Unexpected tag `@returns`'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            returns: false
+          }
+        }
+      }
     }
   ],
   valid: [

--- a/test/rules/assertions/requireReturnsDescription.js
+++ b/test/rules/assertions/requireReturnsDescription.js
@@ -38,6 +38,28 @@ export default {
           }
         }
       }
+    },
+    {
+      code: `
+          /**
+           * @returns
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Unexpected tag `@returns`'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            returns: false
+          }
+        }
+      }
     }
   ],
   valid: [

--- a/test/rules/assertions/requireReturnsType.js
+++ b/test/rules/assertions/requireReturnsType.js
@@ -54,6 +54,28 @@ export default {
           }
         }
       }
+    },
+    {
+      code: `
+          /**
+           * @returns
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Unexpected tag `@returns`'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            returns: false
+          }
+        }
+      }
     }
   ],
   valid: [


### PR DESCRIPTION
feat(check-tag-names): allow rejecting normally valid tag names and/or providing custom error messages when suggesting tags to reject or replace (fixes #108)

Reporting normally valid tags may be of interest for tags like `@todo`. This is implemented by allowing the user to set targeted `tagNamePreference` tags to `false` or to an object with only a `message` and no `replacement`

Custom messages for `check-tag-names` are implemented by allowing the user to set  targeted `tagNamePreference` tags to an object with `message` and `replacement` (mirroring `preferredTypes` behavior). Note that for other rules leveraging `tagNamePreference` (via `utils.getPreferredTagName`) to find the user's preferred tag name, the `replacement` will be used in the likes of error messages but not the `message`.

Also, for various (param, return, and description-related) rules which have used `tagNamePreference` (via the `utils.getPreferredTagName` utility), report to user if they have blocked (probably inadvertently) and not indicated a replacement for the relevant tag needed by the rule in the `tagNamePreference` setting.