### PR TITLE
`require-jsdoc`: Highlight first line only of missing jsdoc

### DIFF
--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -172,6 +172,19 @@ export default {
         return fixer.insertTextBefore(baseNode, insertion);
       };
 
+      const report = () => {
+        const loc = {
+          end: node.loc.start,
+          start: node.loc.start,
+        };
+        context.report({
+          fix,
+          messageId: 'missingJsDoc',
+          node,
+          loc,
+        });
+      };
+
       if (publicOnly) {
         const opt = {
           ancestorsOnly: Boolean(_.get(publicOnly, 'ancestorsOnly', false)),
@@ -183,18 +196,10 @@ export default {
         const exported = exportParser.isExported(node, parseResult, opt);
 
         if (exported) {
-          context.report({
-            fix,
-            messageId: 'missingJsDoc',
-            node,
-          });
+          report();
         }
       } else {
-        context.report({
-          fix,
-          messageId: 'missingJsDoc',
-          node,
-        });
+        report();
       }
     };
 

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -263,6 +263,7 @@ export default {
           }`,
       errors: [
         {
+          endLine: 2,
           line: 2,
           message: 'Missing JSDoc comment.',
         },


### PR DESCRIPTION
fix: avoid highlighting whole function block upon missing jsdoc block in favor of highlighting first line only; fixes #386

I'm calling it a "fix" as it is not really a new feature, and more of fixing an annoyance, though it's kind of change in behavior a little, so requesting your review, @golopot .