### PR TITLE
Add type "symbol" to noUndefinedTypes

### DIFF
--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -5,9 +5,9 @@ import iterateJsdoc, {parseComment} from '../iterateJsdoc';
 import jsdocUtils from '../jsdocUtils';
 
 const extraTypes = [
-  'null', 'undefined', 'string', 'boolean', 'object',
+  'null', 'undefined', 'string', 'symbol', 'boolean', 'object',
   'function',
-  'number', 'NaN', 'Infinity',
+  'number', 'bigint', 'NaN', 'Infinity',
   'any', '*',
   'Array', 'Object', 'RegExp', 'Date', 'Function',
 ];


### PR DESCRIPTION
Continued for https://github.com/gajus/eslint-plugin-jsdoc/issues/360
Add type "symbol" and "bigint" to noUndefinedTypes

Fix: https://github.com/gajus/eslint-plugin-jsdoc/issues/370