### PR TITLE
`matchImplicit` option for `require-description`

### DIFF
--- a/.README/rules/require-description.md
+++ b/.README/rules/require-description.md
@@ -2,25 +2,32 @@
 
 Requires that all functions have a description.
 
-* All functions must have a `@description` tag.
-* Every description tag must have a non-empty description that explains the purpose of the method.
+* All functions must have an implicit description or have the option
+  `descriptionStyle` set to `tag`.
+* Every jsdoc block description (or description tag if `descriptionStyle` is
+  `"tag"`) must have a non-empty description that explains the purpose of the
+  method.
 
 #### Options
 
 An options object may have any of the following properties:
 
 - `contexts` - Set to an array of strings representing the AST context
-  where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
-  Overrides the default contexts (see below).
-- `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
-    block avoids the need for a `@description`. Defaults to an empty array.
+  where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6
+  classes). Overrides the default contexts (see below).
+- `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the
+    document block avoids the need for a `@description`. Defaults to an
+    empty array.
+- `descriptionStyle` - Whether to accept implicit descriptions (`"body"`) or
+    `@description` tags (`"tag"`) as satisfying the rule. Set to `"any"` to
+    accept either style. Defaults to `"body"`.
 
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
-|Tags|`description`|
+|Tags|`description` or jsdoc block|
 |Aliases|`desc`|
-|Options|`contexts`, `exemptedBy`|
+|Options|`contexts`, `exemptedBy`, `descriptionStyle`|
 |Settings|`overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`|
 
 <!-- assertions requireDescription -->

