### PR TITLE
Move settings to options

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -123,12 +123,6 @@ You can then selectively add to or override the recommended rules.
 - `settings.jsdoc.ignorePrivate` - Disables all rules for the comment block
   on which it occurs.
 
-### Exempting empty functions from `require-jsdoc`
-
-- `settings.jsdoc.exemptEmptyFunctions` - Will not report missing jsdoc blocks
-  above functions/methods with no parameters or return values (intended where
-  variable names are sufficient for themselves as documentation).
-
 ### Alias Preference
 
 Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a JSDoc tag. The format of the configuration is: `<primary tag name>: <preferred alias name>`, e.g.
@@ -320,33 +314,6 @@ See the option of `check-types`, `unifyParentAndChildTypeChecks`, for
 how the keys of `preferredTypes` may have `<>` or `.<>` (or just `.`)
 appended and its bearing on whether types are checked as parents/children
 only (e.g., to match `Array` if the type is `Array` vs. `Array.<string>`).
-
-### Settings to Configure `valid-types`
-
-* `settings.jsdoc.allowEmptyNamepaths` - Set to `false` to disallow
-  empty name paths with `@callback`, `@event`, `@class`, `@constructor`,
-  `@constant`, `@const`, `@function`, `@func`, `@method`, `@interface`,
-  `@member`, `@var`, `@mixin`, `@namespace`, `@listens`, `@fires`,
-  or `@emits` (these might often be expected to have an accompanying
-  name path, though they have some indicative value without one; these
-  may also allow names to be defined in another manner elsewhere in
-  the block)
-* `settings.jsdoc.checkSeesForNamepaths` - Set this to `true` to insist
-  that `@see` only use name paths (the tag is normally permitted to
-  allow other text)
-
-### Settings to Configure `require-returns`
-
-* `settings.jsdoc.forceRequireReturn` - Set to `true` to always insist on
-  `@returns` documentation regardless of implicit or explicit `return`'s
-  in the function. May be desired to flag that a project is aware of an
-  `undefined`/`void` return.
-
-### Settings to Configure `require-example`
-
-* `settings.jsdoc.avoidExampleOnConstructors` - Set to `true` to avoid the
-  need for an example on a constructor (whether indicated as such by a
-  jsdoc tag or by being within an ES6 `class`).
 
 ### Settings to Configure `check-examples`
 

--- a/.README/rules/require-example.md
+++ b/.README/rules/require-example.md
@@ -7,10 +7,14 @@ Requires that all functions have examples.
 
 #### Options
 
-Has an object option with one optional property:
+This rule has an object option:
 
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
   block avoids the need for an `@example`. Defaults to an empty array.
+
+- `avoidExampleOnConstructors` (default: false) - Set to `true` to avoid the
+  need for an example on a constructor (whether indicated as such by a
+  jsdoc tag or by being within an ES6 `class`).
 
 |||
 |---|---|

--- a/.README/rules/require-example.md
+++ b/.README/rules/require-example.md
@@ -20,7 +20,6 @@ This rule has an object option:
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
 |Tags|`example`|
-|Options|`exemptedBy`|
-|Settings|`avoidExampleOnConstructors`|
+|Options|`exemptedBy`, `avoidExampleOnConstructors`|
 
 <!-- assertions requireExample -->

--- a/.README/rules/require-jsdoc.md
+++ b/.README/rules/require-jsdoc.md
@@ -44,7 +44,6 @@ Accepts one optional options object with the following optional keys.
 |---|---|
 |Context|`ArrowFunctionExpression`, `ClassDeclaration`, `ClassExpression`, `FunctionDeclaration`, `FunctionExpression`|
 |Tags|N/A|
-|Options|`publicOnly`, `require`, `contexts`|
-|Settings|`exemptEmptyFunctions`|
+|Options|`publicOnly`, `require`, `contexts`, `exemptEmptyFunctions`|
 
 <!-- assertions requireJsdoc -->

--- a/.README/rules/require-jsdoc.md
+++ b/.README/rules/require-jsdoc.md
@@ -36,6 +36,10 @@ Accepts one optional options object with the following optional keys.
   AST contexts where you wish the rule to be applied (e.g., `Property` for
   properties). Defaults to an empty array.
 
+- `exemptEmptyFunctions` (default: false) - When `true`, the rule will not report
+  missing jsdoc blocks above functions/methods with no parameters or return values
+  (intended where variable names are sufficient for themselves as documentation).
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `ClassDeclaration`, `ClassExpression`, `FunctionDeclaration`, `FunctionExpression`|

--- a/.README/rules/require-returns.md
+++ b/.README/rules/require-returns.md
@@ -6,6 +6,10 @@ Requires returns are documented.
 
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
     block avoids the need for a `@returns`. Defaults to an empty array.
+- `forceRequireReturn` - Set to `true` to always insist on
+  `@returns` documentation regardless of implicit or explicit `return`'s
+  in the function. May be desired to flag that a project is aware of an
+  `undefined`/`void` return. Defaults to `false`.
 - `forceReturnsWithAsync` - By default `async` functions that do not explicitly return a value pass this rule. You can force all `async` functions to require return statements by setting `forceReturnsWithAsync` to `true` on the options object. This may be useful as an `async` function will always return a `Promise`, even if the `Promise` returns void. Defaults to `false`.
 
 ```js

--- a/.README/rules/require-returns.md
+++ b/.README/rules/require-returns.md
@@ -21,7 +21,6 @@ Requires returns are documented.
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
 |Tags|`returns`|
 |Aliases|`return`|
-|Settings|`forceRequireReturn`|
-|Options|`exemptedBy`, `forceReturnsWithAsync`|
+|Options|`exemptedBy`, `forceRequireReturn`, `forceReturnsWithAsync`|
 
 <!-- assertions requireReturns -->

--- a/.README/rules/valid-types.md
+++ b/.README/rules/valid-types.md
@@ -32,6 +32,21 @@ Also impacts behaviors on namepath (or event)-defining and pointing tags:
    allow `#`, `.`, or `~` at the end (which is not allowed at the end of
    normal paths).
 
