### PR TITLE
Begin `settings.jsdoc.mode` (`check-tag-names` and others indirectly)

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -88,6 +88,12 @@ You can then selectively add to or override the recommended rules.
 - `settings.jsdoc.ignorePrivate` - Disables all rules for the comment block
   on which a `@private` tag occurs. Defaults to `false`.
 
+### Mode
+
+- `settings.jsdoc.mode` - Set to `jsdoc` (the default), `typescript`, or `closure`.
+  Currently is used for checking preferred tag names and in the `check-tag-names`
+  rule.
+
 ### Alias Preference
 
 Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a JSDoc tag. The format of the configuration is: `<primary tag name>: <preferred alias name>`, e.g.

--- a/.README/rules/check-tag-names.md
+++ b/.README/rules/check-tag-names.md
@@ -101,14 +101,16 @@ yield
 ```
 
 For [TypeScript](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html#supported-jsdoc)
-(or Closure), one may also use the following:
+(or Closure), when `settings.jsdoc.mode` is set to `typescript` or `closure`,
+one may also use the following:
 
 ```
 template
 ```
 
 And for [Closure](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#nosideeffects-modifies-thisarguments),
-one may also use:
+when `settings.jsdoc.mode` is set to `closure`, one may use the following (in
+addition to the jsdoc and TypeScript tags):
 
 ```
 define
@@ -128,7 +130,6 @@ polymerBehavior
 preserve
 struct
 suppress
-template
 unrestricted
 ```
 
@@ -138,7 +139,7 @@ Note that the tags indicated as replacements in `settings.jsdoc.tagNamePreferenc
 
 ##### `definedTags`
 