--- a/README.md
+++ b/README.md
@@ -3709,8 +3709,11 @@ function quux () {
 
 Requires that all functions have a description.
 
-* All functions must have a `@description` tag.
-* Every description tag must have a non-empty description that explains the purpose of the method.
+* All functions must have an implicit description or have the option
+  `descriptionStyle` set to `tag`.
+* Every jsdoc block description (or description tag if `descriptionStyle` is
+  `"tag"`) must have a non-empty description that explains the purpose of the
+  method.
 
 <a name="eslint-plugin-jsdoc-rules-require-description-options-6"></a>
 #### Options
@@ -3718,17 +3721,21 @@ Requires that all functions have a description.
 An options object may have any of the following properties:
 
 - `contexts` - Set to an array of strings representing the AST context
-  where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
-  Overrides the default contexts (see below).
-- `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
-    block avoids the need for a `@description`. Defaults to an empty array.
+  where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6
+  classes). Overrides the default contexts (see below).
+- `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the
+    document block avoids the need for a `@description`. Defaults to an
+    empty array.
+- `descriptionStyle` - Whether to accept implicit descriptions (`"body"`) or
+    `@description` tags (`"tag"`) as satisfying the rule. Set to `"any"` to
+    accept either style. Defaults to `"body"`.
 
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
-|Tags|`description`|
+|Tags|`description` or jsdoc block|
 |Aliases|`desc`|
-|Options|`contexts`, `exemptedBy`|
+|Options|`contexts`, `exemptedBy`, `descriptionStyle`|
 |Settings|`overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`|
 
 The following patterns are considered problems:
@@ -3740,6 +3747,34 @@ The following patterns are considered problems:
 function quux () {
 
 }
+// Options: [{"descriptionStyle":"tag"}]
+// Message: Missing JSDoc @description declaration.
+
+/**
+ *
+ */
+function quux () {
+
+}
+// Options: [{"descriptionStyle":"any"}]
+// Message: Missing JSDoc block description or @description declaration.
+
+/**
+ *
+ */
+function quux () {
+
+}
+// Options: [{"descriptionStyle":"body"}]
+// Message: Missing JSDoc block description.
+
+/**
+ *
+ */
+class quux {
+
+}
+// Options: [{"contexts":["ClassDeclaration"],"descriptionStyle":"tag"}]
 // Message: Missing JSDoc @description declaration.
 
 /**
@@ -3748,7 +3783,7 @@ function quux () {
 class quux {
 
 }
-// Options: [{"contexts":["ClassDeclaration"]}]
+// Options: [{"contexts":["ClassDeclaration"],"descriptionStyle":"tag"}]
 // Message: Missing JSDoc @description declaration.
 
 /**
@@ -3757,16 +3792,7 @@ class quux {
 class quux {
 
 }
-// Options: [{"contexts":["ClassDeclaration"]}]
-// Message: Missing JSDoc @description declaration.
-
-/**
- *
- */
-class quux {
-
-}
-// Options: [{"contexts":["ClassDeclaration"]}]
+// Options: [{"contexts":["ClassDeclaration"],"descriptionStyle":"tag"}]
 // Message: Missing JSDoc @description declaration.
 
 /**
@@ -3775,6 +3801,7 @@ class quux {
 function quux () {
 
 }
+// Options: [{"descriptionStyle":"tag"}]
 // Message: Missing JSDoc @description description.
 
 /**
@@ -3783,7 +3810,7 @@ function quux () {
 interface quux {
 
 }
-// Options: [{"contexts":["TSInterfaceDeclaration"]}]
+// Options: [{"contexts":["TSInterfaceDeclaration"],"descriptionStyle":"tag"}]
 // Message: Missing JSDoc @description declaration.
 
 /**
@@ -3792,7 +3819,7 @@ interface quux {
 var quux = class {
 
 };
-// Options: [{"contexts":["ClassExpression"]}]
+// Options: [{"contexts":["ClassExpression"],"descriptionStyle":"tag"}]
 // Message: Missing JSDoc @description declaration.
 
 /**
@@ -3801,7 +3828,7 @@ var quux = class {
 var quux = {
 
 };
-// Options: [{"contexts":["ObjectExpression"]}]
+// Options: [{"contexts":["ObjectExpression"],"descriptionStyle":"tag"}]
 // Message: Missing JSDoc @description declaration.
 
 /**
@@ -3811,6 +3838,7 @@ function quux () {
 
 }
 // Settings: {"jsdoc":{"tagNamePreference":{"description":{"message":"Please avoid `{{tagName}}`; use `{{replacement}}` instead","replacement":"someDesc"}}}}
+// Options: [{"descriptionStyle":"tag"}]
 // Message: Missing JSDoc @someDesc description.
 
 /**
@@ -3820,6 +3848,7 @@ function quux () {
 
 }
 // Settings: {"jsdoc":{"tagNamePreference":{"description":false}}}
+// Options: [{"descriptionStyle":"tag"}]
 // Message: Unexpected tag `@description`
 ````
 
@@ -3833,6 +3862,7 @@ The following patterns are not considered problems:
 function quux () {
 
 }
+// Options: [{"descriptionStyle":"tag"}]
 
 /**
  * @description
@@ -3841,6 +3871,7 @@ function quux () {
 function quux () {
 
 }
+// Options: [{"descriptionStyle":"tag"}]
 
 /**
  * @description <caption>Valid usage</caption>
@@ -3852,6 +3883,7 @@ function quux () {
 function quux () {
 
 }
+// Options: [{"descriptionStyle":"tag"}]
 
 /**
  *
@@ -3859,6 +3891,7 @@ function quux () {
 class quux {
 
 }
+// Options: [{"descriptionStyle":"tag"}]
 
 /**
  *
@@ -3882,6 +3915,7 @@ function quux () {
 interface quux {
 
 }
+// Options: [{"descriptionStyle":"tag"}]
 
 /**
  *
@@ -3889,6 +3923,7 @@ interface quux {
 var quux = class {
 
 };
+// Options: [{"descriptionStyle":"tag"}]
 
 /**
  *
@@ -3896,6 +3931,38 @@ var quux = class {
 var quux = {
 
 };
+// Options: [{"descriptionStyle":"tag"}]
+
+/**
+ * Has an implicit description
+ */
+function quux () {
+
+}
+// Options: [{"descriptionStyle":"body"}]
+
+/**
+ * Has an implicit description
+ */
+function quux () {
+
+}
+
+/**
+ * Has an implicit description
+ */
+function quux () {
+
+}
+// Options: [{"descriptionStyle":"any"}]
+
+/**
+ * @description Has an explicit description
+ */
+function quux () {
+
+}
+// Options: [{"descriptionStyle":"any"}]
 ````
 
 

--- a/test/rules/assertions/requireDescription.js
+++ b/test/rules/assertions/requireDescription.js
@@ -13,6 +13,51 @@ export default {
         {
           message: 'Missing JSDoc @description declaration.'
         }
+      ],
+      options: [
+        {
+          descriptionStyle: 'tag'
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc block description or @description declaration.'
+        }
+      ],
+      options: [
+        {
+          descriptionStyle: 'any'
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc block description.'
+        }
+      ],
+      options: [
+        {
+          descriptionStyle: 'body'
+        }
       ]
     },
     {
@@ -31,7 +76,8 @@ export default {
       ],
       options: [
         {
-          contexts: ['ClassDeclaration']
+          contexts: ['ClassDeclaration'],
+          descriptionStyle: 'tag'
         }
       ]
     },
@@ -51,7 +97,8 @@ export default {
       ],
       options: [
         {
-          contexts: ['ClassDeclaration']
+          contexts: ['ClassDeclaration'],
+          descriptionStyle: 'tag'
         }
       ]
     },