+#### Options
+
+- `allowEmptyNamepaths` (default: true) - Set to `false` to disallow
+  empty name paths with `@callback`, `@event`, `@class`, `@constructor`,
+  `@constant`, `@const`, `@function`, `@func`, `@method`, `@interface`,
+  `@member`, `@var`, `@mixin`, `@namespace`, `@listens`, `@fires`,
+  or `@emits` (these might often be expected to have an accompanying
+  name path, though they have some indicative value without one; these
+  may also allow names to be defined in another manner elsewhere in
+  the block)
+- `checkSeesForNamepaths` (default: false) - Set this to `true` to insist
+  that `@see` only use name paths (the tag is normally permitted to
+  allow other text)
+
+
 |||
 |---|---|
 |Context|everywhere|

--- a/.README/rules/valid-types.md
+++ b/.README/rules/valid-types.md
@@ -53,6 +53,6 @@ Also impacts behaviors on namepath (or event)-defining and pointing tags:
 |Tags|For name only unless otherwise stated: `alias`, `augments`, `borrows`, `callback`, `class` (for name and type), `constant` (for name and type), `enum` (for type), `event`, `external`, `fires`, `function`, `implements` (for type), `interface`, `lends`, `listens`, `member` (for name and type),  `memberof`, `memberof!`, `mixes`, `mixin`, `module` (for name and type), `name`, `namespace` (for name and type), `param` (for name and type), `property` (for name and type), `returns` (for type), `this`, `throws` (for type), `type` (for type), `typedef` (for name and type), `yields` (for type)|
 |Aliases|`extends`, `constructor`, `const`, `host`, `emits`, `func`, `method`, `var`, `arg`, `argument`, `prop`, `return`, `exception`, `yield`|
 |Closure-only|For type only: `package`, `private`, `protected`, `public`, `static`|
-|Settings|`allowEmptyNamepaths`, `checkSeesForNamepaths`|
+|Options|`allowEmptyNamepaths`, `checkSeesForNamepaths`|
 
 <!-- assertions validTypes -->

