### PR TITLE
feat(`getJSDocComment`): ignore line comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,7 +790,7 @@ function f () {
 function quux () {
 
 }
-// Options: [{"baseConfig":{"parser":"/Users/brett/eslint-plugin-jsdoc/node_modules/@typescript-eslint/parser/dist/parser.js","parserOptions":{"ecmaVersion":6},"rules":{"semi":["error","always"]}},"eslintrcForExamples":false}]
+// Options: [{"baseConfig":{"parser":"@typescript-eslint/parser","parserOptions":{"ecmaVersion":6},"rules":{"semi":["error","always"]}},"eslintrcForExamples":false}]
 // Message: @example error (semi): Missing semicolon.
 ````
 
@@ -885,7 +885,7 @@ function quux () {}
 function quux () {
 
 }
-// Options: [{"baseConfig":{"parser":"/Users/brett/eslint-plugin-jsdoc/node_modules/@typescript-eslint/parser/dist/parser.js","parserOptions":{"ecmaVersion":6},"rules":{"semi":["error","always"]}},"eslintrcForExamples":false}]
+// Options: [{"baseConfig":{"parser":"@typescript-eslint/parser","parserOptions":{"ecmaVersion":6},"rules":{"semi":["error","always"]}},"eslintrcForExamples":false}]
 ````
 
 

--- a/src/eslint/getJSDocComment.js
+++ b/src/eslint/getJSDocComment.js
@@ -98,15 +98,27 @@ const getJSDocComment = function (sourceCode, node, settings) {
    * @private
    */
   const findJSDocComment = (astNode) => {
-    const tokenBefore = sourceCode.getTokenBefore(astNode, {includeComments: true});
     const {minLines, maxLines} = settings;
+    let currentNode = astNode;
+    let tokenBefore = null;
+
+    while (currentNode) {
+      tokenBefore = sourceCode.getTokenBefore(currentNode, {includeComments: true});
+      if (!tokenBefore || !isCommentToken(tokenBefore)) {
+        return null;
+      }
+      if (tokenBefore.type === 'Line') {
+        currentNode = tokenBefore;
+        continue;
+      }
+      break;
+    }
+
     if (
-      tokenBefore &&
-      isCommentToken(tokenBefore) &&
       tokenBefore.type === 'Block' &&
       tokenBefore.value.charAt(0) === '*' &&
-      astNode.loc.start.line - tokenBefore.loc.end.line >= minLines &&
-      astNode.loc.start.line - tokenBefore.loc.end.line <= maxLines
+      currentNode.loc.start.line - tokenBefore.loc.end.line >= minLines &&
+      currentNode.loc.start.line - tokenBefore.loc.end.line <= maxLines
     ) {
       return tokenBefore;
     }

--- a/test/eslint/getJSDocComment.js
+++ b/test/eslint/getJSDocComment.js
@@ -43,5 +43,11 @@ ruleTester.run('getJSDocComment', rule, {
     /** Doc */
     var a = {};
     `,
+  }, {
+    code: `
+    /** Doc */
+    // eslint-disable-next-line no-var
+    var a = {};
+    `,
   }],
 });

--- a/test/rules/assertions/checkExamples.js
+++ b/test/rules/assertions/checkExamples.js
@@ -504,7 +504,7 @@ export default {
       ],
       options: [{
         baseConfig: {
-          parser: require.resolve('@typescript-eslint/parser'),
+          parser: '@typescript-eslint/parser',
           parserOptions: {
             ecmaVersion: 6,
           },
@@ -695,7 +695,7 @@ export default {
       `,
       options: [{
         baseConfig: {
-          parser: require.resolve('@typescript-eslint/parser'),
+          parser: '@typescript-eslint/parser',
           parserOptions: {
             ecmaVersion: 6,
           },


### PR DESCRIPTION
Often it is required to disable linting in-between the JSDoc and the
code. This PR allows that to happen.

Without the following change the `jsdoc/require-jsdoc` rule needs to be
constantly disabled.

Consider the following example:

```ts
/**
 * A user.
 * @interface User
 */
interface User {
  /**
   * The users age.
   * @type {number}
   * @memberof User
   */
  age: number;

  /**
   * The users name.
   * @type {string}
   * @memberof User
   */
  name: string;
}

/**
 * Determine if the provided value is a `User`;
 * @param {*} user The value to check.
 * @returns {boolean} Whether or not the provided value is a `User`.
 */
// Allow the Function to check any input.
// tslint:disable-next-line: no-any
function isUser(user: any): user is User {
  if (user == null) {
      return false;
  }
  const { age, name } = user;
  if (typeof age !== `number`) {
      return false;
  }
  if (typeof name !== `string`) {
      return false;
  }
  return true;
}
```

In the above example, using `unknown` wouldn't cut it. This is because
`unknown` cannot be destructured. Eg: `const { age, name } = user;`.

This PR also updates the checkExamples.js assertion so as not to require
an absolute path to @typescript-eslint/parser.

This absolute path would mean constant calls to npm run create-readme
because of the different paths that developers would have the repo
checked out at.