### PR TITLE
fix(checkTagNames): #327 - Tag name autofix confused by adjacent tags

### DIFF
--- a/src/rules/checkTagNames.js
+++ b/src/rules/checkTagNames.js
@@ -57,7 +57,7 @@ export default iterateJsdoc(({
 
       if (preferredTagName !== tagName) {
         report(message, (fixer) => {
-          const replacement = sourceCode.getText(jsdocNode).replace(`@${tagName}`, `@${preferredTagName}`);
+          const replacement = sourceCode.getText(jsdocNode).replace(`@${tagName} `, `@${preferredTagName} `);
 
           return fixer.replaceText(jsdocNode, replacement);
         }, jsdocTag);

--- a/test/rules/assertions/checkTagNames.js
+++ b/test/rules/assertions/checkTagNames.js
@@ -309,6 +309,32 @@ export default {
           }
         }
       }
+    },
+    {
+      code: `
+          /**
+           * @property {object} a
+           * @prop {boolean} b
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Invalid JSDoc tag (preference). Replace "prop" JSDoc tag with "property".'
+        }
+      ],
+      output: `
+          /**
+           * @property {object} a
+           * @property {boolean} b
+           */
+          function quux () {
+
+          }
+      `
     }
   ],
   valid: [


### PR DESCRIPTION
This fix assumes that all tagNames are followed with a space, would that be correct?