### PR TITLE
feat(`empty-tags`): expect certain tags to be empty

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -321,6 +321,7 @@ only (e.g., to match `Array` if the type is `Array` vs. `Array.<string>`).
 {"gitdown": "include", "file": "./rules/check-syntax.md"}
 {"gitdown": "include", "file": "./rules/check-tag-names.md"}
 {"gitdown": "include", "file": "./rules/check-types.md"}
+{"gitdown": "include", "file": "./rules/empty-tags.md"}
 {"gitdown": "include", "file": "./rules/implements-on-classes.md"}
 {"gitdown": "include", "file": "./rules/match-description.md"}
 {"gitdown": "include", "file": "./rules/newline-after-description.md"}

--- a/.README/rules/empty-tags.md
+++ b/.README/rules/empty-tags.md
@@ -1,0 +1,45 @@
+### `empty-tags`
+
+Expects the following tags to be empty of any content:
+
+- `@abstract`
+- `@async`
+- `@generator`
+- `@global`
+- `@hideconstructor`
+- `@ignore`
+- `@inheritdoc`
+- `@inner`
+- `@instance`
+- `@override`
+- `@readonly`
+
+The following will also be expected to be empty unless `settings.jsdoc.mode`
+is set to "closure" (which allows types).
+
+- `@package`
+- `@private`
+- `@protected`
+- `@public`
+- `@static`
+
+#### Options
+
+##### `tags`
+
+If you want additional tags to be checked for their descriptions, you may
+add them within this option.
+
+```js
+{
+  'jsdoc/empty-tags': ['error', {tags: ['event']}]
+}
+```
+
+|||
+|---|---|
+|Context|everywhere|
+|Tags| and others added by `tags`|
+|Aliases||
+|Options|`tags`|
+<!-- assertions emptyTags -->

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ JSDoc linting rules for ESLint.
         * [`check-syntax`](#eslint-plugin-jsdoc-rules-check-syntax)
         * [`check-tag-names`](#eslint-plugin-jsdoc-rules-check-tag-names)
         * [`check-types`](#eslint-plugin-jsdoc-rules-check-types)
+        * [`empty-tags`](#eslint-plugin-jsdoc-rules-empty-tags)
         * [`implements-on-classes`](#eslint-plugin-jsdoc-rules-implements-on-classes)
         * [`match-description`](#eslint-plugin-jsdoc-rules-match-description)
         * [`newline-after-description`](#eslint-plugin-jsdoc-rules-newline-after-description)
@@ -2988,6 +2989,142 @@ var subscribe = function(callback) {};
 ````
 
 
+<a name="eslint-plugin-jsdoc-rules-empty-tags"></a>
+### <code>empty-tags</code>
+
+Expects the following tags to be empty of any content:
+
+- `@abstract`
+- `@async`
+- `@generator`
+- `@global`
+- `@hideconstructor`
+- `@ignore`
+- `@inheritdoc`
+- `@inner`
+- `@instance`
+- `@override`
+- `@readonly`
+
+The following will also be expected to be empty unless `settings.jsdoc.mode`
+is set to "closure" (which allows types).
+
+- `@package`
+- `@private`
+- `@protected`
+- `@public`
+- `@static`
+
+<a name="eslint-plugin-jsdoc-rules-empty-tags-options-5"></a>
+#### Options
+
+<a name="eslint-plugin-jsdoc-rules-empty-tags-options-5-tags"></a>
+##### <code>tags</code>
+
+If you want additional tags to be checked for their descriptions, you may
+add them within this option.
+
+```js
+{
+  'jsdoc/empty-tags': ['error', {tags: ['event']}]
+}
+```
+
+|||
+|---|---|
+|Context|everywhere|
+|Tags| and others added by `tags`|
+|Aliases||
+|Options|`tags`|
+The following patterns are considered problems:
+
+````js
+/**
+ * @abstract extra text
+ */
+function quux () {
+
+}
+// Message: @abstract should be empty.
+
+/**
+ * @abstract extra text
+ * @inheritdoc
+ * @async out of place
+ */
+function quux () {
+
+}
+// Message: @abstract should be empty.
+
+/**
+ * @event anEvent
+ */
+function quux () {
+
+}
+// Options: [{"tags":["event"]}]
+// Message: @event should be empty.
+
+/**
+ * @private {someType}
+ */
+function quux () {
+
+}
+// Message: @private should be empty.
+````
+
+The following patterns are not considered problems:
+
+````js
+/**
+ * @abstract
+ */
+function quux () {
+
+}
+
+/**
+ *
+ */
+function quux () {
+
+}
+
+/**
+ * @param aName
+ */
+function quux () {
+
+}
+
+/**
+ * @abstract
+ * @inheritdoc
+ * @async
+ */
+function quux () {
+
+}
+
+/**
+ * @private {someType}
+ */
+function quux () {
+
+}
+// Settings: {"jsdoc":{"mode":"closure"}}
+
+/**
+ * @private
+ */
+function quux () {
+
+}
+````
+
+
 <a name="eslint-plugin-jsdoc-rules-implements-on-classes"></a>
 ### <code>implements-on-classes</code>
 
@@ -3096,10 +3233,10 @@ by our supported Node versions):
 Applies to the jsdoc block description and `@description` (or `@desc`)
 by default but the `tags` option (see below) may be used to match other tags.
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-5"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-6"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-5-matchdescription"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-6-matchdescription"></a>
 ##### <code>matchDescription</code>
 
 You can supply your own expression to override the default, passing a
@@ -3114,7 +3251,7 @@ You can supply your own expression to override the default, passing a
 As with the default, the supplied regular expression will be applied with the
 Unicode (`"u"`) flag and is *not* case-insensitive.
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-5-tags"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-6-tags-1"></a>
 ##### <code>tags</code>
 
 If you want different regular expressions to apply to tags, you may use
@@ -3151,7 +3288,7 @@ its "description" (e.g., for `@returns {someType} some description`, the
 description is `some description` while for `@some-tag xyz`, the description
 is `xyz`).
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-5-maindescription"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-6-maindescription"></a>
 ##### <code>mainDescription</code>
 
 If you wish to override the main function description without changing the
@@ -3173,7 +3310,7 @@ There is no need to add `mainDescription: true`, as by default, the main
 function (and only the main function) is linted, though you may disable checking
 it by setting it to `false`.
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-5-contexts"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-6-contexts"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
@@ -3793,7 +3930,7 @@ function quux () {
 
 Enforces a consistent padding of the block description.
 
-<a name="eslint-plugin-jsdoc-rules-newline-after-description-options-6"></a>
+<a name="eslint-plugin-jsdoc-rules-newline-after-description-options-7"></a>
 #### Options
 
 This rule allows one optional string argument. If it is `"always"` then a problem is raised when there is no newline after the description. If it is `"never"` then a problem is raised when there is a newline after the description. The default value is `"always"`.
@@ -3977,7 +4114,7 @@ The following types are always considered defined.
 Note that preferred types indicated within `settings.jsdoc.preferredTypes` will
 also be assumed to be defined.
 
-<a name="eslint-plugin-jsdoc-rules-no-undefined-types-options-7"></a>
+<a name="eslint-plugin-jsdoc-rules-no-undefined-types-options-8"></a>
 #### Options
 
 An option object may have the following key:
@@ -4359,10 +4496,10 @@ tag descriptions are written in complete sentences, i.e.,
 * A colon or semi-colon followed by two line breaks is still part of the
   containing paragraph (unlike normal dual line breaks).
 
-<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-8"></a>
+<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-9"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-8-tags-1"></a>
+<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-9-tags-2"></a>
 ##### <code>tags</code>
 
 If you want additional tags to be checked for their descriptions, you may
@@ -4834,7 +4971,7 @@ Requires that all functions have a description.
   `"tag"`) must have a non-empty description that explains the purpose of the
   method.
 
-<a name="eslint-plugin-jsdoc-rules-require-description-options-9"></a>
+<a name="eslint-plugin-jsdoc-rules-require-description-options-10"></a>
 #### Options
 
 An options object may have any of the following properties:
@@ -5119,25 +5256,25 @@ Requires that all functions have examples.
 * All functions must have one or more `@example` tags.
 * Every example tag must have a non-empty description that explains the method's usage.
 
-<a name="eslint-plugin-jsdoc-rules-require-example-options-10"></a>
+<a name="eslint-plugin-jsdoc-rules-require-example-options-11"></a>
 #### Options
 
 This rule has an object option.
 
-<a name="eslint-plugin-jsdoc-rules-require-example-options-10-exemptedby"></a>
+<a name="eslint-plugin-jsdoc-rules-require-example-options-11-exemptedby"></a>
 ##### <code>exemptedBy</code>
 
 Array of tags (e.g., `['type']`) whose presence on the document
 block avoids the need for an `@example`. Defaults to an empty array.
 
-<a name="eslint-plugin-jsdoc-rules-require-example-options-10-avoidexampleonconstructors"></a>
+<a name="eslint-plugin-jsdoc-rules-require-example-options-11-avoidexampleonconstructors"></a>
 ##### <code>avoidExampleOnConstructors</code>
 
 Set to `true` to avoid the need for an example on a constructor (whether
 indicated as such by a jsdoc tag or by being within an ES6 `class`).
 Defaults to `false`.
 
-<a name="eslint-plugin-jsdoc-rules-require-example-options-10-contexts-1"></a>
+<a name="eslint-plugin-jsdoc-rules-require-example-options-11-contexts-1"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
@@ -5315,7 +5452,7 @@ function quux () {
 
 Requires a hyphen before the `@param` description.
 
-<a name="eslint-plugin-jsdoc-rules-require-hyphen-before-param-description-options-11"></a>
+<a name="eslint-plugin-jsdoc-rules-require-hyphen-before-param-description-options-12"></a>
 #### Options
 
 This rule takes one optional string argument. If it is `"always"` then a problem is raised when there is no hyphen before the description. If it is `"never"` then a problem is raised when there is a hyphen before the description. The default value is `"always"`.
@@ -5421,7 +5558,7 @@ function quux () {
 Checks for presence of jsdoc comments, on class declarations as well as
 functions.
 
-<a name="eslint-plugin-jsdoc-rules-require-jsdoc-options-12"></a>
+<a name="eslint-plugin-jsdoc-rules-require-jsdoc-options-13"></a>
 #### Options
 
 Accepts one optional options object with the following optional keys.
@@ -6609,7 +6746,7 @@ function quux (foo) {
 
 Requires that all function parameters are documented.
 
-<a name="eslint-plugin-jsdoc-rules-require-param-options-13"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-options-14"></a>
 #### Options
 
 An options object accepts one optional property:
@@ -7682,7 +7819,7 @@ Requires returns are documented.
 
 Will also report if multiple `@returns` tags are present.
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-options-14"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-options-15"></a>
 #### Options
 
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
@@ -8147,7 +8284,7 @@ Also impacts behaviors on namepath (or event)-defining and pointing tags:
    allow `#`, `.`, or `~` at the end (which is not allowed at the end of
    normal paths).
 
-<a name="eslint-plugin-jsdoc-rules-valid-types-options-15"></a>
+<a name="eslint-plugin-jsdoc-rules-valid-types-options-16"></a>
 #### Options
 
 - `allowEmptyNamepaths` (default: true) - Set to `false` to disallow

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import checkParamNames from './rules/checkParamNames';
 import checkSyntax from './rules/checkSyntax';
 import checkTagNames from './rules/checkTagNames';
 import checkTypes from './rules/checkTypes';
+import emptyTags from './rules/emptyTags';
 import implementsOnClasses from './rules/implementsOnClasses';
 import matchDescription from './rules/matchDescription';
 import newlineAfterDescription from './rules/newlineAfterDescription';
@@ -38,6 +39,7 @@ export default {
         'jsdoc/check-syntax': 'off',
         'jsdoc/check-tag-names': 'warn',
         'jsdoc/check-types': 'warn',
+        'jsdoc/empty-tags': 'warn',
         'jsdoc/implements-on-classes': 'warn',
         'jsdoc/match-description': 'off',
         'jsdoc/newline-after-description': 'warn',
@@ -68,6 +70,7 @@ export default {
     'check-syntax': checkSyntax,
     'check-tag-names': checkTagNames,
     'check-types': checkTypes,
+    'empty-tags': emptyTags,
     'implements-on-classes': implementsOnClasses,
     'match-description': matchDescription,
     'newline-after-description': newlineAfterDescription,

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -255,6 +255,12 @@ const getUtils = (
     return jsdocUtils.getTagsByType(context, mode, tags, tagNamePreference);
   };
 
+  utils.hasOptionTag = (tagName) => {
+    const tags = _.get(context, 'options[0].tags');
+
+    return Boolean(tags && tags.includes(tagName));
+  };
+
   utils.getClassNode = () => {
     // Ancestors missing in `Program` comment iteration
     const greatGrandParent = ancestors.length ?

--- a/src/rules/emptyTags.js
+++ b/src/rules/emptyTags.js
@@ -1,0 +1,60 @@
+import iterateJsdoc from '../iterateJsdoc';
+
+const defaultEmptyTags = [
+  'abstract', 'async', 'generator', 'global', 'hideconstructor',
+  'ignore', 'inheritdoc', 'inner', 'instance', 'override', 'readonly',
+];
+
+const emptyIfNotClosure = [
+  'package', 'private', 'protected', 'public', 'static',
+];
+
+export default iterateJsdoc(({
+  settings,
+  jsdoc,
+  utils,
+}) => {
+  if (!jsdoc.tags) {
+    return;
+  }
+  const emptyTags = utils.filterTags(({tag: tagName}) => {
+    return defaultEmptyTags.includes(tagName) ||
+      utils.hasOptionTag(tagName) && jsdoc.tags.some(({tag}) => {
+        return tag === tagName;
+      }) ||
+      settings.mode !== 'closure' && emptyIfNotClosure.includes(tagName);
+  });
+  emptyTags.forEach((tag) => {
+    const fix = () => {
+      tag.name = '';
+      tag.description = '';
+      tag.type = '';
+      tag.optional = false;
+      tag.default = undefined;
+    };
+    const content = tag.name || tag.description || tag.type;
+    if (content) {
+      utils.reportJSDoc(`@${tag.tag} should be empty.`, tag, fix);
+    }
+  });
+}, {
+  iterateAllJsdocs: true,
+  meta: {
+    fixable: 'code',
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          tags: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
+    type: 'suggestion',
+  },
+});

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -2,6 +2,14 @@ import _ from 'lodash';
 import {RegExtras} from 'regextras/dist/main-umd';
 import iterateJsdoc from '../iterateJsdoc';
 
+const otherDescriptiveTags = [
+  // 'copyright' and 'see' might be good addition, but as the former may be
+  //   sensitive text, and the latter may have just a link, they are not
+  //   included by default
+  'summary', 'file', 'fileoverview', 'overview', 'classdesc', 'todo',
+  'deprecated', 'throws', 'exception', 'yields', 'yield',
+];
+
 const extractParagraphs = (text) => {
   // Todo [engine:node@>8.11.0]: Uncomment following line with neg. lookbehind instead
   // return text.split(/(?<![;:])\n\n/u);
@@ -132,7 +140,6 @@ export default iterateJsdoc(({
   jsdoc,
   report,
   jsdocNode,
-  context,
   utils,
 }) => {
   if (!jsdoc.tags ||
@@ -148,22 +155,10 @@ export default iterateJsdoc(({
     validateDescription(description, report, jsdocNode, sourceCode, matchingJsdocTag);
   }, true);
 
-  const options = context.options[0] || {};
-
-  const hasOptionTag = (tagName) => {
-    return Boolean(options.tags && options.tags.includes(tagName));
-  };
-
   const {tagsWithNames} = utils.getTagsByType(jsdoc.tags);
   const tagsWithoutNames = utils.filterTags(({tag: tagName}) => {
-    return [
-      // 'copyright' and 'see' might be good addition, but as the former may be
-      //   sensitive text, and the latter may have just a link, they are not
-      //   included by default
-      'summary', 'file', 'fileoverview', 'overview', 'classdesc', 'todo',
-      'deprecated', 'throws', 'exception', 'yields', 'yield',
-    ].includes(tagName) ||
-      hasOptionTag(tagName) && !tagsWithNames.some(({tag}) => {
+    return otherDescriptiveTags.includes(tagName) ||
+      utils.hasOptionTag(tagName) && !tagsWithNames.some(({tag}) => {
         // If user accidentally adds tags with names (or like `returns`
         //  get parsed as having names), do not add to this list
         return tag === tagName;

--- a/test/rules/assertions/emptyTags.js
+++ b/test/rules/assertions/emptyTags.js
@@ -1,0 +1,174 @@
+export default {
+  invalid: [
+    {
+      code: `
+          /**
+           * @abstract extra text
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@abstract should be empty.',
+        },
+      ],
+      output: `
+          /**
+           * @abstract
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @abstract extra text
+           * @inheritdoc
+           * @async out of place
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@abstract should be empty.',
+        },
+        {
+          line: 5,
+          message: '@async should be empty.',
+        },
+      ],
+      output: `
+          /**
+           * @abstract
+           * @inheritdoc
+           * @async out of place
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @event anEvent
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@event should be empty.',
+        },
+      ],
+      options: [
+        {
+          tags: ['event'],
+        },
+      ],
+      output: `
+          /**
+           * @event
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+      /**
+       * @private {someType}
+       */
+      function quux () {
+
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@private should be empty.',
+        },
+      ],
+    },
+  ],
+  valid: [
+    {
+      code: `
+          /**
+           * @abstract
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @param aName
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @abstract
+           * @inheritdoc
+           * @async
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+      /**
+       * @private {someType}
+       */
+      function quux () {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'closure',
+        },
+      },
+    },
+    {
+      code: `
+      /**
+       * @private
+       */
+      function quux () {
+
+      }
+      `,
+    },
+  ],
+};

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -15,6 +15,7 @@ const ruleTester = new RuleTester();
   'check-syntax',
   'check-tag-names',
   'check-types',
+  'empty-tags',
   'implements-on-classes',
   'match-description',
   'newline-after-description',


### PR DESCRIPTION
BREAKING CHANGE:

Added rule to `recommended`.

May add additional tags to check for emptiness using `tags` option.