@@ -71,7 +118,8 @@ export default {
       ],
       options: [
         {
-          contexts: ['ClassDeclaration']
+          contexts: ['ClassDeclaration'],
+          descriptionStyle: 'tag'
         }
       ]
     },
@@ -87,6 +135,11 @@ export default {
       errors: [
         {
           message: 'Missing JSDoc @description description.'
+        }
+      ],
+      options: [
+        {
+          descriptionStyle: 'tag'
         }
       ]
     },
@@ -108,7 +161,8 @@ export default {
         {
           contexts: [
             'TSInterfaceDeclaration'
-          ]
+          ],
+          descriptionStyle: 'tag'
         }
       ],
       parser: require.resolve('@typescript-eslint/parser')
@@ -131,7 +185,8 @@ export default {
         {
           contexts: [
             'ClassExpression'
-          ]
+          ],
+          descriptionStyle: 'tag'
         }
       ]
     },
@@ -153,7 +208,8 @@ export default {
         {
           contexts: [
             'ObjectExpression'
-          ]
+          ],
+          descriptionStyle: 'tag'
         }
       ]
     },
@@ -169,6 +225,11 @@ export default {
       errors: [
         {
           message: 'Missing JSDoc @someDesc description.'
+        }
+      ],
+      options: [
+        {
+          descriptionStyle: 'tag'
         }
       ],
       settings: {
@@ -196,6 +257,11 @@ export default {
           message: 'Unexpected tag `@description`'
         }
       ],
+      options: [
+        {
+          descriptionStyle: 'tag'
+        }
+      ],
       settings: {
         jsdoc: {
           tagNamePreference: {
@@ -215,7 +281,12 @@ export default {
           function quux () {
 
           }
-      `
+      `,
+      options: [
+        {
+          descriptionStyle: 'tag'
+        }
+      ]
     },
     {
       code: `
@@ -226,7 +297,12 @@ export default {
           function quux () {
 
           }
-      `
+      `,
+      options: [
+        {
+          descriptionStyle: 'tag'
+        }
+      ]
     },
     {
       code: `
@@ -240,7 +316,12 @@ export default {
           function quux () {
 
           }
-      `
+      `,
+      options: [
+        {
+          descriptionStyle: 'tag'
+        }
+      ]
     },
     {
       code: `
@@ -250,7 +331,12 @@ export default {
           class quux {
 
           }
-      `
+      `,
+      options: [
+        {
+          descriptionStyle: 'tag'
+        }
+      ]
     },
     {
       code: `
@@ -291,6 +377,11 @@ export default {
 
           }
       `,
+      options: [
+        {
+          descriptionStyle: 'tag'
+        }
+      ],
       parser: require.resolve('@typescript-eslint/parser')
     },
     {
@@ -301,7 +392,12 @@ export default {
           var quux = class {
 
           };
-      `
+      `,
+      options: [
+        {
+          descriptionStyle: 'tag'
+        }
+      ]
     },
     {
       code: `
@@ -311,7 +407,67 @@ export default {
           var quux = {
 
           };
+      `,
+      options: [
+        {
+          descriptionStyle: 'tag'
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * Has an implicit description
+           */
+          function quux () {
+
+          }
+      `,
+      options: [
+        {
+          descriptionStyle: 'body'
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * Has an implicit description
+           */
+          function quux () {
+
+          }
       `
+    },
+    {
+      code: `
+          /**
+           * Has an implicit description
+           */
+          function quux () {
+
+          }
+      `,
+      options: [
+        {
+          descriptionStyle: 'any'
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * @description Has an explicit description
+           */
+          function quux () {
+
+          }
+      `,
+      options: [
+        {
+          descriptionStyle: 'any'
+        }
+      ]
     }
   ]
 };


### PR DESCRIPTION
~feat(`require-description`): add `matchImplicit` option to accept implicit descriptions as satisfying the rule (fixes #301)~

feat(`require-description`): add `descriptionStyle` option to accept implicit descriptions as satisfying the rule by default (fixes #301)

BREAKING CHANGE:

To restore old behavior, set the option `descriptionStyle` to `"tag"`

----

Other alternatives would be to allow implicit descriptions (i.e., jsdoc blocks with any non-tag intro text) as satisfying this rule by default. An advantage of such an approach would be that it would more closely match how `match-description` and `require-description-complete-sentence` behave as they automatically check both implicit and explicit descriptions now.

But since people have been using the `require-description` rule so far to insist on an explicit `@description`, I think if such a breaking change were to be made to accept implicit descriptions, such a change should at least be accompanied by an option (maybe `matchExplicitOnly`) so people can at least opt back in to the old behavior of only accepting an explicit `@description`.

~In case you didn't want such a breaking change, I thought I'd start with a non-breaking version, though I should be able to easily adapt it to the breaking version if you prefer that instead.~ *Done.*