### PR TITLE
fix: Alignment fixer should use indentation character from sourceCode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,31 @@ The following patterns are considered problems:
   * @param {Number} foo
  */
 function quux (foo) {
+  // with spaces
+}
+// Message: Expected JSDoc block to be aligned.
 
+/**
+  * @param {Number} foo
+ */
+function quux (foo) {
+	// with tabs
+}
+// Message: Expected JSDoc block to be aligned.
+
+/**
+  * @param {Number} foo
+ */
+function quux (foo) {
+  // with spaces
+}
+// Message: Expected JSDoc block to be aligned.
+
+/**
+* @param {Number} foo
+*/
+function quux (foo) {
+  // with spaces
 }
 // Message: Expected JSDoc block to be aligned.
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -499,7 +499,9 @@ export default function iterateJsdoc (iterator, ruleConfig) {
           return;
         }
 
-        const indent = ' '.repeat(jsdocNode.loc.start.column);
+        const sourceLine = sourceCode.lines[jsdocNode.loc.start.line - 1];
+
+        const indent = sourceLine.charAt(0).repeat(jsdocNode.loc.start.column);
 
         const jsdoc = parseComment(jsdocNode, indent);
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -422,7 +422,8 @@ const iterateAllJsdocs = (iterator, ruleConfig) => {
               return;
             }
 
-            const indent = ' '.repeat(comment.loc.start.column);
+            const sourceLine = sourceCode.lines[comment.loc.start.line - 1];
+            const indent = sourceLine.charAt(0).repeat(comment.loc.start.column);
             const jsdoc = parseComment(comment, indent, !ruleConfig.noTrim);
             const settings = getSettings(context);
             const report = makeReport(context, comment);

--- a/src/rules/checkAlignment.js
+++ b/src/rules/checkAlignment.js
@@ -1,5 +1,8 @@
-import _ from 'lodash';
 import iterateJsdoc from '../iterateJsdoc';
+
+const trimStart = (string) => {
+  return string.replace(/^\s+/, '');
+};
 
 export default iterateJsdoc(({
   sourceCode,
@@ -15,16 +18,16 @@ export default iterateJsdoc(({
       return line.split('*')[0];
     })
     .filter((line) => {
-      return !line.trim().length;
+      return !trimStart(line).length;
     });
 
   const fix = (fixer) => {
     const replacement = sourceCode.getText(jsdocNode).split('\n')
       .map((line, index) => {
         // Ignore the first line and all lines not starting with `*`
-        const ignored = !index || line.split('*')[0].trim().length;
+        const ignored = !index || trimStart(line.split('*')[0]).length;
 
-        return ignored ? line : `${indent} ${_.trimStart(line)}`;
+        return ignored ? line : `${indent} ${trimStart(line)}`;
       })
       .join('\n');
 

--- a/test/rules/assertions/checkAlignment.js
+++ b/test/rules/assertions/checkAlignment.js
@@ -24,15 +24,14 @@ export default {
         }
       `,
     },
-    /* eslint-disable no-tabs */
     {
       code: `
-				/**
-				  * @param {Number} foo
-				 */
-				function quux (foo) {
-					// with tabs
-				}
+\t\t\t\t/**
+\t\t\t\t  * @param {Number} foo
+\t\t\t\t */
+\t\t\t\tfunction quux (foo) {
+\t\t\t\t\t// with tabs
+\t\t\t\t}
       `,
       errors: [
         {
@@ -41,15 +40,62 @@ export default {
         },
       ],
       output: `
-				/**
-				 * @param {Number} foo
-				 */
-				function quux (foo) {
-					// with tabs
-				}
+\t\t\t\t/**
+\t\t\t\t * @param {Number} foo
+\t\t\t\t */
+\t\t\t\tfunction quux (foo) {
+\t\t\t\t\t// with tabs
+\t\t\t\t}
       `,
     },
-    /* eslint-enable no-tabs */
+    {
+      code: `
+/**
+  * @param {Number} foo
+ */
+function quux (foo) {
+  // with spaces
+}
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected JSDoc block to be aligned.',
+        },
+      ],
+      output: `
+/**
+ * @param {Number} foo
+ */
+function quux (foo) {
+  // with spaces
+}
+      `,
+    },
+    {
+      code: `
+/**
+* @param {Number} foo
+*/
+function quux (foo) {
+  // with spaces
+}
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected JSDoc block to be aligned.',
+        },
+      ],
+      output: `
+/**
+ * @param {Number} foo
+ */
+function quux (foo) {
+  // with spaces
+}
+      `,
+    },
     {
       code: `
         /**

--- a/test/rules/assertions/checkAlignment.js
+++ b/test/rules/assertions/checkAlignment.js
@@ -6,7 +6,7 @@ export default {
           * @param {Number} foo
          */
         function quux (foo) {
-
+          // with spaces
         }
       `,
       errors: [
@@ -20,10 +20,36 @@ export default {
          * @param {Number} foo
          */
         function quux (foo) {
-
+          // with spaces
         }
       `,
     },
+    /* eslint-disable no-tabs */
+    {
+      code: `
+				/**
+				  * @param {Number} foo
+				 */
+				function quux (foo) {
+					// with tabs
+				}
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected JSDoc block to be aligned.',
+        },
+      ],
+      output: `
+				/**
+				 * @param {Number} foo
+				 */
+				function quux (foo) {
+					// with tabs
+				}
+      `,
+    },
+    /* eslint-enable no-tabs */
     {
       code: `
         /**


### PR DESCRIPTION
addresses #368 

There were a few other areas where `' '.repeat` is used that probably need to be looked into further, as I believe they apply to rules other than "check-alignment".