### PR TITLE
Allow `match-description` to apply to descriptions of arbitrary tags

### DIFF
--- a/.README/rules/match-description.md
+++ b/.README/rules/match-description.md
@@ -50,6 +50,14 @@ tag should be linted with the `matchDescription` value (or the default).
 }
 ```
 
+The tags `@param`/`@arg`/`@argument` will be properly parsed to ensure that
+the matched "description" text includes only the text after the name.
+All other tags will treat the text following the tag name, a space, and
+an optional curly-bracketed type expression (and another space) as part of
+its "description" (e.g., for `@returns {someType} some description`, the
+description is `some description` while for `@some-tag xyz`, the description
+is `xyz`).
+
 ##### `mainDescription`
 
 If you wish to override the main function description without changing the
@@ -82,6 +90,6 @@ Overrides the default contexts (see below).
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|N/A by default but see `tags` options|
 |Settings||
-|Options|`contexts`, `tags` (allows for 'param', 'arg', 'argument', 'returns', 'return', 'description', 'desc'), `mainDescription`, `matchDescription`|
+|Options|`contexts`, `tags` (allows for 'param', 'arg', 'argument', 'description', 'desc', and any added to `tags` option, e.g., 'returns', 'return'), `mainDescription`, `matchDescription`|
 
 <!-- assertions matchDescription -->

--- a/README.md
+++ b/README.md
@@ -2428,6 +2428,14 @@ tag should be linted with the `matchDescription` value (or the default).
 }
 ```
 
+The tags `@param`/`@arg`/`@argument` will be properly parsed to ensure that
+the matched "description" text includes only the text after the name.
+All other tags will treat the text following the tag name, a space, and
+an optional curly-bracketed type expression (and another space) as part of
+its "description" (e.g., for `@returns {someType} some description`, the
+description is `some description` while for `@some-tag xyz`, the description
+is `xyz`).
+
 <a name="eslint-plugin-jsdoc-rules-match-description-options-3-maindescription"></a>
 ##### <code>mainDescription</code>
 
@@ -2462,7 +2470,7 @@ Overrides the default contexts (see below).
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|N/A by default but see `tags` options|
 |Settings||
-|Options|`contexts`, `tags` (allows for 'param', 'arg', 'argument', 'returns', 'return', 'description', 'desc'), `mainDescription`, `matchDescription`|
+|Options|`contexts`, `tags` (allows for 'param', 'arg', 'argument', 'description', 'desc', and any added to `tags` option, e.g., 'returns', 'return'), `mainDescription`, `matchDescription`|
 
 The following patterns are considered problems:
 
@@ -2536,6 +2544,39 @@ function quux (foo) {
 
 }
 // Options: [{"tags":{"param":true}}]
+// Message: JSDoc description does not satisfy the regex pattern.
+
+/**
+ * Foo.
+ *
+ * @summary foo.
+ */
+function quux () {
+
+}
+// Options: [{"tags":{"summary":true}}]
+// Message: JSDoc description does not satisfy the regex pattern.
+
+/**
+ * Foo.
+ *
+ * @author
+ */
+function quux () {
+
+}
+// Options: [{"tags":{"author":".+"}}]
+// Message: JSDoc description does not satisfy the regex pattern.
+
+/**
+ * Foo.
+ *
+ * @x-tag
+ */
+function quux () {
+
+}
+// Options: [{"tags":{"x-tag":".+"}}]
 // Message: JSDoc description does not satisfy the regex pattern.
 
 /**
@@ -2798,6 +2839,14 @@ function quux () {
 // Options: [{"tags":{"returns":true}}]
 
 /**
+ * @returns {type1} Foo bar.
+ */
+function quux () {
+
+}
+// Options: [{"tags":{"returns":true}}]
+
+/**
  * @description Foo bar.
  */
 function quux () {
@@ -2934,6 +2983,36 @@ function quux () {
 
 }
 // Options: [{"tags":{"param":true}}]
+
+/**
+ * Foo.
+ *
+ * @summary Foo.
+ */
+function quux () {
+
+}
+// Options: [{"tags":{"summary":true}}]
+
+/**
+ * Foo.
+ *
+ * @author Somebody
+ */
+function quux () {
+
+}
+// Options: [{"tags":{"author":".+"}}]
+
+/**
+ * Foo.
+ *
+ * @x-tag something
+ */
+function quux () {
+
+}
+// Options: [{"tags":{"x-tag":".+"}}]
 ````
 
 

--- a/test/rules/assertions/matchDescription.js
+++ b/test/rules/assertions/matchDescription.js
@@ -165,6 +165,81 @@ export default {
           /**
            * Foo.
            *
+           * @summary foo.
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 5,
+          message: 'JSDoc description does not satisfy the regex pattern.'
+        }
+      ],
+      options: [
+        {
+          tags: {
+            summary: true
+          }
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * Foo.
+           *
+           * @author
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 5,
+          message: 'JSDoc description does not satisfy the regex pattern.'
+        }
+      ],
+      options: [
+        {
+          tags: {
+            author: '.+'
+          }
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * Foo.
+           *
+           * @x-tag
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 5,
+          message: 'JSDoc description does not satisfy the regex pattern.'
+        }
+      ],
+      options: [
+        {
+          tags: {
+            'x-tag': '.+'
+          }
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * Foo.
+           *
            * @description foo foo.
            */
           function quux (foo) {
@@ -709,6 +784,23 @@ export default {
     {
       code: `
           /**
+           * @returns {type1} Foo bar.
+           */
+          function quux () {
+
+          }
+      `,
+      options: [
+        {
+          tags: {
+            returns: true
+          }
+        }
+      ]
+    },
+    {
+      code: `
+          /**
            * @description Foo bar.
            */
           function quux () {
@@ -936,6 +1028,63 @@ export default {
         {tags: {
           param: true
         }}
+      ]
+    },
+    {
+      code: `
+          /**
+           * Foo.
+           *
+           * @summary Foo.
+           */
+          function quux () {
+
+          }
+      `,
+      options: [
+        {
+          tags: {
+            summary: true
+          }
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * Foo.
+           *
+           * @author Somebody
+           */
+          function quux () {
+
+          }
+      `,
+      options: [
+        {
+          tags: {
+            author: '.+'
+          }
+        }
+      ]
+    },
+    {
+      code: `
+          /**
+           * Foo.
+           *
+           * @x-tag something
+           */
+          function quux () {
+
+          }
+      `,
+      options: [
+        {
+          tags: {
+            'x-tag': '.+'
+          }
+        }
       ]
     }
   ]


### PR DESCRIPTION
feat(`match-description`): allow arbitrary tags; also fixes `returns`/`return` to avoid skipping matching of an initial "name" and space

The one disadvantage here is that because `tags` is an option instead of a setting, adding arbitrary tags doesn't make them automatically available to `check-tag-names` as well.

Also helps users work around lack of #233 support.