### PR TITLE
fix(`require-jsdoc`): allow additional contexts to block preceeding...

### DIFF
--- a/README.md
+++ b/README.md
@@ -5890,6 +5890,50 @@ interface Example {
   test: string
 }
 // Options: [{"contexts":["TSInterfaceDeclaration"]}]
+
+/**
+ * This example type is great!
+ */
+export type Example = {
+  /**
+   * My super test string!
+   */
+  test: string
+};
+// Options: [{"contexts":["TSTypeAliasDeclaration"]}]
+
+/**
+ * This example type is great!
+ */
+type Example = {
+  /**
+   * My super test string!
+   */
+  test: string
+};
+// Options: [{"contexts":["TSTypeAliasDeclaration"]}]
+
+/**
+ * This example enum is great!
+ */
+export enum Example {
+  /**
+   * My super test enum!
+   */
+  test = 123
+}
+// Options: [{"contexts":["TSEnumDeclaration"]}]
+
+/**
+ * This example enum is great!
+ */
+enum Example {
+  /**
+   * My super test enum!
+   */
+  test = 123
+}
+// Options: [{"contexts":["TSEnumDeclaration"]}]
 ````
 
 

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -2230,6 +2230,100 @@ export default {
     parserOptions: {
       sourceType: 'module',
     },
+  }, {
+    code: `
+    /**
+     * This example type is great!
+     */
+    export type Example = {
+      /**
+       * My super test string!
+       */
+      test: string
+    };
+    `,
+    options: [
+      {
+        contexts: [
+          'TSTypeAliasDeclaration',
+        ],
+      },
+    ],
+    parser: require.resolve('@typescript-eslint/parser'),
+    parserOptions: {
+      sourceType: 'module',
+    },
+  },
+  {
+    code: `
+    /**
+     * This example type is great!
+     */
+    type Example = {
+      /**
+       * My super test string!
+       */
+      test: string
+    };
+    `,
+    options: [
+      {
+        contexts: [
+          'TSTypeAliasDeclaration',
+        ],
+      },
+    ],
+    parser: require.resolve('@typescript-eslint/parser'),
+    parserOptions: {
+      sourceType: 'module',
+    },
+  }, {
+    code: `
+    /**
+     * This example enum is great!
+     */
+    export enum Example {
+      /**
+       * My super test enum!
+       */
+      test = 123
+    }
+    `,
+    options: [
+      {
+        contexts: [
+          'TSEnumDeclaration',
+        ],
+      },
+    ],
+    parser: require.resolve('@typescript-eslint/parser'),
+    parserOptions: {
+      sourceType: 'module',
+    },
+  },
+  {
+    code: `
+    /**
+     * This example enum is great!
+     */
+    enum Example {
+      /**
+       * My super test enum!
+       */
+      test = 123
+    }
+    `,
+    options: [
+      {
+        contexts: [
+          'TSEnumDeclaration',
+        ],
+      },
+    ],
+    parser: require.resolve('@typescript-eslint/parser'),
+    parserOptions: {
+      sourceType: 'module',
+    },
   },
   ],
 };


### PR DESCRIPTION
export and find JSDoc comments.

Adds fixes for TSTypeAliasDeclaration and TSEnumDeclaration similar to the recent changes to support TSInterfaceDeclaration within require-jsdoc (#385). These node types were failing when declared with the `export` keyword.

Adding these additional types to the switch statement pushed getJSDocComment function complexity over 20, so it was split into two functions.