--- a/README.md
+++ b/README.md
@@ -14,13 +14,9 @@ JSDoc linting rules for ESLint.
     * [Configuration](#eslint-plugin-jsdoc-configuration)
     * [Settings](#eslint-plugin-jsdoc-settings)
         * [Allow `@private` to disable rules for that comment block](#eslint-plugin-jsdoc-settings-allow-private-to-disable-rules-for-that-comment-block)
-        * [Exempting empty functions from `require-jsdoc`](#eslint-plugin-jsdoc-settings-exempting-empty-functions-from-require-jsdoc)
         * [Alias Preference](#eslint-plugin-jsdoc-settings-alias-preference)
         * [`@override`/`@augments`/`@extends`/`@implements` Without Accompanying `@param`/`@description`/`@example`/`@returns`](#eslint-plugin-jsdoc-settings-override-augments-extends-implements-without-accompanying-param-description-example-returns)
         * [Settings to Configure `check-types` and `no-undefined-types`](#eslint-plugin-jsdoc-settings-settings-to-configure-check-types-and-no-undefined-types)
-        * [Settings to Configure `valid-types`](#eslint-plugin-jsdoc-settings-settings-to-configure-valid-types)
-        * [Settings to Configure `require-returns`](#eslint-plugin-jsdoc-settings-settings-to-configure-require-returns)
-        * [Settings to Configure `require-example`](#eslint-plugin-jsdoc-settings-settings-to-configure-require-example)
         * [Settings to Configure `check-examples`](#eslint-plugin-jsdoc-settings-settings-to-configure-check-examples)
     * [Rules](#eslint-plugin-jsdoc-rules)
         * [`check-alignment`](#eslint-plugin-jsdoc-rules-check-alignment)
@@ -169,13 +165,6 @@ You can then selectively add to or override the recommended rules.
 
 - `settings.jsdoc.ignorePrivate` - Disables all rules for the comment block
   on which it occurs.
-
-<a name="eslint-plugin-jsdoc-settings-exempting-empty-functions-from-require-jsdoc"></a>
-### Exempting empty functions from <code>require-jsdoc</code>
-
-- `settings.jsdoc.exemptEmptyFunctions` - Will not report missing jsdoc blocks
-  above functions/methods with no parameters or return values (intended where
-  variable names are sufficient for themselves as documentation).
 
 <a name="eslint-plugin-jsdoc-settings-alias-preference"></a>
 ### Alias Preference
@@ -371,36 +360,6 @@ See the option of `check-types`, `unifyParentAndChildTypeChecks`, for
 how the keys of `preferredTypes` may have `<>` or `.<>` (or just `.`)
 appended and its bearing on whether types are checked as parents/children
 only (e.g., to match `Array` if the type is `Array` vs. `Array.<string>`).
-
-<a name="eslint-plugin-jsdoc-settings-settings-to-configure-valid-types"></a>
-### Settings to Configure <code>valid-types</code>
-
-* `settings.jsdoc.allowEmptyNamepaths` - Set to `false` to disallow
-  empty name paths with `@callback`, `@event`, `@class`, `@constructor`,
-  `@constant`, `@const`, `@function`, `@func`, `@method`, `@interface`,
-  `@member`, `@var`, `@mixin`, `@namespace`, `@listens`, `@fires`,
-  or `@emits` (these might often be expected to have an accompanying
-  name path, though they have some indicative value without one; these
-  may also allow names to be defined in another manner elsewhere in
-  the block)
-* `settings.jsdoc.checkSeesForNamepaths` - Set this to `true` to insist
-  that `@see` only use name paths (the tag is normally permitted to
-  allow other text)
-
-<a name="eslint-plugin-jsdoc-settings-settings-to-configure-require-returns"></a>
-### Settings to Configure <code>require-returns</code>
-
-* `settings.jsdoc.forceRequireReturn` - Set to `true` to always insist on
-  `@returns` documentation regardless of implicit or explicit `return`'s
-  in the function. May be desired to flag that a project is aware of an
-  `undefined`/`void` return.
-
-<a name="eslint-plugin-jsdoc-settings-settings-to-configure-require-example"></a>
-### Settings to Configure <code>require-example</code>
-
-* `settings.jsdoc.avoidExampleOnConstructors` - Set to `true` to avoid the
-  need for an example on a constructor (whether indicated as such by a
-  jsdoc tag or by being within an ES6 `class`).
 
 <a name="eslint-plugin-jsdoc-settings-settings-to-configure-check-examples"></a>
 ### Settings to Configure <code>check-examples</code>
@@ -3942,10 +3901,14 @@ Requires that all functions have examples.
 <a name="eslint-plugin-jsdoc-rules-require-example-options-6"></a>
 #### Options
 
-Has an object option with one optional property:
+This rule has an object option:
 
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
   block avoids the need for an `@example`. Defaults to an empty array.
+
+- `avoidExampleOnConstructors` (default: false) - Set to `true` to avoid the
+  need for an example on a constructor (whether indicated as such by a
+  jsdoc tag or by being within an ES6 `class`).
 
 |||
 |---|---|
@@ -3972,6 +3935,15 @@ function quux () {
 
 }
 // Message: Missing JSDoc @example description.
+
+/**
+ * @constructor
+ */
+function f () {
+
+}
+// Settings: {"jsdoc":{"avoidExampleOnConstructors":true}}
+// Message: `settings.jsdoc.avoidExampleOnConstructors` has been removed, use options in the rule `require-example` instead.
 
 /**
  * @constructor
@@ -4027,7 +3999,7 @@ function quux () {
 function quux () {
 
 }
-// Settings: {"jsdoc":{"avoidExampleOnConstructors":true}}
+// Options: [{"avoidExampleOnConstructors":true}]
 
 /**
  * @constructor
@@ -4036,7 +4008,7 @@ function quux () {
 function quux () {
 
 }
-// Settings: {"jsdoc":{"avoidExampleOnConstructors":true}}
+// Options: [{"avoidExampleOnConstructors":true}]
 
 class Foo {
   /**
@@ -4046,7 +4018,7 @@ class Foo {
 
   }
 }
-// Settings: {"jsdoc":{"avoidExampleOnConstructors":true}}
+// Options: [{"avoidExampleOnConstructors":true}]
 
 /**
  * @inheritdoc
@@ -4210,6 +4182,10 @@ Accepts one optional options object with the following optional keys.
   AST contexts where you wish the rule to be applied (e.g., `Property` for
   properties). Defaults to an empty array.
 
+- `exemptEmptyFunctions` (default: false) - When `true`, the rule will not report
+  missing jsdoc blocks above functions/methods with no parameters or return values
+  (intended where variable names are sufficient for themselves as documentation).
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `ClassDeclaration`, `ClassExpression`, `FunctionDeclaration`, `FunctionExpression`|
@@ -4266,10 +4242,14 @@ function quux (foo) {
 }
 // Message: Missing JSDoc comment.
 
+
+// Settings: {"jsdoc":{"exemptEmptyFunctions":true}}
+// Message: `settings.jsdoc.exemptEmptyFunctions` has been removed, use options in the rule `require-jsdoc` instead.
+
 function quux (foo) {
 
 }
-// Settings: {"jsdoc":{"exemptEmptyFunctions":true}}
+// Options: [{"exemptEmptyFunctions":true}]
 // Message: Missing JSDoc comment.
 
 function myFunction() {}
@@ -4355,13 +4335,13 @@ var foo = {bar: function() {}}
 // Message: Missing JSDoc comment.
 
 function foo (abc) {}
-// Settings: {"jsdoc":{"exemptEmptyFunctions":false}}
+// Options: [{"exemptEmptyFunctions":false}]
 // Message: Missing JSDoc comment.
 
 function foo () {
   return true;
 }
-// Settings: {"jsdoc":{"exemptEmptyFunctions":false}}
+// Options: [{"exemptEmptyFunctions":false}]
 // Message: Missing JSDoc comment.
 
 module.exports = function quux () {
@@ -4758,12 +4738,12 @@ var foo = { [function() {}]: 1 };
 // Options: [{"require":{"FunctionExpression":true}}]
 
 function foo () {}
-// Settings: {"jsdoc":{"exemptEmptyFunctions":true}}
+// Options: [{"exemptEmptyFunctions":true}]
 
 function foo () {
   return;
 }
-// Settings: {"jsdoc":{"exemptEmptyFunctions":true}}
+// Options: [{"exemptEmptyFunctions":true}]
 
 const test = {};
 /**
@@ -6144,6 +6124,10 @@ Requires returns are documented.
 
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
     block avoids the need for a `@returns`. Defaults to an empty array.
+- `forceRequireReturn` - Set to `true` to always insist on
+  `@returns` documentation regardless of implicit or explicit `return`'s
+  in the function. May be desired to flag that a project is aware of an
+  `undefined`/`void` return. Defaults to `false`.
 - `forceReturnsWithAsync` - By default `async` functions that do not explicitly return a value pass this rule. You can force all `async` functions to require return statements by setting `forceReturnsWithAsync` to `true` on the options object. This may be useful as an `async` function will always return a `Promise`, even if the `Promise` returns void. Defaults to `false`.
 
 ```js
@@ -6203,30 +6187,42 @@ function quux (foo) {
 /**
  *
  */
+function foo() {}
+
+/**
+ *
+ */
+function bar() {}
+// Settings: {"jsdoc":{"forceRequireReturn":true}}
+// Message: `settings.jsdoc.forceRequireReturn` has been removed, use options in the rule `require-returns` instead.
+
+/**
+ *
+ */
 async function quux() {
 }
-// Settings: {"jsdoc":{"forceRequireReturn":true}}
+// Options: [{"forceRequireReturn":true}]
 // Message: Missing JSDoc @returns declaration.
 
 /**
  *
  */
 const quux = async function () {}
-// Settings: {"jsdoc":{"forceRequireReturn":true}}
+// Options: [{"forceRequireReturn":true}]
 // Message: Missing JSDoc @returns declaration.
 
 /**
  *
  */
 const quux = async () => {}
-// Settings: {"jsdoc":{"forceRequireReturn":true}}
+// Options: [{"forceRequireReturn":true}]
 // Message: Missing JSDoc @returns declaration.
 
 /**
 *
 */
 async function quux () {}
-// Settings: {"jsdoc":{"forceRequireReturn":true}}
+// Options: [{"forceRequireReturn":true}]
 // Message: Missing JSDoc @returns declaration.
 
 /**
@@ -6234,7 +6230,7 @@ async function quux () {}
  */
 function quux () {
 }
-// Settings: {"jsdoc":{"forceRequireReturn":true}}
+// Options: [{"forceRequireReturn":true}]
 // Message: Missing JSDoc @returns declaration.
 
 const language = {
@@ -6427,7 +6423,7 @@ class Foo {
   constructor () {
   }
 }
-// Settings: {"jsdoc":{"forceRequireReturn":true}}
+// Options: [{"forceRequireReturn":true}]
 
 const language = {
   /**
@@ -6443,7 +6439,7 @@ const language = {
  */
 function quux () {
 }
-// Settings: {"jsdoc":{"forceRequireReturn":true}}
+// Options: [{"forceRequireReturn":true}]
 
 /**
  * @returns {void}
@@ -6458,7 +6454,7 @@ function quux () {
 function quux () {
   return undefined;
 }
-// Settings: {"jsdoc":{"forceRequireReturn":true}}
+// Options: [{"forceRequireReturn":true}]
 
 /**
  * @returns {void}
@@ -6472,7 +6468,7 @@ function quux () {
  */
 function quux () {
 }
-// Settings: {"jsdoc":{"forceRequireReturn":true}}
+// Options: [{"forceRequireReturn":true}]
 
 /**
  * @returns {void}
@@ -6480,7 +6476,7 @@ function quux () {
 function quux () {
   return;
 }
-// Settings: {"jsdoc":{"forceRequireReturn":true}}
+// Options: [{"forceRequireReturn":true}]
 
 /** @type {RequestHandler} */
 function quux (req, res , next) {
@@ -6492,7 +6488,7 @@ function quux (req, res , next) {
  */
 async function quux () {
 }
-// Settings: {"jsdoc":{"forceRequireReturn":true}}
+// Options: [{"forceRequireReturn":true}]
 
 /**
  * @returns {Promise}
@@ -6579,6 +6575,22 @@ Also impacts behaviors on namepath (or event)-defining and pointing tags:
    allow `#`, `.`, or `~` at the end (which is not allowed at the end of
    normal paths).
 
+<a name="eslint-plugin-jsdoc-rules-valid-types-options-11"></a>
+#### Options
+
+- `allowEmptyNamepaths` (default: true) - Set to `false` to disallow
+  empty name paths with `@callback`, `@event`, `@class`, `@constructor`,
+  `@constant`, `@const`, `@function`, `@func`, `@method`, `@interface`,
+  `@member`, `@var`, `@mixin`, `@namespace`, `@listens`, `@fires`,
+  or `@emits` (these might often be expected to have an accompanying
+  name path, though they have some indicative value without one; these
+  may also allow names to be defined in another manner elsewhere in
+  the block)
+- `checkSeesForNamepaths` (default: false) - Set this to `true` to insist
+  that `@see` only use name paths (the tag is normally permitted to
+  allow other text)
+
+
 |||
 |---|---|
 |Context|everywhere|
@@ -6652,8 +6664,13 @@ function quux() {
 function quux() {
 
 }
-// Settings: {"jsdoc":{"checkSeesForNamepaths":true}}
+// Options: [{"checkSeesForNamepaths":true}]
 // Message: Syntax error in type: foo%
+
+/** */
+function foo() {}
+// Settings: {"jsdoc":{"allowEmptyNamepaths":true,"checkSeesForNamepaths":true}}
+// Message: `settings.jsdoc.allowEmptyNamepaths` has been removed, use options in the rule `valid-types` instead.
 
 /**
  * @alias module:abc#event:foo-bar
@@ -6677,7 +6694,7 @@ function quux() {
 function quux() {
 
 }
-// Settings: {"jsdoc":{"allowEmptyNamepaths":false}}
+// Options: [{"allowEmptyNamepaths":false}]
 // Message: Syntax error in type: 
 ````
 

--- a/README.md
+++ b/README.md
@@ -3914,8 +3914,7 @@ This rule has an object option:
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
 |Tags|`example`|
-|Options|`exemptedBy`|
-|Settings|`avoidExampleOnConstructors`|
+|Options|`exemptedBy`, `avoidExampleOnConstructors`|
 
 The following patterns are considered problems:
 
@@ -4190,8 +4189,7 @@ Accepts one optional options object with the following optional keys.
 |---|---|
 |Context|`ArrowFunctionExpression`, `ClassDeclaration`, `ClassExpression`, `FunctionDeclaration`, `FunctionExpression`|
 |Tags|N/A|
-|Options|`publicOnly`, `require`, `contexts`|
-|Settings|`exemptEmptyFunctions`|
+|Options|`publicOnly`, `require`, `contexts`, `exemptEmptyFunctions`|
 
 The following patterns are considered problems:
 
@@ -6139,8 +6137,7 @@ Requires returns are documented.
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
 |Tags|`returns`|
 |Aliases|`return`|
-|Settings|`forceRequireReturn`|
-|Options|`exemptedBy`, `forceReturnsWithAsync`|
+|Options|`exemptedBy`, `forceRequireReturn`, `forceReturnsWithAsync`|
 
 The following patterns are considered problems:
 
@@ -6597,7 +6594,7 @@ Also impacts behaviors on namepath (or event)-defining and pointing tags:
 |Tags|For name only unless otherwise stated: `alias`, `augments`, `borrows`, `callback`, `class` (for name and type), `constant` (for name and type), `enum` (for type), `event`, `external`, `fires`, `function`, `implements` (for type), `interface`, `lends`, `listens`, `member` (for name and type),  `memberof`, `memberof!`, `mixes`, `mixin`, `module` (for name and type), `name`, `namespace` (for name and type), `param` (for name and type), `property` (for name and type), `returns` (for type), `this`, `throws` (for type), `type` (for type), `typedef` (for name and type), `yields` (for type)|
 |Aliases|`extends`, `constructor`, `const`, `host`, `emits`, `func`, `method`, `var`, `arg`, `argument`, `prop`, `return`, `exception`, `yield`|
 |Closure-only|For type only: `package`, `private`, `protected`, `public`, `static`|
-|Settings|`allowEmptyNamepaths`, `checkSeesForNamepaths`|
+|Options|`allowEmptyNamepaths`, `checkSeesForNamepaths`|
 
 The following patterns are considered problems:
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -275,9 +275,6 @@ const getSettings = (context) => {
   settings.allowImplementsWithoutParam = _.get(context, 'settings.jsdoc.allowImplementsWithoutParam');
   settings.allowAugmentsExtendsWithoutParam = _.get(context, 'settings.jsdoc.allowAugmentsExtendsWithoutParam');
 
-  // `require-example` only
-  settings.avoidExampleOnConstructors = Boolean(_.get(context, 'settings.jsdoc.avoidExampleOnConstructors'));
-
   return settings;
 };
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -281,9 +281,6 @@ const getSettings = (context) => {
   settings.allowEmptyNamepaths = _.get(context, 'settings.jsdoc.allowEmptyNamepaths') !== false;
   settings.checkSeesForNamepaths = Boolean(_.get(context, 'settings.jsdoc.checkSeesForNamepaths'));
 
-  // `require-returns` only
-  settings.forceRequireReturn = Boolean(_.get(context, 'settings.jsdoc.forceRequireReturn'));
-
   // `require-example` only
   settings.avoidExampleOnConstructors = Boolean(_.get(context, 'settings.jsdoc.avoidExampleOnConstructors'));
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -28,14 +28,12 @@ const getUtils = (
   jsdocNode,
   {
     tagNamePreference,
-    allowEmptyNamepaths,
     overrideReplacesDocs,
     implementsReplacesDocs,
     augmentsExtendsReplacesDocs,
     allowOverrideWithoutParam,
     allowImplementsWithoutParam,
-    allowAugmentsExtendsWithoutParam,
-    checkSeesForNamepaths
+    allowAugmentsExtendsWithoutParam
   },
   report,
   context
@@ -158,7 +156,7 @@ const getUtils = (
   utils.isNamepathDefiningTag = (tagName) => {
     return jsdocUtils.isNamepathDefiningTag(tagName);
   };
-  utils.isNamepathTag = (tagName) => {
+  utils.isNamepathTag = (tagName, checkSeesForNamepaths) => {
     return jsdocUtils.isNamepathTag(tagName, checkSeesForNamepaths);
   };
 
@@ -166,7 +164,7 @@ const getUtils = (
     return jsdocUtils.isTagWithType(tagName);
   };
 
-  utils.passesEmptyNamepathCheck = (tag) => {
+  utils.passesEmptyNamepathCheck = (tag, allowEmptyNamepaths) => {
     return !tag.name && allowEmptyNamepaths &&
       jsdocUtils.isPotentiallyEmptyNamepathTag(tag.tag);
   };
@@ -276,10 +274,6 @@ const getSettings = (context) => {
   settings.allowOverrideWithoutParam = _.get(context, 'settings.jsdoc.allowOverrideWithoutParam');
   settings.allowImplementsWithoutParam = _.get(context, 'settings.jsdoc.allowImplementsWithoutParam');
   settings.allowAugmentsExtendsWithoutParam = _.get(context, 'settings.jsdoc.allowAugmentsExtendsWithoutParam');
-
-  // `valid-types` only
-  settings.allowEmptyNamepaths = _.get(context, 'settings.jsdoc.allowEmptyNamepaths') !== false;
-  settings.checkSeesForNamepaths = Boolean(_.get(context, 'settings.jsdoc.checkSeesForNamepaths'));
 
   // `require-example` only
   settings.avoidExampleOnConstructors = Boolean(_.get(context, 'settings.jsdoc.avoidExampleOnConstructors'));

--- a/src/rules/requireExample.js
+++ b/src/rules/requireExample.js
@@ -14,9 +14,7 @@ export default iterateJsdoc(({
     return;
   }
 
-  const options = context.options[0] || {
-    avoidExampleOnConstructors: false
-  };
+  const {avoidExampleOnConstructors = false} = context.options[0] || {};
 
   const targetTagName = 'example';
 
@@ -24,7 +22,7 @@ export default iterateJsdoc(({
     tag: targetTagName
   });
 
-  if (options.avoidExampleOnConstructors && (
+  if (avoidExampleOnConstructors && (
     utils.hasATag([
       'class',
       'constructor'

--- a/src/rules/requireExample.js
+++ b/src/rules/requireExample.js
@@ -1,15 +1,22 @@
 import _ from 'lodash';
 import iterateJsdoc from '../iterateJsdoc';
+import warnRemovedSettings from '../warnRemovedSettings';
 
 export default iterateJsdoc(({
   jsdoc,
   report,
   utils,
-  settings
+  context
 }) => {
+  warnRemovedSettings(context, 'require-example');
+
   if (utils.avoidDocs()) {
     return;
   }
+
+  const options = context.options[0] || {
+    avoidExampleOnConstructors: false
+  };
 
   const targetTagName = 'example';
 
@@ -17,7 +24,7 @@ export default iterateJsdoc(({
     tag: targetTagName
   });
 
-  if (settings.avoidExampleOnConstructors && (
+  if (options.avoidExampleOnConstructors && (
     utils.hasATag([
       'class',
       'constructor'
@@ -46,6 +53,10 @@ export default iterateJsdoc(({
       {
         additionalProperties: false,
         properties: {
+          avoidExampleOnConstructors: {
+            default: false,
+            type: 'boolean'
+          },
           exemptedBy: {
             items: {
               type: 'string'

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -54,10 +54,10 @@ export default iterateJsdoc(({
     return;
   }
 
-  const options = context.options[0] || {
-    forceRequireReturn: false,
-    forceReturnsWithAsync: false
-  };
+  const {
+    forceRequireReturn = false,
+    forceReturnsWithAsync = false
+  } = context.options[0] || {};
 
   const tagName = utils.getPreferredTagName('returns');
   if (!tagName) {
@@ -73,7 +73,7 @@ export default iterateJsdoc(({
   const [tag] = tags;
   const missingReturnTag = typeof tag === 'undefined' || tag === null;
   if (missingReturnTag &&
-    ((utils.isAsync() && !utils.hasReturnValue(true) ? options.forceReturnsWithAsync : utils.hasReturnValue()) || options.forceRequireReturn)
+    ((utils.isAsync() && !utils.hasReturnValue(true) ? forceReturnsWithAsync : utils.hasReturnValue()) || forceRequireReturn)
   ) {
     report(`Missing JSDoc @${tagName} declaration.`);
   }

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -1,4 +1,5 @@
 import iterateJsdoc from '../iterateJsdoc';
+import warnRemovedSettings from '../warnRemovedSettings';
 
 /**
  * We can skip checking for a return value, in case the documentation is inherited
@@ -43,16 +44,20 @@ const canSkip = (utils) => {
 export default iterateJsdoc(({
   report,
   utils,
-  context,
-  settings
+  context
 }) => {
+  warnRemovedSettings(context, 'require-returns');
+
   // A preflight check. We do not need to run a deep check
   // in case the @returns comment is optional or undefined.
   if (canSkip(utils)) {
     return;
   }
 
-  const options = context.options[0] || {};
+  const options = context.options[0] || {
+    forceRequireReturn: false,
+    forceReturnsWithAsync: false
+  };
 
   const tagName = utils.getPreferredTagName('returns');
   if (!tagName) {
@@ -68,7 +73,7 @@ export default iterateJsdoc(({
   const [tag] = tags;
   const missingReturnTag = typeof tag === 'undefined' || tag === null;
   if (missingReturnTag &&
-    ((utils.isAsync() && !utils.hasReturnValue(true) ? options.forceReturnsWithAsync : utils.hasReturnValue()) || settings.forceRequireReturn)
+    ((utils.isAsync() && !utils.hasReturnValue(true) ? options.forceReturnsWithAsync : utils.hasReturnValue()) || options.forceRequireReturn)
   ) {
     report(`Missing JSDoc @${tagName} declaration.`);
   }
@@ -83,6 +88,10 @@ export default iterateJsdoc(({
               type: 'string'
             },
             type: 'array'
+          },
+          forceRequireReturn: {
+            default: false,
+            type: 'boolean'
           },
           forceReturnsWithAsync: {
             default: false,

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -12,10 +12,10 @@ export default iterateJsdoc(({
 }) => {
   warnRemovedSettings(context, 'valid-types');
 
-  const options = context.options[0] || {
-    allowEmptyNamepaths: true,
-    checkSeesForNamepaths: false
-  };
+  const {
+    allowEmptyNamepaths = true,
+    checkSeesForNamepaths = false
+  } = context.options[0] || {};
 
   if (!jsdoc.tags) {
     return;
@@ -75,8 +75,8 @@ export default iterateJsdoc(({
 
         validTypeParsing(thatNamepath);
       }
-    } else if (utils.isNamepathTag(tag.tag, options.checkSeesForNamepaths)) {
-      if (utils.passesEmptyNamepathCheck(tag, options.allowEmptyNamepaths)) {
+    } else if (utils.isNamepathTag(tag.tag, checkSeesForNamepaths)) {
+      if (utils.passesEmptyNamepathCheck(tag, allowEmptyNamepaths)) {
         return;
       }
       validTypeParsing(tag.name, tag.tag);

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -1,13 +1,22 @@
 import {parse} from 'jsdoctypeparser';
 import iterateJsdoc from '../iterateJsdoc';
+import warnRemovedSettings from '../warnRemovedSettings';
 
 const asExpression = /as\s+/;
 
 export default iterateJsdoc(({
   jsdoc,
   report,
-  utils
+  utils,
+  context
 }) => {
+  warnRemovedSettings(context, 'valid-types');
+
+  const options = context.options[0] || {
+    allowEmptyNamepaths: true,
+    checkSeesForNamepaths: false
+  };
+
   if (!jsdoc.tags) {
     return;
   }
@@ -66,8 +75,8 @@ export default iterateJsdoc(({
 
         validTypeParsing(thatNamepath);
       }
-    } else if (utils.isNamepathTag(tag.tag)) {
-      if (utils.passesEmptyNamepathCheck(tag)) {
+    } else if (utils.isNamepathTag(tag.tag, options.checkSeesForNamepaths)) {
+      if (utils.passesEmptyNamepathCheck(tag, options.allowEmptyNamepaths)) {
         return;
       }
       validTypeParsing(tag.name, tag.tag);
@@ -78,6 +87,22 @@ export default iterateJsdoc(({
 }, {
   iterateAllJsdocs: true,
   meta: {
+    schema: [
+      {
+        additionalProperies: false,
+        properties: {
+          allowEmptyNamepaths: {
+            default: true,
+            type: 'boolean'
+          },
+          checkSeesForNamepaths: {
+            default: false,
+            type: 'boolean'
+          }
+        },
+        type: 'object'
+      }
+    ],
     type: 'suggestion'
   }
 });

--- a/src/warnRemovedSettings.js
+++ b/src/warnRemovedSettings.js
@@ -1,0 +1,107 @@
+/**
+ * @typedef {(
+ *   | "require-jsdoc"
+ *   | "require-returns"
+ *   | "valid-types"
+ *   | "require-example"
+ *   | "check-examples"
+ * )} RulesWithMovedSettings
+ */
+
+/** @type {WeakMap<Object, Set<string>>} */
+const warnedSettings = new WeakMap();
+
+/**
+ * Warn only once for each context and setting
+ *
+ * @param {Object} context
+ * @param {string} setting
+ */
+const hasBeenWarned = (context, setting) => {
+  return warnedSettings.has(context) && warnedSettings.get(context).has(setting);
+};
+
+const markSettingAsWarned = (context, setting) => {
+  if (!warnedSettings.has(context)) {
+    warnedSettings.set(context, new Set());
+  }
+
+  warnedSettings.get(context).add(setting);
+};
+
+/**
+ * @param {Object} obj
+ * @param {string} property
+ * @returns {boolean}
+ */
+const has = (obj, property) => {
+  return Object.prototype.hasOwnProperty.call(obj, property);
+};
+
+/**
+ *
+ * @param {RulesWithMovedSettings} ruleName
+ * @returns {string[]}
+ */
+const getMovedSettings = (ruleName) => {
+  switch (ruleName) {
+  case 'require-jsdoc':
+    return ['exemptEmptyFunctions'];
+  case 'require-returns':
+    return ['forceRequireReturn'];
+  case 'valid-types':
+    return ['allowEmptyNamepaths', 'checkSeesForNamepaths'];
+  case 'require-example':
+    return ['avoidExampleOnConstructors'];
+
+  // TODO: move settings of check-examples to options
+  /* istanbul ignore next */
+  case 'check-examples':
+    return [
+      'captionRequired',
+      'exampleCodeRegex',
+      'rejectExampleCodeRegex',
+      'allowInlineConfig',
+      'noDefaultExampleRules',
+      'matchingFileName',
+      'configFile',
+      'eslintrcForExamples',
+      'baseConfig',
+      'reportUnusedDisableDirectives'
+    ];
+  }
+
+  /* istanbul ignore next */
+  return [];
+};
+
+/**
+ * @param {Object} context
+ * @param {RulesWithMovedSettings} ruleName
+ */
+export default function warnRemovedSettings (context, ruleName) {
+  const movedSettings = getMovedSettings(ruleName);
+
+  if (!context.settings || !context.settings.jsdoc) {
+    return;
+  }
+
+  for (const setting of movedSettings) {
+    if (
+      has(context.settings.jsdoc, setting) &&
+      !hasBeenWarned(context, setting)
+    ) {
+      context.report({
+        loc: {
+          start: {
+            column: 1,
+            line: 1
+          }
+        },
+        message: `\`settings.jsdoc.${setting}\` has been removed, ` +
+          `use options in the rule \`${ruleName}\` instead.`
+      });
+      markSettingAsWarned(context, setting);
+    }
+  }
+}

--- a/test/rules/assertions/requireExample.js
+++ b/test/rules/assertions/requireExample.js
@@ -35,6 +35,29 @@ export default {
       /**
        * @constructor
        */
+      function f () {
+
+      }
+      `,
+      errors: [
+        {
+          message: '`settings.jsdoc.avoidExampleOnConstructors` has been removed, use options in the rule `require-example` instead.'
+        },
+        {
+          message: 'Missing JSDoc @example declaration.'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          avoidExampleOnConstructors: true
+        }
+      }
+    },
+    {
+      code: `
+      /**
+       * @constructor
+       */
       function quux () {
 
       }
@@ -108,11 +131,9 @@ export default {
 
       }
       `,
-      settings: {
-        jsdoc: {
-          avoidExampleOnConstructors: true
-        }
-      }
+      options: [
+        {avoidExampleOnConstructors: true}
+      ]
     },
     {
       code: `
@@ -124,11 +145,9 @@ export default {
 
       }
       `,
-      settings: {
-        jsdoc: {
-          avoidExampleOnConstructors: true
-        }
-      }
+      options: [
+        {avoidExampleOnConstructors: true}
+      ]
     },
     {
       code: `
@@ -141,11 +160,9 @@ export default {
         }
       }
       `,
-      settings: {
-        jsdoc: {
-          avoidExampleOnConstructors: true
-        }
-      }
+      options: [
+        {avoidExampleOnConstructors: true}
+      ]
     },
     {
       code: `

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -203,6 +203,19 @@ export default {
       ]
     },
     {
+      code: '',
+      errors: [
+        {
+          message: '`settings.jsdoc.exemptEmptyFunctions` has been removed, use options in the rule `require-jsdoc` instead.'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          exemptEmptyFunctions: true
+        }
+      }
+    },
+    {
       code: `
         function quux (foo) {
 
@@ -213,11 +226,9 @@ export default {
           message: 'Missing JSDoc comment.'
         }
       ],
-      settings: {
-        jsdoc: {
-          exemptEmptyFunctions: true
-        }
-      }
+      options: [
+        {exemptEmptyFunctions: true}
+      ]
     },
     {
       code: 'function myFunction() {}',
@@ -427,11 +438,9 @@ export default {
         message: 'Missing JSDoc comment.',
         type: 'FunctionDeclaration'
       }],
-      settings: {
-        jsdoc: {
-          exemptEmptyFunctions: false
-        }
-      }
+      options: [
+        {exemptEmptyFunctions: false}
+      ]
     },
     {
       code: `
@@ -443,11 +452,9 @@ export default {
         message: 'Missing JSDoc comment.',
         type: 'FunctionDeclaration'
       }],
-      settings: {
-        jsdoc: {
-          exemptEmptyFunctions: false
-        }
-      }
+      options: [
+        {exemptEmptyFunctions: false}
+      ]
     },
     {
       code: `
@@ -1383,11 +1390,9 @@ export default {
     code: `
       function foo () {}
     `,
-    settings: {
-      jsdoc: {
-        exemptEmptyFunctions: true
-      }
-    }
+    options: [
+      {exemptEmptyFunctions: true}
+    ]
   },
   {
     code: `
@@ -1395,11 +1400,9 @@ export default {
         return;
       }
     `,
-    settings: {
-      jsdoc: {
-        exemptEmptyFunctions: true
-      }
-    }
+    options: [
+      {exemptEmptyFunctions: true}
+    ]
   },
   {
     code: `

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -90,6 +90,29 @@ export default {
           /**
            *
            */
+          function foo() {}
+
+          /**
+           *
+           */
+          function bar() {}
+          `,
+      errors: [
+        {
+          message: '`settings.jsdoc.forceRequireReturn` has been removed, use options in the rule `require-returns` instead.'
+        }
+      ],
+      settings: {
+        jsdoc: {
+          forceRequireReturn: true
+        }
+      }
+    },
+    {
+      code: `
+          /**
+           *
+           */
           async function quux() {
           }
       `,
@@ -99,13 +122,11 @@ export default {
           message: 'Missing JSDoc @returns declaration.'
         }
       ],
+      options: [{
+        forceRequireReturn: true
+      }],
       parserOptions: {
         ecmaVersion: 8
-      },
-      settings: {
-        jsdoc: {
-          forceRequireReturn: true
-        }
       }
     },
     {
@@ -121,13 +142,11 @@ export default {
           message: 'Missing JSDoc @returns declaration.'
         }
       ],
+      options: [{
+        forceRequireReturn: true
+      }],
       parserOptions: {
         ecmaVersion: 8
-      },
-      settings: {
-        jsdoc: {
-          forceRequireReturn: true
-        }
       }
     },
     {
@@ -143,13 +162,11 @@ export default {
           message: 'Missing JSDoc @returns declaration.'
         }
       ],
+      options: [{
+        forceRequireReturn: true
+      }],
       parserOptions: {
         ecmaVersion: 8
-      },
-      settings: {
-        jsdoc: {
-          forceRequireReturn: true
-        }
       }
     },
     {
@@ -165,13 +182,11 @@ export default {
           message: 'Missing JSDoc @returns declaration.'
         }
       ],
+      options: [{
+        forceRequireReturn: true
+      }],
       parserOptions: {
         ecmaVersion: 8
-      },
-      settings: {
-        jsdoc: {
-          forceRequireReturn: true
-        }
       }
     },
     {
@@ -188,11 +203,9 @@ export default {
           message: 'Missing JSDoc @returns declaration.'
         }
       ],
-      settings: {
-        jsdoc: {
-          forceRequireReturn: true
-        }
-      }
+      options: [{
+        forceRequireReturn: true
+      }]
     },
     {
       code: `
@@ -490,11 +503,9 @@ export default {
         }
       }
       `,
-      settings: {
-        jsdoc: {
-          forceRequireReturn: true
-        }
-      }
+      options: [{
+        forceRequireReturn: true
+      }]
     },
     {
       code: `
@@ -516,11 +527,9 @@ export default {
           function quux () {
           }
       `,
-      settings: {
-        jsdoc: {
-          forceRequireReturn: true
-        }
-      }
+      options: [{
+        forceRequireReturn: true
+      }]
     },
     {
       code: `
@@ -541,11 +550,9 @@ export default {
             return undefined;
           }
       `,
-      settings: {
-        jsdoc: {
-          forceRequireReturn: true
-        }
-      }
+      options: [{
+        forceRequireReturn: true
+      }]
     },
     {
       code: `
@@ -565,11 +572,9 @@ export default {
           function quux () {
           }
       `,
-      settings: {
-        jsdoc: {
-          forceRequireReturn: true
-        }
-      }
+      options: [{
+        forceRequireReturn: true
+      }]
     },
     {
       code: `
@@ -580,11 +585,9 @@ export default {
             return;
           }
       `,
-      settings: {
-        jsdoc: {
-          forceRequireReturn: true
-        }
-      }
+      options: [{
+        forceRequireReturn: true
+      }]
     },
     {
       code: `
@@ -602,13 +605,11 @@ export default {
           async function quux () {
           }
       `,
+      options: [{
+        forceRequireReturn: true
+      }],
       parserOptions: {
         ecmaVersion: 8
-      },
-      settings: {
-        jsdoc: {
-          forceRequireReturn: true
-        }
       }
     },
     {

--- a/test/rules/assertions/validTypes.js
+++ b/test/rules/assertions/validTypes.js
@@ -117,8 +117,26 @@ export default {
         line: 3,
         message: 'Syntax error in type: foo%'
       }],
+      options: [{
+        checkSeesForNamepaths: true
+      }]
+    },
+    {
+      code: `
+          /** */
+          function foo() {}
+      `,
+      errors: [
+        {
+          message: '`settings.jsdoc.allowEmptyNamepaths` has been removed, use options in the rule `valid-types` instead.'
+        },
+        {
+          message: '`settings.jsdoc.checkSeesForNamepaths` has been removed, use options in the rule `valid-types` instead.'
+        }
+      ],
       settings: {
         jsdoc: {
+          allowEmptyNamepaths: true,
           checkSeesForNamepaths: true
         }
       }
@@ -164,11 +182,9 @@ export default {
         line: 3,
         message: 'Syntax error in type: '
       }],
-      settings: {
-        jsdoc: {
-          allowEmptyNamepaths: false
-        }
-      }
+      options: [{
+        allowEmptyNamepaths: false
+      }]
     }
   ],
   valid: [


### PR DESCRIPTION
Fixes part of #216.

This pr moves some settings to rule options. When a removed setting is set, a warning or error will be reported.

Does not move settings for `check-examples` because it is too much work.

BREAKING CHANGE: The following settings has been removed and became options
    under relevant rules.
    * `settings.jsdoc.allowEmptyNamepaths` -> option in `valid-types`
    * `settings.jsdoc.checkSeesForNamepaths` -> option in `valid-types`
    * `settings.jsdoc.exemptEmptyFunctions` -> option in `require-jsdoc`
    * `settings.jsdoc.forceRequireReturn` -> option in `require-returns`
    * `settings.jsdoc.avoidExampleOnConstructors` -> option in `require-example`
