### PR TITLE
fix(`no-undefined-types`): do not crash on variadic arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -4090,6 +4090,13 @@ class Foo {
   }
 }
 // Message: The type 'TEMPLATE_TYPE_A' is undefined.
+
+/**
+ * @param {...VAR_TYPE} varargs
+ */
+function quux (varargs) {
+}
+// Message: The type 'VAR_TYPE' is undefined.
 ````
 
 The following patterns are not considered problems:
@@ -4281,6 +4288,18 @@ class Foo {
  */
 function quux () {
 
+}
+
+/**
+ * @param {...} varargs
+ */
+function quux (varargs) {
+}
+
+/**
+ * @param {...number} varargs
+ */
+function quux (varargs) {
 }
 ````
 

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -119,7 +119,11 @@ export default iterateJsdoc(({
       return;
     }
 
-    traverse(parsedType, ({type, name}) => {
+    traverse(parsedType, (arg) => {
+      // In case of a variadic jsdoc arguments, `arg` is `null`,
+      // but `parsedType` will be the tag we should be operating on.
+      const {type, name} = arg || parsedType;
+
       if (type === 'NAME') {
         if (!allDefinedTypes.includes(name)) {
           report(`The type '${name}' is undefined.`, null, tag);

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -261,6 +261,21 @@ export default {
         },
       ],
     },
+    {
+      code: `
+      /**
+       * @param {...VAR_TYPE} varargs
+       */
+      function quux (varargs) {
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'The type \'VAR_TYPE\' is undefined.',
+        },
+      ],
+    },
   ],
   valid: [
     {
@@ -561,6 +576,24 @@ export default {
 
       }
        `,
+    },
+    {
+      code: `
+      /**
+       * @param {...} varargs
+       */
+      function quux (varargs) {
+      }
+      `,
+    },
+    {
+      code: `
+      /**
+       * @param {...number} varargs
+       */
+      function quux (varargs) {
+      }
+      `,
     },
   ],
 };


### PR DESCRIPTION
When running `no-undefined-types` on our codebase, I discovered that it
crashes on `variadic` arguments. It turns out that jsdoctypeparser does
not cleanly traverse over variadic arguments. Thus, used the
`parsedType` to traverse over instead.