### PR TITLE
`match-description`

### DIFF
--- a/.README/rules/match-description.md
+++ b/.README/rules/match-description.md
@@ -82,6 +82,6 @@ Overrides the default contexts (see below).
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|N/A by default but see `tags` options|
 |Settings||
-|Options|`contexts`, `tags` (allows for 'param', 'arg', 'argument', 'returns', 'return'), `mainDescription`, `matchDescription`|
+|Options|`contexts`, `tags` (allows for 'param', 'arg', 'argument', 'returns', 'return', 'description', 'desc'), `mainDescription`, `matchDescription`|
 
 <!-- assertions matchDescription -->

--- a/README.md
+++ b/README.md
@@ -2495,7 +2495,7 @@ Overrides the default contexts (see below).
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|N/A by default but see `tags` options|
 |Settings||
-|Options|`contexts`, `tags` (allows for 'param', 'arg', 'argument', 'returns', 'return'), `mainDescription`, `matchDescription`|
+|Options|`contexts`, `tags` (allows for 'param', 'arg', 'argument', 'returns', 'return', 'description', 'desc'), `mainDescription`, `matchDescription`|
 
 The following patterns are considered problems:
 
@@ -2569,6 +2569,17 @@ function quux (foo) {
 
 }
 // Options: [{"tags":{"param":true}}]
+// Message: JSDoc description does not satisfy the regex pattern.
+
+/**
+ * Foo.
+ *
+ * @description foo foo.
+ */
+function quux (foo) {
+
+}
+// Options: [{"tags":{"description":true}}]
 // Message: JSDoc description does not satisfy the regex pattern.
 
 /**
@@ -2696,6 +2707,16 @@ function quux () {
 // Message: JSDoc description does not satisfy the regex pattern.
 
 /**
+ * @description notRet
+ * @returns Тест.
+ */
+function quux () {
+
+}
+// Options: [{"tags":{"description":"[А-Я][А-я]+\\."}}]
+// Message: JSDoc description does not satisfy the regex pattern.
+
+/**
  * foo.
  */
 class quux {
@@ -2785,6 +2806,15 @@ function quux () {
 // Options: [{"tags":{"returns":"[А-Я][А-я]+\\."}}]
 
 /**
+ * @param notRet
+ * @description Тест.
+ */
+function quux () {
+
+}
+// Options: [{"tags":{"description":"[А-Я][А-я]+\\."}}]
+
+/**
  * Foo
  * bar.
  */
@@ -2799,6 +2829,14 @@ function quux () {
 
 }
 // Options: [{"tags":{"returns":true}}]
+
+/**
+ * @description Foo bar.
+ */
+function quux () {
+
+}
+// Options: [{"tags":{"description":true}}]
 
 /**
  * Foo. {@see Math.sin}.
@@ -2921,6 +2959,14 @@ const q = {
 
 };
 // Options: [{"contexts":[]}]
+
+/**
+ * @description foo.
+ */
+function quux () {
+
+}
+// Options: [{"tags":{"param":true}}]
 ````
 
 

--- a/src/rules/matchDescription.js
+++ b/src/rules/matchDescription.js
@@ -53,9 +53,19 @@ export default iterateJsdoc(({
     return;
   }
 
+  const hasOptionTag = (tagName) => {
+    return {}.hasOwnProperty.call(options.tags, tagName) && options.tags[tagName];
+  };
+
+  utils.forEachPreferredTag('description', (matchingJsdocTag, targetTagName) => {
+    const description = (matchingJsdocTag.name + ' ' + matchingJsdocTag.description).trim();
+    if (hasOptionTag(targetTagName)) {
+      validateDescription(description, matchingJsdocTag);
+    }
+  });
+
   const tags = utils.filterTags(({tag}) => {
-    return tagsWithDescriptions.includes(tag) &&
-      {}.hasOwnProperty.call(options.tags, tag) && options.tags[tag];
+    return tagsWithDescriptions.includes(tag) && hasOptionTag(tag);
   });
 
   tags.some((tag) => {

--- a/src/rules/matchDescription.js
+++ b/src/rules/matchDescription.js
@@ -54,7 +54,7 @@ export default iterateJsdoc(({
   }
 
   const hasOptionTag = (tagName) => {
-    return {}.hasOwnProperty.call(options.tags, tagName) && options.tags[tagName];
+    return Boolean(options.tags[tagName]);
   };
 
   utils.forEachPreferredTag('description', (matchingJsdocTag, targetTagName) => {

--- a/test/rules/assertions/matchDescription.js
+++ b/test/rules/assertions/matchDescription.js
@@ -163,6 +163,31 @@ export default {
     {
       code: `
           /**
+           * Foo.
+           *
+           * @description foo foo.
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 5,
+          message: 'JSDoc description does not satisfy the regex pattern.'
+        }
+      ],
+      options: [
+        {
+          tags: {
+            description: true
+          }
+        }
+      ]
+    },
+    {
+      code: `
+          /**
            * Foo
            *
            * @param foo foo.
@@ -443,6 +468,28 @@ export default {
     {
       code: `
           /**
+           * @description notRet
+           * @returns Тест.
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'JSDoc description does not satisfy the regex pattern.'
+        }
+      ],
+      options: [{
+        tags: {
+          description: '[\u0410-\u042F][\u0410-\u044F]+\\.'
+        }
+      }]
+    },
+    {
+      code: `
+          /**
            * foo.
            */
           class quux {
@@ -618,6 +665,22 @@ export default {
     {
       code: `
           /**
+           * @param notRet
+           * @description Тест.
+           */
+          function quux () {
+
+          }
+      `,
+      options: [{
+        tags: {
+          description: '[\u0410-\u042F][\u0410-\u044F]+\\.'
+        }
+      }]
+    },
+    {
+      code: `
+          /**
            * Foo
            * bar.
            */
@@ -639,6 +702,23 @@ export default {
         {
           tags: {
             returns: true
+          }
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * @description Foo bar.
+           */
+          function quux () {
+
+          }
+      `,
+      options: [
+        {
+          tags: {
+            description: true
           }
         }
       ]
@@ -841,6 +921,21 @@ export default {
           contexts: [
           ]
         }
+      ]
+    },
+    {
+      code: `
+          /**
+           * @description foo.
+           */
+          function quux () {
+
+          }
+      `,
+      options: [
+        {tags: {
+          param: true
+        }}
       ]
     }
   ]


### PR DESCRIPTION
feat(match-description): allow `description` and `desc` tags to be matched for validation

Fixes part of #301. This expands the tags that can be validated through the existing `tags` option to include `@description`/`@desc` tags.