-Use an array of `definedTags` strings to configure additional, allowed JSDoc tags.
+Use an array of `definedTags` strings to configure additional, allowed tags.
 The format is as follows:
 
 ```json
@@ -152,6 +153,6 @@ The format is as follows:
 |Context|everywhere|
 |Tags|N/A|
 |Options|`definedTags`|
-|Settings|`tagNamePreference`|
+|Settings|`tagNamePreference`, `mode`|
 
 <!-- assertions checkTagNames -->

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ JSDoc linting rules for ESLint.
     * [Configuration](#eslint-plugin-jsdoc-configuration)
     * [Settings](#eslint-plugin-jsdoc-settings)
         * [Allow `@private` to disable rules for that comment block](#eslint-plugin-jsdoc-settings-allow-private-to-disable-rules-for-that-comment-block)
+        * [Mode](#eslint-plugin-jsdoc-settings-mode)
         * [Alias Preference](#eslint-plugin-jsdoc-settings-alias-preference)
         * [`@override`/`@augments`/`@extends`/`@implements` Without Accompanying `@param`/`@description`/`@example`/`@returns`](#eslint-plugin-jsdoc-settings-override-augments-extends-implements-without-accompanying-param-description-example-returns)
         * [Settings to Configure `check-types` and `no-undefined-types`](#eslint-plugin-jsdoc-settings-settings-to-configure-check-types-and-no-undefined-types)
@@ -127,6 +128,13 @@ You can then selectively add to or override the recommended rules.
 
 - `settings.jsdoc.ignorePrivate` - Disables all rules for the comment block
   on which a `@private` tag occurs. Defaults to `false`.
+
+<a name="eslint-plugin-jsdoc-settings-mode"></a>
+### Mode
+
+- `settings.jsdoc.mode` - Set to `jsdoc` (the default), `typescript`, or `closure`.
+  Currently is used for checking preferred tag names and in the `check-tag-names`
+  rule.
 
 <a name="eslint-plugin-jsdoc-settings-alias-preference"></a>
 ### Alias Preference
@@ -1495,14 +1503,16 @@ yield
 ```
 
 For [TypeScript](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html#supported-jsdoc)
-(or Closure), one may also use the following:
+(or Closure), when `settings.jsdoc.mode` is set to `typescript` or `closure`,
+one may also use the following:
 
 ```
 template
 ```
 
 And for [Closure](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#nosideeffects-modifies-thisarguments),
-one may also use:
+when `settings.jsdoc.mode` is set to `closure`, one may use the following (in
+addition to the jsdoc and TypeScript tags):
 
 ```
 define
@@ -1522,7 +1532,6 @@ polymerBehavior
 preserve
 struct
 suppress
-template
 unrestricted
 ```
 
@@ -1534,7 +1543,7 @@ Note that the tags indicated as replacements in `settings.jsdoc.tagNamePreferenc
 <a name="eslint-plugin-jsdoc-rules-check-tag-names-options-2-definedtags"></a>
 ##### <code>definedTags</code>
 
-Use an array of `definedTags` strings to configure additional, allowed JSDoc tags.
+Use an array of `definedTags` strings to configure additional, allowed tags.
 The format is as follows:
 
 ```json
@@ -1548,7 +1557,7 @@ The format is as follows:
 |Context|everywhere|
 |Tags|N/A|
 |Options|`definedTags`|
-|Settings|`tagNamePreference`|
+|Settings|`tagNamePreference`, `mode`|
 
 The following patterns are considered problems:
 
@@ -1709,6 +1718,162 @@ function quux () {
 }
 // Settings: {"jsdoc":{"tagNamePreference":{"abc":"abcd"}}}
 // Message: Invalid JSDoc tag (preference). Replace "abc" JSDoc tag with "abcd".
+
+/** 
+ * @modifies
+ * @abstract
+ * @access
+ * @alias
+ * @async
+ * @augments
+ * @author
+ * @borrows
+ * @callback
+ * @class
+ * @classdesc
+ * @constant
+ * @constructs
+ * @copyright
+ * @default
+ * @deprecated
+ * @description
+ * @enum
+ * @event
+ * @example
+ * @exports
+ * @external
+ * @file
+ * @fires
+ * @function
+ * @generator
+ * @global
+ * @hideconstructor
+ * @ignore
+ * @implements
+ * @inheritdoc
+ * @inner
+ * @instance
+ * @interface
+ * @kind
+ * @lends
+ * @license
+ * @listens
+ * @member
+ * @memberof
+ * @memberof!
+ * @mixes
+ * @mixin
+ * @module
+ * @name
+ * @namespace
+ * @override
+ * @package
+ * @param
+ * @private
+ * @property
+ * @protected
+ * @public
+ * @readonly
+ * @requires
+ * @returns
+ * @see
+ * @since
+ * @static
+ * @summary
+ * @this
+ * @throws
+ * @todo
+ * @tutorial
+ * @type
+ * @typedef
+ * @variation
+ * @version
+ * @yields
+ */
+function quux (foo) {}
+// Settings: {"jsdoc":{"mode":"badMode"}}
+// Message: Unrecognized value `badMode` for `settings.jsdoc.mode`.
+
+/** 
+ * @modifies
+ * @abstract
+ * @access
+ * @alias
+ * @async
+ * @augments
+ * @author
+ * @borrows
+ * @callback
+ * @class
+ * @classdesc
+ * @constant
+ * @constructs
+ * @copyright
+ * @default
+ * @deprecated
+ * @description
+ * @enum
+ * @event
+ * @example
+ * @exports
+ * @external
+ * @file
+ * @fires
+ * @function
+ * @generator
+ * @global
+ * @hideconstructor
+ * @ignore
+ * @implements
+ * @inheritdoc
+ * @inner
+ * @instance
+ * @interface
+ * @kind
+ * @lends
+ * @license
+ * @listens
+ * @member
+ * @memberof
+ * @memberof!
+ * @mixes
+ * @mixin
+ * @module
+ * @name
+ * @namespace
+ * @override
+ * @package
+ * @param
+ * @private
+ * @property
+ * @protected
+ * @public
+ * @readonly
+ * @requires
+ * @returns
+ * @see
+ * @since
+ * @static
+ * @summary
+ * @this
+ * @throws
+ * @todo
+ * @tutorial
+ * @type
+ * @typedef
+ * @variation
+ * @version
+ * @yields
+ * @template
+ */
+function quux (foo) {}
+// Message: Invalid JSDoc tag name "template".
+
+/** 
+ * @externs
+ */
+function quux (foo) {}
+// Message: Invalid JSDoc tag name "externs".
 ````
 
 The following patterns are not considered problems:
@@ -1832,6 +1997,87 @@ function quux (foo) {
  * @yields
  */
 function quux (foo) {}
+
+/** 
+ * @modifies
+ * @abstract
+ * @access
+ * @alias
+ * @async
+ * @augments
+ * @author
+ * @borrows
+ * @callback
+ * @class
+ * @classdesc
+ * @constant
+ * @constructs
+ * @copyright
+ * @default
+ * @deprecated
+ * @description
+ * @enum
+ * @event
+ * @example
+ * @exports
+ * @external
+ * @file
+ * @fires
+ * @function
+ * @generator
+ * @global
+ * @hideconstructor
+ * @ignore
+ * @implements
+ * @inheritdoc
+ * @inner
+ * @instance
+ * @interface
+ * @kind
+ * @lends
+ * @license
+ * @listens
+ * @member
+ * @memberof
+ * @memberof!
+ * @mixes
+ * @mixin
+ * @module
+ * @name
+ * @namespace
+ * @override
+ * @package
+ * @param
+ * @private
+ * @property
+ * @protected
+ * @public
+ * @readonly
+ * @requires
+ * @returns
+ * @see
+ * @since
+ * @static
+ * @summary
+ * @this
+ * @throws
+ * @todo
+ * @tutorial
+ * @type
+ * @typedef
+ * @variation
+ * @version
+ * @yields
+ * @template
+ */
+function quux (foo) {}
+// Settings: {"jsdoc":{"mode":"typescript"}}
+
+/** 
+ * @externs
+ */
+function quux (foo) {}
+// Settings: {"jsdoc":{"mode":"closure"}}
 
 /**
  *

--- a/src/WarnSettings.js
+++ b/src/WarnSettings.js
@@ -1,0 +1,26 @@
+const WarnSettings = function () {
+  /** @type {WeakMap<object, Set<string>>} */
+  const warnedSettings = new WeakMap();
+
+  return {
+    /**
+     * Warn only once for each context and setting
+     *
+     * @param {object} context
+     * @param {string} setting
+     */
+    hasBeenWarned (context, setting) {
+      return warnedSettings.has(context) && warnedSettings.get(context).has(setting);
+    },
+
+    markSettingAsWarned (context, setting) {
+      if (!warnedSettings.has(context)) {
+        warnedSettings.set(context, new Set());
+      }
+
+      warnedSettings.get(context).add(setting);
+    },
+  };
+};
+
+export default WarnSettings;

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -84,6 +84,7 @@ const getUtils = (
     augmentsExtendsReplacesDocs,
     maxLines,
     minLines,
+    mode,
   },
   report,
   context,
@@ -139,7 +140,7 @@ const getUtils = (
   };
 
   utils.getPreferredTagName = ({tagName, skipReportingBlockedTag = false, allowObjectReturn = false, defaultMessage = `Unexpected tag \`@${tagName}\``}) => {
-    const ret = jsdocUtils.getPreferredTagName(tagName, tagNamePreference);
+    const ret = jsdocUtils.getPreferredTagName(context, mode, tagName, tagNamePreference);
     const isObject = ret && typeof ret === 'object';
     if (utils.hasTag(tagName) && (ret === false || isObject && !ret.replacement)) {
       if (skipReportingBlockedTag) {
@@ -158,7 +159,7 @@ const getUtils = (
   };
 
   utils.isValidTag = (name, definedTags) => {
-    return jsdocUtils.isValidTag(name, definedTags);
+    return jsdocUtils.isValidTag(context, mode, name, definedTags);
   };
 
   utils.hasATag = (name) => {
@@ -251,7 +252,7 @@ const getUtils = (
   };
 
   utils.getTagsByType = (tags) => {
-    return jsdocUtils.getTagsByType(tags, tagNamePreference);
+    return jsdocUtils.getTagsByType(context, mode, tags, tagNamePreference);
   };
 
   utils.getClassNode = () => {
@@ -343,6 +344,9 @@ const getSettings = (context) => {
   settings.overrideReplacesDocs = _.get(context, 'settings.jsdoc.overrideReplacesDocs');
   settings.implementsReplacesDocs = _.get(context, 'settings.jsdoc.implementsReplacesDocs');
   settings.augmentsExtendsReplacesDocs = _.get(context, 'settings.jsdoc.augmentsExtendsReplacesDocs');
+
+  // Many rules, e.g., `check-tag-names`
+  settings.mode = _.get(context, 'settings.jsdoc.mode') || 'jsdoc';
 
   return settings;
 };

--- a/src/warnRemovedSettings.js
+++ b/src/warnRemovedSettings.js
@@ -1,3 +1,7 @@
+import WarnSettings from './WarnSettings';
+
+const warnSettings = WarnSettings();
+
 /**
  * @typedef {(
  *   | "require-jsdoc"
@@ -7,27 +11,6 @@
  *   | "check-examples"
  * )} RulesWithMovedSettings
  */
-
-/** @type {WeakMap<object, Set<string>>} */
-const warnedSettings = new WeakMap();
-
-/**
- * Warn only once for each context and setting
- *
- * @param {object} context
- * @param {string} setting
- */
-const hasBeenWarned = (context, setting) => {
-  return warnedSettings.has(context) && warnedSettings.get(context).has(setting);
-};
-
-const markSettingAsWarned = (context, setting) => {
-  if (!warnedSettings.has(context)) {
-    warnedSettings.set(context, new Set());
-  }
-
-  warnedSettings.get(context).add(setting);
-};
 
 /**
  * @param {object} obj
@@ -86,7 +69,7 @@ export default function warnRemovedSettings (context, ruleName) {
   for (const setting of movedSettings) {
     if (
       has(context.settings.jsdoc, setting) &&
-      !hasBeenWarned(context, setting)
+      !warnSettings.hasBeenWarned(context, setting)
     ) {
       context.report({
         loc: {
@@ -98,7 +81,7 @@ export default function warnRemovedSettings (context, ruleName) {
         message: `\`settings.jsdoc.${setting}\` has been removed, ` +
           `use options in the rule \`${ruleName}\` instead.`,
       });
-      markSettingAsWarned(context, setting);
+      warnSettings.markSettingAsWarned(context, setting);
     }
   }
 }

--- a/test/jsdocUtils.js
+++ b/test/jsdocUtils.js
@@ -10,38 +10,38 @@ describe('jsdocUtils', () => {
     context('no preferences', () => {
       context('alias name', () => {
         it('returns the primary tag name', () => {
-          expect(jsdocUtils.getPreferredTagName('return')).to.equal('returns');
+          expect(jsdocUtils.getPreferredTagName({}, 'jsdoc', 'return')).to.equal('returns');
         });
       });
       it('returns the primary tag name', () => {
-        expect(jsdocUtils.getPreferredTagName('returns')).to.equal('returns');
+        expect(jsdocUtils.getPreferredTagName({}, 'jsdoc', 'returns')).to.equal('returns');
       });
     });
     context('with preferences', () => {
       it('returns the preferred tag name', () => {
-        expect(jsdocUtils.getPreferredTagName('return', {returns: 'return'})).to.equal('return');
+        expect(jsdocUtils.getPreferredTagName({}, 'jsdoc', 'return', {returns: 'return'})).to.equal('return');
       });
     });
   });
   describe('isValidTag()', () => {
     context('tag is invalid', () => {
       it('returns false', () => {
-        expect(jsdocUtils.isValidTag('foo', [])).to.equal(false);
+        expect(jsdocUtils.isValidTag({}, 'jsdoc', 'foo', [])).to.equal(false);
       });
     });
     context('tag is valid', () => {
       it('returns true', () => {
-        expect(jsdocUtils.isValidTag('param', [])).to.equal(true);
+        expect(jsdocUtils.isValidTag({}, 'jsdoc', 'param', [])).to.equal(true);
       });
     });
     context('tag is valid alias', () => {
       it('returns true', () => {
-        expect(jsdocUtils.isValidTag('arg', [])).to.equal(true);
+        expect(jsdocUtils.isValidTag({}, 'jsdoc', 'arg', [])).to.equal(true);
       });
     });
     context('tag is valid and customized', () => {
       it('returns true', () => {
-        expect(jsdocUtils.isValidTag('foobar', ['foobar'])).to.equal(true);
+        expect(jsdocUtils.isValidTag({}, 'jsdoc', 'foobar', ['foobar'])).to.equal(true);
       });
     });
   });

--- a/test/rules/assertions/checkTagNames.js
+++ b/test/rules/assertions/checkTagNames.js
@@ -1,10 +1,15 @@
-import {jsdocTags} from '../../../src/tagNames';
+import {jsdocTags, typeScriptTags, closureTags} from '../../../src/tagNames';
 
-const ALL_JSDOC_TAGS_COMMENT = '/** \n * @' + Object.keys(
-  jsdocTags,
-).reduce((string, tagName, idx) => {
-  return string + (idx === 0 ? '' : '\n * @') + tagName;
-}, '') + '\n */';
+const buildTagBlock = (tags) => {
+  return '/** \n * @' + Object.keys(tags).reduce((string, tagName, idx) => {
+    return string + (idx === 0 ? '' : '\n * @') + tagName;
+  }, '') + '\n */';
+};
+
+// We avoid testing all closure tags as too many
+const ALL_JSDOC_TAGS_COMMENT = buildTagBlock(jsdocTags);
+const ALL_TYPESCRIPT_TAGS_COMMENT = buildTagBlock(typeScriptTags);
+const ONE_CLOSURE_TAGS_COMMENT = buildTagBlock({externs: closureTags.externs});
 
 export default {
   invalid: [
@@ -411,6 +416,35 @@ export default {
         },
       },
     },
+    {
+      code: `${ALL_JSDOC_TAGS_COMMENT}\nfunction quux (foo) {}`,
+      errors: [
+        {
+          message: 'Unrecognized value `badMode` for `settings.jsdoc.mode`.',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          mode: 'badMode',
+        },
+      },
+    },
+    {
+      code: `${ALL_TYPESCRIPT_TAGS_COMMENT}\nfunction quux (foo) {}`,
+      errors: [
+        {
+          message: 'Invalid JSDoc tag name "template".',
+        },
+      ],
+    },
+    {
+      code: `${ONE_CLOSURE_TAGS_COMMENT}\nfunction quux (foo) {}`,
+      errors: [
+        {
+          message: 'Invalid JSDoc tag name "externs".',
+        },
+      ],
+    },
   ],
   valid: [
     {
@@ -500,6 +534,22 @@ export default {
     },
     {
       code: `${ALL_JSDOC_TAGS_COMMENT}\nfunction quux (foo) {}`,
+    },
+    {
+      code: `${ALL_TYPESCRIPT_TAGS_COMMENT}\nfunction quux (foo) {}`,
+      settings: {
+        jsdoc: {
+          mode: 'typescript',
+        },
+      },
+    },
+    {
+      code: `${ONE_CLOSURE_TAGS_COMMENT}\nfunction quux (foo) {}`,
+      settings: {
+        jsdoc: {
+          mode: 'closure',
+        },
+      },
     },
     {
       code: `


### PR DESCRIPTION
feat(`check-tag-names` and other rules): begin `settings.jsdoc.mode`; utilize in `getPreferredTagName`, `isValidTag`, `getTagsByType`; fixes part of #356

BREAKING CHANGE: Allowable values: jsdoc|typescript|closure

I don't like the relatively large list of tags added to the README, but I also don't like not testing them so not sure if there is a better approach.