### PR TITLE
Remove deprecated settings specific to `require-param`

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -258,11 +258,6 @@ The format of the configuration is as follows:
 }
 ```
 
-`settings.jsdoc.allowOverrideWithoutParam`,
-`settings.jsdoc.allowImplementsWithoutParam`, and
-`settings.jsdoc.allowAugmentsExtendsWithoutParam` performed a similar function
-but restricted to `@param`. These settings are now deprecated.
-
 ### Settings to Configure `check-types` and `no-undefined-types`
 
 - `settings.jsdoc.preferredTypes` An option map to indicate preferred

--- a/README.md
+++ b/README.md
@@ -303,11 +303,6 @@ The format of the configuration is as follows:
 }
 ```
 
-`settings.jsdoc.allowOverrideWithoutParam`,
-`settings.jsdoc.allowImplementsWithoutParam`, and
-`settings.jsdoc.allowAugmentsExtendsWithoutParam` performed a similar function
-but restricted to `@param`. These settings are now deprecated.
-
 <a name="eslint-plugin-jsdoc-settings-settings-to-configure-check-types-and-no-undefined-types"></a>
 ### Settings to Configure <code>check-types</code> and <code>no-undefined-types</code>
 
@@ -5255,7 +5250,7 @@ function quux (foo, bar) {
 function quux (foo) {
 
 }
-// Settings: {"jsdoc":{"allowOverrideWithoutParam":false}}
+// Settings: {"jsdoc":{"overrideReplacesDocs":false}}
 // Message: Missing JSDoc @param "foo" declaration.
 
 /**
@@ -5264,7 +5259,7 @@ function quux (foo) {
 function quux (foo) {
 
 }
-// Settings: {"jsdoc":{"allowImplementsWithoutParam":false}}
+// Settings: {"jsdoc":{"implementsReplacesDocs":false}}
 // Message: Missing JSDoc @param "foo" declaration.
 
 /**
@@ -5294,7 +5289,7 @@ class A {
 
   }
 }
-// Settings: {"jsdoc":{"allowOverrideWithoutParam":false}}
+// Settings: {"jsdoc":{"overrideReplacesDocs":false}}
 // Message: Missing JSDoc @param "foo" declaration.
 
 /**
@@ -5308,7 +5303,7 @@ class A {
 
   }
 }
-// Settings: {"jsdoc":{"allowImplementsWithoutParam":false}}
+// Settings: {"jsdoc":{"implementsReplacesDocs":false}}
 // Message: Missing JSDoc @param "foo" declaration.
 
 /**
@@ -5413,7 +5408,7 @@ class A {
 function quux (foo) {
 
 }
-// Settings: {"jsdoc":{"allowOverrideWithoutParam":true}}
+// Settings: {"jsdoc":{"overrideReplacesDocs":true}}
 
 /**
  * @implements
@@ -5440,7 +5435,7 @@ function quux (foo) {
 function quux (foo) {
 
 }
-// Settings: {"jsdoc":{"allowImplementsWithoutParam":true}}
+// Settings: {"jsdoc":{"implementsReplacesDocs":true}}
 
 /**
  * @implements
@@ -5456,7 +5451,7 @@ function quux (foo) {
 function quux (foo) {
 
 }
-// Settings: {"jsdoc":{"allowAugmentsExtendsWithoutParam":true}}
+// Settings: {"jsdoc":{"augmentsExtendsReplacesDocs":true}}
 
 /**
  * @augments
@@ -5472,7 +5467,7 @@ function quux (foo) {
 function quux (foo) {
 
 }
-// Settings: {"jsdoc":{"allowAugmentsExtendsWithoutParam":true}}
+// Settings: {"jsdoc":{"augmentsExtendsReplacesDocs":true}}
 
 /**
  * @extends
@@ -5521,7 +5516,7 @@ class A {
 
   }
 }
-// Settings: {"jsdoc":{"allowOverrideWithoutParam":true}}
+// Settings: {"jsdoc":{"overrideReplacesDocs":true}}
 
 /**
  * @implements
@@ -5534,7 +5529,7 @@ class A {
 
   }
 }
-// Settings: {"jsdoc":{"allowImplementsWithoutParam":true}}
+// Settings: {"jsdoc":{"implementsReplacesDocs":true}}
 
 /**
  * @implements
@@ -5559,7 +5554,7 @@ class A {
 
   }
 }
-// Settings: {"jsdoc":{"allowAugmentsExtendsWithoutParam":true}}
+// Settings: {"jsdoc":{"augmentsExtendsReplacesDocs":true}}
 
 /**
  * @augments
@@ -5584,7 +5579,7 @@ class A {
 
   }
 }
-// Settings: {"jsdoc":{"allowAugmentsExtendsWithoutParam":true}}
+// Settings: {"jsdoc":{"augmentsExtendsReplacesDocs":true}}
 
 /**
  * @extends

--- a/package.json
+++ b/package.json
@@ -64,10 +64,10 @@
     "build": "rm -fr ./dist && NODE_ENV=production babel ./src --out-dir ./dist --copy-files --source-maps",
     "create-readme": "gitdown ./.README/README.md --output-file ./README.md && npm run add-assertions",
     "lint": "eslint ./src ./test",
-    "test-cov": "BABEL_ENV=test nyc mocha --recursive --require @babel/register --reporter progress --timeout 7000",
-    "test-no-cov": "BABEL_ENV=test mocha --recursive --require @babel/register --reporter progress --timeout 7000",
-    "test-index": "BABEL_ENV=test mocha --recursive --require @babel/register --reporter progress --timeout 7000 test/rules/index.js",
-    "test": "BABEL_ENV=test nyc --reporter text-summary mocha --recursive --require @babel/register --reporter progress --timeout 7000"
+    "test-cov": "BABEL_ENV=test nyc mocha --recursive --require @babel/register --reporter progress --timeout 9000",
+    "test-no-cov": "BABEL_ENV=test mocha --recursive --require @babel/register --reporter progress --timeout 9000",
+    "test-index": "BABEL_ENV=test mocha --recursive --require @babel/register --reporter progress --timeout 9000 test/rules/index.js",
+    "test": "BABEL_ENV=test nyc --reporter text-summary mocha --recursive --require @babel/register --reporter progress --timeout 9000"
   },
   "nyc": {
     "require": [

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -30,10 +30,7 @@ const getUtils = (
     tagNamePreference,
     overrideReplacesDocs,
     implementsReplacesDocs,
-    augmentsExtendsReplacesDocs,
-    allowOverrideWithoutParam,
-    allowImplementsWithoutParam,
-    allowAugmentsExtendsWithoutParam
+    augmentsExtendsReplacesDocs
   },
   report,
   context
@@ -98,42 +95,12 @@ const getUtils = (
     return jsdocUtils.hasTag(jsdoc, name);
   };
 
-  // These settings are deprecated and may be removed in the future along with this method.
-  utils.avoidDocsParamOnly = () => {
-    // These three checks are all for deprecated settings and may be removed in the future
-
-    // When settings.jsdoc.allowOverrideWithoutParam is true, override implies that all documentation is inherited.
-    if ((utils.hasTag('override') || utils.classHasTag('override')) && allowOverrideWithoutParam !== false) {
-      return true;
-    }
-
-    // When settings.jsdoc.allowImplementsWithoutParam is true, implements implies that all documentation is inherited.
-    // See https://github.com/gajus/eslint-plugin-jsdoc/issues/100
-    if ((utils.hasTag('implements') || utils.classHasTag('implements')) && allowImplementsWithoutParam !== false) {
-      return true;
-    }
-
-    // When settings.jsdoc.allowAugmentsExtendsWithoutParam is true, augments or extends implies that all documentation is inherited.
-    if ((utils.hasTag('augments') || utils.hasTag('extends') ||
-      utils.classHasTag('augments') || utils.classHasTag('extends')) && allowAugmentsExtendsWithoutParam) {
-      return true;
-    }
-
-    return false;
-  };
-
-  utils.avoidDocsParamConditionally = (param) => {
-    // After deprecation, the `param` parameter can be removed, but for now,
-    //  don't default for `param` as it may have its own explicit settings to the contrary
-    return (param && overrideReplacesDocs || !param && overrideReplacesDocs !== false) &&
-      (utils.hasTag('override') || utils.classHasTag('override')) ||
-    (param && implementsReplacesDocs || !param && implementsReplacesDocs !== false) &&
-      (utils.hasTag('implements') || utils.classHasTag('implements'));
-  };
-
-  utils.avoidDocs = (param) => {
-    if (param && utils.avoidDocsParamOnly() ||
-      utils.avoidDocsParamConditionally(param) ||
+  utils.avoidDocs = () => {
+    if (
+      overrideReplacesDocs !== false &&
+        (utils.hasTag('override') || utils.classHasTag('override')) ||
+      implementsReplacesDocs !== false &&
+        (utils.hasTag('implements') || utils.classHasTag('implements')) ||
 
       // inheritdoc implies that all documentation is inherited; see https://jsdoc.app/tags-inheritdoc.html
       utils.hasTag('inheritdoc') ||
@@ -260,11 +227,6 @@ const getSettings = (context) => {
   settings.overrideReplacesDocs = _.get(context, 'settings.jsdoc.overrideReplacesDocs');
   settings.implementsReplacesDocs = _.get(context, 'settings.jsdoc.implementsReplacesDocs');
   settings.augmentsExtendsReplacesDocs = _.get(context, 'settings.jsdoc.augmentsExtendsReplacesDocs');
-
-  // `require-param` only (deprecated)
-  settings.allowOverrideWithoutParam = _.get(context, 'settings.jsdoc.allowOverrideWithoutParam');
-  settings.allowImplementsWithoutParam = _.get(context, 'settings.jsdoc.allowImplementsWithoutParam');
-  settings.allowAugmentsExtendsWithoutParam = _.get(context, 'settings.jsdoc.allowAugmentsExtendsWithoutParam');
 
   return settings;
 };

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -11,7 +11,7 @@ export default iterateJsdoc(({
     return;
   }
 
-  if (utils.avoidDocs('param')) {
+  if (utils.avoidDocs()) {
     return;
   }
 

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -74,7 +74,7 @@ export default {
       ],
       settings: {
         jsdoc: {
-          allowOverrideWithoutParam: false
+          overrideReplacesDocs: false
         }
       }
     },
@@ -94,7 +94,7 @@ export default {
       ],
       settings: {
         jsdoc: {
-          allowImplementsWithoutParam: false
+          implementsReplacesDocs: false
         }
       }
     },
@@ -149,7 +149,7 @@ export default {
       ],
       settings: {
         jsdoc: {
-          allowOverrideWithoutParam: false
+          overrideReplacesDocs: false
         }
       }
     },
@@ -174,7 +174,7 @@ export default {
       ],
       settings: {
         jsdoc: {
-          allowImplementsWithoutParam: false
+          implementsReplacesDocs: false
         }
       }
     },
@@ -345,7 +345,7 @@ export default {
       `,
       settings: {
         jsdoc: {
-          allowOverrideWithoutParam: true
+          overrideReplacesDocs: true
         }
       }
     },
@@ -385,7 +385,7 @@ export default {
       `,
       settings: {
         jsdoc: {
-          allowImplementsWithoutParam: true
+          implementsReplacesDocs: true
         }
       }
     },
@@ -411,7 +411,7 @@ export default {
       `,
       settings: {
         jsdoc: {
-          allowAugmentsExtendsWithoutParam: true
+          augmentsExtendsReplacesDocs: true
         }
       }
     },
@@ -437,7 +437,7 @@ export default {
       `,
       settings: {
         jsdoc: {
-          allowAugmentsExtendsWithoutParam: true
+          augmentsExtendsReplacesDocs: true
         }
       }
     },
@@ -513,7 +513,7 @@ export default {
       `,
       settings: {
         jsdoc: {
-          allowOverrideWithoutParam: true
+          overrideReplacesDocs: true
         }
       }
     },
@@ -533,7 +533,7 @@ export default {
       `,
       settings: {
         jsdoc: {
-          allowImplementsWithoutParam: true
+          implementsReplacesDocs: true
         }
       }
     },
@@ -568,7 +568,7 @@ export default {
       `,
       settings: {
         jsdoc: {
-          allowAugmentsExtendsWithoutParam: true
+          augmentsExtendsReplacesDocs: true
         }
       }
     },
@@ -603,7 +603,7 @@ export default {
       `,
       settings: {
         jsdoc: {
-          allowAugmentsExtendsWithoutParam: true
+          augmentsExtendsReplacesDocs: true
         }
       }
     },


### PR DESCRIPTION
feat(`require-param`): remove deprecated settings `allowOverrideWithoutParam`, `allowImplementsWithoutParam`, `allowAugmentsExtendsWithoutParam`

BREAKING CHANGE:

Removes the following settings in favor of mentioned replacements settings:

- `settings.jsdoc.allowOverrideWithoutParam` - replaced by `settings.jsdoc.overrideReplacesDocs`
- `settings.jsdoc.allowImplementsWithoutParam` - replaced by `settings.jsdoc.implementsReplacesDocs`
- `settings.jsdoc.allowAugmentsExtendsWithoutParam` - replaced by `settings.jsdoc.augmentsExtendsReplacesDocs`

