### PR TITLE
fix: move escape-regex-string to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "comment-parser": "^0.5.5",
     "debug": "^4.1.1",
+    "escape-regex-string": "^1.0.6",
     "flat-map-polyfill": "^0.3.8",
     "jsdoctypeparser": "4.0.0",
     "lodash": "^4.17.11"
@@ -24,7 +25,6 @@
     "babel-plugin-add-module-exports": "^1.0.2",
     "babel-plugin-istanbul": "^5.1.4",
     "chai": "^4.2.0",
-    "escape-regex-string": "^1.0.6",
     "eslint": "^6.0.1",
     "eslint-config-canonical": "^17.1.1",
     "gitdown": "^2.6.1",


### PR DESCRIPTION
Fixes https://github.com/gajus/eslint-plugin-jsdoc/issues/314

Moves `escape-regex-string` to dependencies