### PR TITLE
docs: remove wrong examples in README.md(check-alignment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,23 +389,7 @@ function quux (foo) {
 // Message: Expected JSDoc block to be aligned.
 
 /**
- * @param {Number} foo
- */
-function quux (foo) {
-
-}
-// Message: Expected JSDoc block to be aligned.
-
-/**
   * @param {Number} foo
- */
-function quux (foo) {
-
-}
-// Message: Expected JSDoc block to be aligned.
-
-/**
- * @param {Number} foo
  */
 function quux (foo) {
 


### PR DESCRIPTION
The two examples you explained in README.md(check-alignment) are wrong I think, you mentioned 'thees are wrong', but in my opinion it is right.
When I run eslint with plugin these two didn't warn.