### PR TITLE
require-description-complete-sentence explicit `@description` tag validation

### DIFF
--- a/.README/rules/require-description-complete-sentence.md
+++ b/.README/rules/require-description-complete-sentence.md
@@ -1,16 +1,18 @@
 ### `require-description-complete-sentence`
 
-Requires that block description and tag description are written in complete sentences, i.e.,
+Requires that block description, explicit `@description`, and `@param`/`@returns`
+tag descriptions are written in complete sentences, i.e.,
 
 * Description must start with an uppercase alphabetical character.
 * Paragraphs must start with an uppercase alphabetical character.
 * Sentences must end with a period.
-* Every line in a paragraph (except the first) which starts with an uppercase character must be preceded by a line ending with a period.
+* Every line in a paragraph (except the first) which starts with an uppercase
+  character must be preceded by a line ending with a period.
 
 |||
 |---|---|
 |Context|everywhere|
-|Tags|`param`, `returns`|
-|Aliases|`arg`, `argument`, `return`|
+|Tags|`param`, `returns`, `description`|
+|Aliases|`arg`, `argument`, `return`, `desc`|
 
 <!-- assertions requireDescriptionCompleteSentence -->

--- a/README.md
+++ b/README.md
@@ -3404,24 +3404,34 @@ function quux () {
 <a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence"></a>
 ### <code>require-description-complete-sentence</code>
 
-Requires that block description and tag description are written in complete sentences, i.e.,
+Requires that block description, explicit `@description`, and `@param`/`@returns`
+tag descriptions are written in complete sentences, i.e.,
 
 * Description must start with an uppercase alphabetical character.
 * Paragraphs must start with an uppercase alphabetical character.
 * Sentences must end with a period.
-* Every line in a paragraph (except the first) which starts with an uppercase character must be preceded by a line ending with a period.
+* Every line in a paragraph (except the first) which starts with an uppercase
+  character must be preceded by a line ending with a period.
 
 |||
 |---|---|
 |Context|everywhere|
-|Tags|`param`, `returns`|
-|Aliases|`arg`, `argument`, `return`|
+|Tags|`param`, `returns`, `description`|
+|Aliases|`arg`, `argument`, `return`, `desc`|
 
 The following patterns are considered problems:
 
 ````js
 /**
  * foo.
+ */
+function quux () {
+
+}
+// Message: Sentence should start with an uppercase character.
+
+/**
+ * @description foo.
  */
 function quux () {
 
@@ -3667,6 +3677,13 @@ function quux () {
 
 /**
  *
+ */
+function quux () {
+
+}
+
+/**
+ * @description Foo.
  */
 function quux () {
 

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -111,13 +111,19 @@ export default iterateJsdoc(({
   sourceCode,
   jsdoc,
   report,
-  jsdocNode
+  jsdocNode,
+  utils
 }) => {
   if (!jsdoc.tags ||
     validateDescription(jsdoc.description, report, jsdocNode, sourceCode)
   ) {
     return;
   }
+
+  utils.forEachPreferredTag('description', (matchingJsdocTag, targetTagName) => {
+    const description = (matchingJsdocTag.name + ' ' + matchingJsdocTag.description).trim();
+    validateDescription(description, report, jsdocNode, sourceCode, targetTagName);
+  });
 
   const tags = jsdoc.tags.filter((tag) => {
     return ['param', 'arg', 'argument', 'returns', 'return'].includes(tag.tag);

--- a/test/rules/assertions/requireDescriptionCompleteSentence.js
+++ b/test/rules/assertions/requireDescriptionCompleteSentence.js
@@ -26,6 +26,29 @@ export default {
     {
       code: `
           /**
+           * @description foo.
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Sentence should start with an uppercase character.'
+        }
+      ],
+      output: `
+          /**
+           * @description Foo.
+           */
+          function quux () {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
            * Foo)
            */
           function quux () {
@@ -548,6 +571,16 @@ export default {
       code: `
           /**
            *
+           */
+          function quux () {
+
+          }
+      `
+    },
+    {
+      code: `
+          /**
+           * @description Foo.
            */
           function quux () {
 


### PR DESCRIPTION
feat(require-description-complete-sentence): validate explicit `description` tags

Fixes part of #301 to add checks on explicit `@description` tags (as already done for implicit jsdoc block ones and param/returns descriptions).