### PR TITLE
feat(check-values): Add new rule for checking special tag values

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -322,6 +322,7 @@ only (e.g., to match `Array` if the type is `Array` vs. `Array.<string>`).
 {"gitdown": "include", "file": "./rules/check-syntax.md"}
 {"gitdown": "include", "file": "./rules/check-tag-names.md"}
 {"gitdown": "include", "file": "./rules/check-types.md"}
+{"gitdown": "include", "file": "./rules/check-values.md"}
 {"gitdown": "include", "file": "./rules/empty-tags.md"}
 {"gitdown": "include", "file": "./rules/implements-on-classes.md"}
 {"gitdown": "include", "file": "./rules/match-description.md"}

--- a/.README/README.md
+++ b/.README/README.md
@@ -314,6 +314,7 @@ only (e.g., to match `Array` if the type is `Array` vs. `Array.<string>`).
 
 ## Rules
 
+{"gitdown": "include", "file": "./rules/check-access.md"}
 {"gitdown": "include", "file": "./rules/check-alignment.md"}
 {"gitdown": "include", "file": "./rules/check-examples.md"}
 {"gitdown": "include", "file": "./rules/check-indentation.md"}

--- a/.README/README.md
+++ b/.README/README.md
@@ -321,6 +321,7 @@ only (e.g., to match `Array` if the type is `Array` vs. `Array.<string>`).
 {"gitdown": "include", "file": "./rules/check-syntax.md"}
 {"gitdown": "include", "file": "./rules/check-tag-names.md"}
 {"gitdown": "include", "file": "./rules/check-types.md"}
+{"gitdown": "include", "file": "./rules/empty-tags.md"}
 {"gitdown": "include", "file": "./rules/implements-on-classes.md"}
 {"gitdown": "include", "file": "./rules/match-description.md"}
 {"gitdown": "include", "file": "./rules/newline-after-description.md"}

--- a/.README/rules/check-access.md
+++ b/.README/rules/check-access.md
@@ -1,0 +1,21 @@
+### `check-access`
+
+Checks that `@access` tags use one of the following values:
+
+- "package", "private", "protected", "public"
+
+Also reports:
+
+- Mixing of `@access` with `@public`, `@private`, `@protected`, or `@package`
+  on the same doc block.
+- Use of multiple instances of `@access` (or the `@public`, etc. style tags)
+  on the same doc block.
+
+|||
+|---|---|
+|Context|everywhere|
+|Tags|`@access`|
+|Settings||
+|Options||
+
+<!-- assertions checkAccess -->

--- a/.README/rules/check-values.md
+++ b/.README/rules/check-values.md
@@ -1,0 +1,33 @@
+### `check-values`
+
+This rule checks the values for a handful of tags:
+
+1. `@version` - Checks that there is a present and valid
+    [semver](https://semver.org/) version value.
+2. `@since` - As with `@version`
+3. `@license` - Checks that there is a present and valid SPDX identifier
+    or is present within an `allowedLicenses` option.
+4. `@author` - Checks there is a value present, and if the option
+    `allowedAuthors` is present, ensure that the author value is one
+    of these array items.
+
+#### Options
+
+##### `allowedAuthors`
+
+An array of allowable author values. If absent, only non-whitespace will
+be checked for.
+
+##### `allowedLicenses`
+
+An array of allowable license values or `true` to allow any license text.
+If present as an array, will be used in place of SPDX identifiers.
+
+|||
+|---|---|
+|Context|everywhere|
+|Tags|`@version`, `@since`, `@license`, `@author`|
+|Options|`allowedAuthors`, `allowedLicenses`|
+|Settings|`tagNamePreference`|
+
+<!-- assertions checkValues -->

--- a/.README/rules/empty-tags.md
+++ b/.README/rules/empty-tags.md
@@ -1,0 +1,45 @@
+### `empty-tags`
+
+Expects the following tags to be empty of any content:
+
+- `@abstract`
+- `@async`
+- `@generator`
+- `@global`
+- `@hideconstructor`
+- `@ignore`
+- `@inheritdoc`
+- `@inner`
+- `@instance`
+- `@override`
+- `@readonly`
+
+The following will also be expected to be empty unless `settings.jsdoc.mode`
+is set to "closure" (which allows types).
+
+- `@package`
+- `@private`
+- `@protected`
+- `@public`
+- `@static`
+
+#### Options
+
+##### `tags`
+
+If you want additional tags to be checked for their descriptions, you may
+add them within this option.
+
+```js
+{
+  'jsdoc/empty-tags': ['error', {tags: ['event']}]
+}
+```
+
+|||
+|---|---|
+|Context|everywhere|
+|Tags| and others added by `tags`|
+|Aliases||
+|Options|`tags`|
+<!-- assertions emptyTags -->

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ JSDoc linting rules for ESLint.
         * [`check-syntax`](#eslint-plugin-jsdoc-rules-check-syntax)
         * [`check-tag-names`](#eslint-plugin-jsdoc-rules-check-tag-names)
         * [`check-types`](#eslint-plugin-jsdoc-rules-check-types)
+        * [`empty-tags`](#eslint-plugin-jsdoc-rules-empty-tags)
         * [`implements-on-classes`](#eslint-plugin-jsdoc-rules-implements-on-classes)
         * [`match-description`](#eslint-plugin-jsdoc-rules-match-description)
         * [`newline-after-description`](#eslint-plugin-jsdoc-rules-newline-after-description)
@@ -2988,6 +2989,142 @@ var subscribe = function(callback) {};
 ````
 
 
+<a name="eslint-plugin-jsdoc-rules-empty-tags"></a>
+### <code>empty-tags</code>
+
+Expects the following tags to be empty of any content:
+
+- `@abstract`
+- `@async`
+- `@generator`
+- `@global`
+- `@hideconstructor`
+- `@ignore`
+- `@inheritdoc`
+- `@inner`
+- `@instance`
+- `@override`
+- `@readonly`
+
+The following will also be expected to be empty unless `settings.jsdoc.mode`
+is set to "closure" (which allows types).
+
+- `@package`
+- `@private`
+- `@protected`
+- `@public`
+- `@static`
+
+<a name="eslint-plugin-jsdoc-rules-empty-tags-options-5"></a>
+#### Options
+
+<a name="eslint-plugin-jsdoc-rules-empty-tags-options-5-tags"></a>
+##### <code>tags</code>
+
+If you want additional tags to be checked for their descriptions, you may
+add them within this option.
+
+```js
+{
+  'jsdoc/empty-tags': ['error', {tags: ['event']}]
+}
+```
+
+|||
+|---|---|
+|Context|everywhere|
+|Tags| and others added by `tags`|
+|Aliases||
+|Options|`tags`|
+The following patterns are considered problems:
+
+````js
+/**
+ * @abstract extra text
+ */
+function quux () {
+
+}
+// Message: @abstract should be empty.
+
+/**
+ * @abstract extra text
+ * @inheritdoc
+ * @async out of place
+ */
+function quux () {
+
+}
+// Message: @abstract should be empty.
+
+/**
+ * @event anEvent
+ */
+function quux () {
+
+}
+// Options: [{"tags":["event"]}]
+// Message: @event should be empty.
+
+/**
+ * @private {someType}
+ */
+function quux () {
+
+}
+// Message: @private should be empty.
+````
+
+The following patterns are not considered problems:
+
+````js
+/**
+ * @abstract
+ */
+function quux () {
+
+}
+
+/**
+ *
+ */
+function quux () {
+
+}
+
+/**
+ * @param aName
+ */
+function quux () {
+
+}
+
+/**
+ * @abstract
+ * @inheritdoc
+ * @async
+ */
+function quux () {
+
+}
+
+/**
+ * @private {someType}
+ */
+function quux () {
+
+}
+// Settings: {"jsdoc":{"mode":"closure"}}
+
+/**
+ * @private
+ */
+function quux () {
+
+}
+````
+
+
 <a name="eslint-plugin-jsdoc-rules-implements-on-classes"></a>
 ### <code>implements-on-classes</code>
 
@@ -3096,10 +3233,10 @@ by our supported Node versions):
 Applies to the jsdoc block description and `@description` (or `@desc`)
 by default but the `tags` option (see below) may be used to match other tags.
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-5"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-6"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-5-matchdescription"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-6-matchdescription"></a>
 ##### <code>matchDescription</code>
 
 You can supply your own expression to override the default, passing a
@@ -3114,7 +3251,7 @@ You can supply your own expression to override the default, passing a
 As with the default, the supplied regular expression will be applied with the
 Unicode (`"u"`) flag and is *not* case-insensitive.
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-5-tags"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-6-tags-1"></a>
 ##### <code>tags</code>
 
 If you want different regular expressions to apply to tags, you may use
@@ -3151,7 +3288,7 @@ its "description" (e.g., for `@returns {someType} some description`, the
 description is `some description` while for `@some-tag xyz`, the description
 is `xyz`).
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-5-maindescription"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-6-maindescription"></a>
 ##### <code>mainDescription</code>
 
 If you wish to override the main function description without changing the
@@ -3173,7 +3310,7 @@ There is no need to add `mainDescription: true`, as by default, the main
 function (and only the main function) is linted, though you may disable checking
 it by setting it to `false`.
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-5-contexts"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-6-contexts"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
@@ -3793,7 +3930,7 @@ function quux () {
 
 Enforces a consistent padding of the block description.
 
-<a name="eslint-plugin-jsdoc-rules-newline-after-description-options-6"></a>
+<a name="eslint-plugin-jsdoc-rules-newline-after-description-options-7"></a>
 #### Options
 
 This rule allows one optional string argument. If it is `"always"` then a problem is raised when there is no newline after the description. If it is `"never"` then a problem is raised when there is a newline after the description. The default value is `"always"`.
@@ -3977,7 +4114,7 @@ The following types are always considered defined.
 Note that preferred types indicated within `settings.jsdoc.preferredTypes` will
 also be assumed to be defined.
 
-<a name="eslint-plugin-jsdoc-rules-no-undefined-types-options-7"></a>
+<a name="eslint-plugin-jsdoc-rules-no-undefined-types-options-8"></a>
 #### Options
 
 An option object may have the following key:
@@ -4359,10 +4496,10 @@ tag descriptions are written in complete sentences, i.e.,
 * A colon or semi-colon followed by two line breaks is still part of the
   containing paragraph (unlike normal dual line breaks).
 
-<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-8"></a>
+<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-9"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-8-tags-1"></a>
+<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-9-tags-2"></a>
 ##### <code>tags</code>
 
 If you want additional tags to be checked for their descriptions, you may
@@ -4834,7 +4971,7 @@ Requires that all functions have a description.
   `"tag"`) must have a non-empty description that explains the purpose of the
   method.
 
-<a name="eslint-plugin-jsdoc-rules-require-description-options-9"></a>
+<a name="eslint-plugin-jsdoc-rules-require-description-options-10"></a>
 #### Options
 
 An options object may have any of the following properties:
@@ -5119,25 +5256,25 @@ Requires that all functions have examples.
 * All functions must have one or more `@example` tags.
 * Every example tag must have a non-empty description that explains the method's usage.
 
-<a name="eslint-plugin-jsdoc-rules-require-example-options-10"></a>
+<a name="eslint-plugin-jsdoc-rules-require-example-options-11"></a>
 #### Options
 
 This rule has an object option.
 
-<a name="eslint-plugin-jsdoc-rules-require-example-options-10-exemptedby"></a>
+<a name="eslint-plugin-jsdoc-rules-require-example-options-11-exemptedby"></a>
 ##### <code>exemptedBy</code>
 
 Array of tags (e.g., `['type']`) whose presence on the document
 block avoids the need for an `@example`. Defaults to an empty array.
 
-<a name="eslint-plugin-jsdoc-rules-require-example-options-10-avoidexampleonconstructors"></a>
+<a name="eslint-plugin-jsdoc-rules-require-example-options-11-avoidexampleonconstructors"></a>
 ##### <code>avoidExampleOnConstructors</code>
 
 Set to `true` to avoid the need for an example on a constructor (whether
 indicated as such by a jsdoc tag or by being within an ES6 `class`).
 Defaults to `false`.
 
-<a name="eslint-plugin-jsdoc-rules-require-example-options-10-contexts-1"></a>
+<a name="eslint-plugin-jsdoc-rules-require-example-options-11-contexts-1"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
@@ -5315,7 +5452,7 @@ function quux () {
 
 Requires a hyphen before the `@param` description.
 
-<a name="eslint-plugin-jsdoc-rules-require-hyphen-before-param-description-options-11"></a>
+<a name="eslint-plugin-jsdoc-rules-require-hyphen-before-param-description-options-12"></a>
 #### Options
 
 This rule takes one optional string argument. If it is `"always"` then a problem is raised when there is no hyphen before the description. If it is `"never"` then a problem is raised when there is a hyphen before the description. The default value is `"always"`.
@@ -5421,7 +5558,7 @@ function quux () {
 Checks for presence of jsdoc comments, on class declarations as well as
 functions.
 
-<a name="eslint-plugin-jsdoc-rules-require-jsdoc-options-12"></a>
+<a name="eslint-plugin-jsdoc-rules-require-jsdoc-options-13"></a>
 #### Options
 
 Accepts one optional options object with the following optional keys.
@@ -6609,7 +6746,7 @@ function quux (foo) {
 
 Requires that all function parameters are documented.
 
-<a name="eslint-plugin-jsdoc-rules-require-param-options-13"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-options-14"></a>
 #### Options
 
 An options object accepts one optional property:
@@ -7682,7 +7819,7 @@ Requires returns are documented.
 
 Will also report if multiple `@returns` tags are present.
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-options-14"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-options-15"></a>
 #### Options
 
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
@@ -8147,7 +8284,7 @@ Also impacts behaviors on namepath (or event)-defining and pointing tags:
    allow `#`, `.`, or `~` at the end (which is not allowed at the end of
    normal paths).
 
-<a name="eslint-plugin-jsdoc-rules-valid-types-options-15"></a>
+<a name="eslint-plugin-jsdoc-rules-valid-types-options-16"></a>
 #### Options
 
 - `allowEmptyNamepaths` (default: true) - Set to `false` to disallow

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ JSDoc linting rules for ESLint.
         * [`@override`/`@augments`/`@extends`/`@implements` Without Accompanying `@param`/`@description`/`@example`/`@returns`](#eslint-plugin-jsdoc-settings-override-augments-extends-implements-without-accompanying-param-description-example-returns)
         * [Settings to Configure `check-types` and `no-undefined-types`](#eslint-plugin-jsdoc-settings-settings-to-configure-check-types-and-no-undefined-types)
     * [Rules](#eslint-plugin-jsdoc-rules)
+        * [`check-access`](#eslint-plugin-jsdoc-rules-check-access)
         * [`check-alignment`](#eslint-plugin-jsdoc-rules-check-alignment)
         * [`check-examples`](#eslint-plugin-jsdoc-rules-check-examples)
         * [`check-indentation`](#eslint-plugin-jsdoc-rules-check-indentation)
@@ -362,6 +363,142 @@ only (e.g., to match `Array` if the type is `Array` vs. `Array.<string>`).
 
 <a name="eslint-plugin-jsdoc-rules"></a>
 ## Rules
+
+<a name="eslint-plugin-jsdoc-rules-check-access"></a>
+### <code>check-access</code>
+
+Checks that `@access` tags use one of the following values:
+
+- "package", "private", "protected", "public"
+
+Also reports:
+
+- Mixing of `@access` with `@public`, `@private`, `@protected`, or `@package`
+  on the same doc block.
+- Use of multiple instances of `@access` (or the `@public`, etc. style tags)
+  on the same doc block.
+
+|||
+|---|---|
+|Context|everywhere|
+|Tags|`@access`|
+|Settings||
+|Options||
+
+The following patterns are considered problems:
+
+````js
+/**
+ * @access foo
+ */
+function quux (foo) {
+
+}
+// Message: Missing valid JSDoc @access level.
+
+/**
+ * @accessLevel foo
+ */
+function quux (foo) {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"access":"accessLevel"}}}
+// Message: Missing valid JSDoc @accessLevel level.
+
+/**
+ * @access
+ */
+function quux (foo) {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"access":false}}}
+// Message: Unexpected tag `@access`
+
+class MyClass {
+  /**
+   * @access
+   */
+  myClassField = 1
+}
+// Message: Missing valid JSDoc @access level.
+
+/**
+ * @access public
+ * @public
+ */
+function quux (foo) {
+
+}
+// Message: The @access tag may not be used with specific access-control tags (@package, @private, @protected, or @public).
+
+/**
+ * @access public
+ * @access private
+ */
+function quux (foo) {
+
+}
+// Message: At most one access-control tag may be present on a jsdoc block.
+
+/**
+ * @public
+ * @private
+ */
+function quux (foo) {
+
+}
+// Message: At most one access-control tag may be present on a jsdoc block.
+
+/**
+ * @public
+ * @public
+ */
+function quux (foo) {
+
+}
+// Message: At most one access-control tag may be present on a jsdoc block.
+````
+
+The following patterns are not considered problems:
+
+````js
+/**
+ *
+ */
+function quux (foo) {
+
+}
+
+/**
+ * @access public
+ */
+function quux (foo) {
+
+}
+
+/**
+ * @accessLevel package
+ */
+function quux (foo) {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"access":"accessLevel"}}}
+
+class MyClass {
+  /**
+   * @access private
+   */
+  myClassField = 1
+}
+
+/**
+ * @public
+ */
+function quux (foo) {
+
+}
+````
+
 
 <a name="eslint-plugin-jsdoc-rules-check-alignment"></a>
 ### <code>check-alignment</code>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ JSDoc linting rules for ESLint.
         * [`check-syntax`](#eslint-plugin-jsdoc-rules-check-syntax)
         * [`check-tag-names`](#eslint-plugin-jsdoc-rules-check-tag-names)
         * [`check-types`](#eslint-plugin-jsdoc-rules-check-types)
+        * [`check-values`](#eslint-plugin-jsdoc-rules-check-values)
         * [`empty-tags`](#eslint-plugin-jsdoc-rules-empty-tags)
         * [`implements-on-classes`](#eslint-plugin-jsdoc-rules-implements-on-classes)
         * [`match-description`](#eslint-plugin-jsdoc-rules-match-description)
@@ -3126,6 +3127,177 @@ var subscribe = function(callback) {};
 ````
 
 
+<a name="eslint-plugin-jsdoc-rules-check-values"></a>
+### <code>check-values</code>
+
+This rule checks the values for a handful of tags:
+
+1. `@version` - Checks that there is a present and valid
+    [semver](https://semver.org/) version value.
+2. `@since` - As with `@version`
+3. `@license` - Checks that there is a present and valid SPDX identifier
+    or is present within an `allowedLicenses` option.
+4. `@author` - Checks there is a value present, and if the option
+    `allowedAuthors` is present, ensure that the author value is one
+    of these array items.
+
+<a name="eslint-plugin-jsdoc-rules-check-values-options-5"></a>
+#### Options
+
+<a name="eslint-plugin-jsdoc-rules-check-values-options-5-allowedauthors"></a>
+##### <code>allowedAuthors</code>
+
+An array of allowable author values. If absent, only non-whitespace will
+be checked for.
+
+<a name="eslint-plugin-jsdoc-rules-check-values-options-5-allowedlicenses"></a>
+##### <code>allowedLicenses</code>
+
+An array of allowable license values or `true` to allow any license text.
+If present as an array, will be used in place of SPDX identifiers.
+
+|||
+|---|---|
+|Context|everywhere|
+|Tags|`@version`, `@since`, `@license`, `@author`|
+|Options|`allowedAuthors`, `allowedLicenses`|
+|Settings|`tagNamePreference`|
+
+The following patterns are considered problems:
+
+````js
+/**
+ * @version
+ */
+function quux (foo) {
+
+}
+// Message: Missing JSDoc @version.
+
+/**
+ * @version 3.1
+ */
+function quux (foo) {
+
+}
+// Message: Invalid JSDoc @version: "3.1".
+
+/**
+ * @since
+ */
+function quux (foo) {
+
+}
+// Message: Missing JSDoc @since.
+
+/**
+ * @since 3.1
+ */
+function quux (foo) {
+
+}
+// Message: Invalid JSDoc @since: "3.1".
+
+/**
+ * @license
+ */
+function quux (foo) {
+
+}
+// Message: Missing JSDoc @license.
+
+/**
+ * @license FOO
+ */
+function quux (foo) {
+
+}
+// Message: Invalid JSDoc @license: "FOO"; expected SPDX identifier: https://spdx.org/licenses/.
+
+/**
+ * @license FOO
+ */
+function quux (foo) {
+
+}
+// Options: [{"allowedLicenses":["BAR","BAX"]}]
+// Message: Invalid JSDoc @license: "FOO"; expected one of BAR, BAX.
+
+/**
+ * @author
+ */
+function quux (foo) {
+
+}
+// Message: Missing JSDoc @author.
+
+/**
+ * @author Brett Zamir
+ */
+function quux (foo) {
+
+}
+// Options: [{"allowedAuthors":["Gajus Kuizinas","golopot"]}]
+// Message: Invalid JSDoc @author: "Brett Zamir"; expected one of Gajus Kuizinas, golopot.
+````
+
+The following patterns are not considered problems:
+
+````js
+/**
+ * @version 3.4.1
+ */
+function quux (foo) {
+
+}
+
+/**
+ * @since 3.4.1
+ */
+function quux (foo) {
+
+}
+
+/**
+ * @license MIT
+ */
+function quux (foo) {
+
+}
+
+/**
+ * @license FOO
+ */
+function quux (foo) {
+
+}
+// Options: [{"allowedLicenses":["FOO","BAR","BAX"]}]
+
+/**
+ * @license FOO
+ */
+function quux (foo) {
+
+}
+// Options: [{"allowedLicenses":true}]
+
+/**
+ * @author Gajus Kuizinas
+ */
+function quux (foo) {
+
+}
+
+/**
+ * @author Brett Zamir
+ */
+function quux (foo) {
+
+}
+// Options: [{"allowedAuthors":["Gajus Kuizinas","golopot","Brett Zamir"]}]
+````
+
+
 <a name="eslint-plugin-jsdoc-rules-empty-tags"></a>
 ### <code>empty-tags</code>
 
@@ -3152,10 +3324,10 @@ is set to "closure" (which allows types).
 - `@public`
 - `@static`
 
-<a name="eslint-plugin-jsdoc-rules-empty-tags-options-5"></a>
+<a name="eslint-plugin-jsdoc-rules-empty-tags-options-6"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-empty-tags-options-5-tags"></a>
+<a name="eslint-plugin-jsdoc-rules-empty-tags-options-6-tags"></a>
 ##### <code>tags</code>
 
 If you want additional tags to be checked for their descriptions, you may
@@ -3370,10 +3542,10 @@ by our supported Node versions):
 Applies to the jsdoc block description and `@description` (or `@desc`)
 by default but the `tags` option (see below) may be used to match other tags.
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-6"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-7"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-6-matchdescription"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-7-matchdescription"></a>
 ##### <code>matchDescription</code>
 
 You can supply your own expression to override the default, passing a
@@ -3388,7 +3560,7 @@ You can supply your own expression to override the default, passing a
 As with the default, the supplied regular expression will be applied with the
 Unicode (`"u"`) flag and is *not* case-insensitive.
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-6-tags-1"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-7-tags-1"></a>
 ##### <code>tags</code>
 
 If you want different regular expressions to apply to tags, you may use
@@ -3425,7 +3597,7 @@ its "description" (e.g., for `@returns {someType} some description`, the
 description is `some description` while for `@some-tag xyz`, the description
 is `xyz`).
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-6-maindescription"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-7-maindescription"></a>
 ##### <code>mainDescription</code>
 
 If you wish to override the main function description without changing the
@@ -3447,7 +3619,7 @@ There is no need to add `mainDescription: true`, as by default, the main
 function (and only the main function) is linted, though you may disable checking
 it by setting it to `false`.
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-6-contexts"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-7-contexts"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
@@ -4067,7 +4239,7 @@ function quux () {
 
 Enforces a consistent padding of the block description.
 
-<a name="eslint-plugin-jsdoc-rules-newline-after-description-options-7"></a>
+<a name="eslint-plugin-jsdoc-rules-newline-after-description-options-8"></a>
 #### Options
 
 This rule allows one optional string argument. If it is `"always"` then a problem is raised when there is no newline after the description. If it is `"never"` then a problem is raised when there is a newline after the description. The default value is `"always"`.
@@ -4251,7 +4423,7 @@ The following types are always considered defined.
 Note that preferred types indicated within `settings.jsdoc.preferredTypes` will
 also be assumed to be defined.
 
-<a name="eslint-plugin-jsdoc-rules-no-undefined-types-options-8"></a>
+<a name="eslint-plugin-jsdoc-rules-no-undefined-types-options-9"></a>
 #### Options
 
 An option object may have the following key:
@@ -4633,10 +4805,10 @@ tag descriptions are written in complete sentences, i.e.,
 * A colon or semi-colon followed by two line breaks is still part of the
   containing paragraph (unlike normal dual line breaks).
 
-<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-9"></a>
+<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-10"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-9-tags-2"></a>
+<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-10-tags-2"></a>
 ##### <code>tags</code>
 
 If you want additional tags to be checked for their descriptions, you may
@@ -5108,7 +5280,7 @@ Requires that all functions have a description.
   `"tag"`) must have a non-empty description that explains the purpose of the
   method.
 
-<a name="eslint-plugin-jsdoc-rules-require-description-options-10"></a>
+<a name="eslint-plugin-jsdoc-rules-require-description-options-11"></a>
 #### Options
 
 An options object may have any of the following properties:
@@ -5393,25 +5565,25 @@ Requires that all functions have examples.
 * All functions must have one or more `@example` tags.
 * Every example tag must have a non-empty description that explains the method's usage.
 
-<a name="eslint-plugin-jsdoc-rules-require-example-options-11"></a>
+<a name="eslint-plugin-jsdoc-rules-require-example-options-12"></a>
 #### Options
 
 This rule has an object option.
 
-<a name="eslint-plugin-jsdoc-rules-require-example-options-11-exemptedby"></a>
+<a name="eslint-plugin-jsdoc-rules-require-example-options-12-exemptedby"></a>
 ##### <code>exemptedBy</code>
 
 Array of tags (e.g., `['type']`) whose presence on the document
 block avoids the need for an `@example`. Defaults to an empty array.
 
-<a name="eslint-plugin-jsdoc-rules-require-example-options-11-avoidexampleonconstructors"></a>
+<a name="eslint-plugin-jsdoc-rules-require-example-options-12-avoidexampleonconstructors"></a>
 ##### <code>avoidExampleOnConstructors</code>
 
 Set to `true` to avoid the need for an example on a constructor (whether
 indicated as such by a jsdoc tag or by being within an ES6 `class`).
 Defaults to `false`.
 
-<a name="eslint-plugin-jsdoc-rules-require-example-options-11-contexts-1"></a>
+<a name="eslint-plugin-jsdoc-rules-require-example-options-12-contexts-1"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
@@ -5589,7 +5761,7 @@ function quux () {
 
 Requires a hyphen before the `@param` description.
 
-<a name="eslint-plugin-jsdoc-rules-require-hyphen-before-param-description-options-12"></a>
+<a name="eslint-plugin-jsdoc-rules-require-hyphen-before-param-description-options-13"></a>
 #### Options
 
 This rule takes one optional string argument. If it is `"always"` then a problem is raised when there is no hyphen before the description. If it is `"never"` then a problem is raised when there is a hyphen before the description. The default value is `"always"`.
@@ -5695,7 +5867,7 @@ function quux () {
 Checks for presence of jsdoc comments, on class declarations as well as
 functions.
 
-<a name="eslint-plugin-jsdoc-rules-require-jsdoc-options-13"></a>
+<a name="eslint-plugin-jsdoc-rules-require-jsdoc-options-14"></a>
 #### Options
 
 Accepts one optional options object with the following optional keys.
@@ -6883,7 +7055,7 @@ function quux (foo) {
 
 Requires that all function parameters are documented.
 
-<a name="eslint-plugin-jsdoc-rules-require-param-options-14"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-options-15"></a>
 #### Options
 
 An options object accepts one optional property:
@@ -7956,7 +8128,7 @@ Requires returns are documented.
 
 Will also report if multiple `@returns` tags are present.
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-options-15"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-options-16"></a>
 #### Options
 
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
@@ -8421,7 +8593,7 @@ Also impacts behaviors on namepath (or event)-defining and pointing tags:
    allow `#`, `.`, or `~` at the end (which is not allowed at the end of
    normal paths).
 
-<a name="eslint-plugin-jsdoc-rules-valid-types-options-16"></a>
+<a name="eslint-plugin-jsdoc-rules-valid-types-options-17"></a>
 #### Options
 
 - `allowEmptyNamepaths` (default: true) - Set to `false` to disallow

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "jsdoctypeparser": "^6.0.0",
     "lodash": "^4.17.15",
     "object.entries-ponyfill": "^1.0.1",
-    "regextras": "^0.6.1"
+    "regextras": "^0.6.1",
+    "semver": "^6.3.0",
+    "spdx-license-list": "^6.1.0"
   },
   "description": "JSDoc linting rules for ESLint.",
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import checkParamNames from './rules/checkParamNames';
 import checkSyntax from './rules/checkSyntax';
 import checkTagNames from './rules/checkTagNames';
 import checkTypes from './rules/checkTypes';
+import emptyTags from './rules/emptyTags';
 import implementsOnClasses from './rules/implementsOnClasses';
 import matchDescription from './rules/matchDescription';
 import newlineAfterDescription from './rules/newlineAfterDescription';
@@ -38,6 +39,7 @@ export default {
         'jsdoc/check-syntax': 'off',
         'jsdoc/check-tag-names': 'warn',
         'jsdoc/check-types': 'warn',
+        'jsdoc/empty-tags': 'warn',
         'jsdoc/implements-on-classes': 'warn',
         'jsdoc/match-description': 'off',
         'jsdoc/newline-after-description': 'warn',
@@ -68,6 +70,7 @@ export default {
     'check-syntax': checkSyntax,
     'check-tag-names': checkTagNames,
     'check-types': checkTypes,
+    'empty-tags': emptyTags,
     'implements-on-classes': implementsOnClasses,
     'match-description': matchDescription,
     'newline-after-description': newlineAfterDescription,

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 /* eslint-disable import/max-dependencies */
+import checkAccess from './rules/checkAccess';
 import checkAlignment from './rules/checkAlignment';
 import checkExamples from './rules/checkExamples';
 import checkIndentation from './rules/checkIndentation';
@@ -32,6 +33,7 @@ export default {
     recommended: {
       plugins: ['jsdoc'],
       rules: {
+        'jsdoc/check-access': 'warn',
         'jsdoc/check-alignment': 'warn',
         'jsdoc/check-examples': 'off',
         'jsdoc/check-indentation': 'off',
@@ -63,6 +65,7 @@ export default {
     },
   },
   rules: {
+    'check-access': checkAccess,
     'check-alignment': checkAlignment,
     'check-examples': checkExamples,
     'check-indentation': checkIndentation,

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import checkParamNames from './rules/checkParamNames';
 import checkSyntax from './rules/checkSyntax';
 import checkTagNames from './rules/checkTagNames';
 import checkTypes from './rules/checkTypes';
+import checkValues from './rules/checkValues';
 import emptyTags from './rules/emptyTags';
 import implementsOnClasses from './rules/implementsOnClasses';
 import matchDescription from './rules/matchDescription';
@@ -41,6 +42,7 @@ export default {
         'jsdoc/check-syntax': 'off',
         'jsdoc/check-tag-names': 'warn',
         'jsdoc/check-types': 'warn',
+        'jsdoc/check-values': 'warn',
         'jsdoc/empty-tags': 'warn',
         'jsdoc/implements-on-classes': 'warn',
         'jsdoc/match-description': 'off',
@@ -73,6 +75,7 @@ export default {
     'check-syntax': checkSyntax,
     'check-tag-names': checkTagNames,
     'check-types': checkTypes,
+    'check-values': checkValues,
     'empty-tags': emptyTags,
     'implements-on-classes': implementsOnClasses,
     'match-description': matchDescription,

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -255,6 +255,12 @@ const getUtils = (
     return jsdocUtils.getTagsByType(context, mode, tags, tagNamePreference);
   };
 
+  utils.hasOptionTag = (tagName) => {
+    const tags = _.get(context, 'options[0].tags');
+
+    return Boolean(tags && tags.includes(tagName));
+  };
+
   utils.getClassNode = () => {
     // Ancestors missing in `Program` comment iteration
     const greatGrandParent = ancestors.length ?

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -30,7 +30,10 @@ const parseComment = (commentNode, indent, trim = true) => {
       skipSeeLink(commentParser.PARSERS.parse_type),
       skipSeeLink(
         (str, data) => {
-          if (['example', 'return', 'returns', 'throws', 'exception', 'access'].includes(data.tag)) {
+          if ([
+            'example', 'return', 'returns', 'throws', 'exception',
+            'access', 'version', 'since', 'license', 'author',
+          ].includes(data.tag)) {
             return null;
           }
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -30,7 +30,7 @@ const parseComment = (commentNode, indent, trim = true) => {
       skipSeeLink(commentParser.PARSERS.parse_type),
       skipSeeLink(
         (str, data) => {
-          if (['example', 'return', 'returns', 'throws', 'exception'].includes(data.tag)) {
+          if (['example', 'return', 'returns', 'throws', 'exception', 'access'].includes(data.tag)) {
             return null;
           }
 

--- a/src/rules/checkAccess.js
+++ b/src/rules/checkAccess.js
@@ -1,0 +1,39 @@
+import iterateJsdoc from '../iterateJsdoc';
+
+const accessLevels = ['package', 'private', 'protected', 'public'];
+
+export default iterateJsdoc(({
+  report,
+  utils,
+}) => {
+  utils.forEachPreferredTag('access', (jsdocParameter, targetTagName) => {
+    const desc = targetTagName === 'access' ?
+      jsdocParameter.description :
+      jsdocParameter.name + ' ' + jsdocParameter.description;
+
+    if (!accessLevels.includes(desc.trim())) {
+      report(
+        `Missing valid JSDoc @${targetTagName} level.`,
+        null,
+        jsdocParameter,
+      );
+    }
+  });
+  const accessLength = utils.getTags('access').length;
+  const individualTagLength = utils.getPresentTags(accessLevels).length;
+  if (accessLength && individualTagLength) {
+    report(
+      'The @access tag may not be used with specific access-control tags (@package, @private, @protected, or @public).',
+    );
+  }
+  if (accessLength > 1 || individualTagLength > 1) {
+    report(
+      'At most one access-control tag may be present on a jsdoc block.',
+    );
+  }
+}, {
+  iterateAllJsdocs: true,
+  meta: {
+    type: 'suggestion',
+  },
+});

--- a/src/rules/checkValues.js
+++ b/src/rules/checkValues.js
@@ -1,0 +1,123 @@
+import semver from 'semver';
+import spdxLicenseList from 'spdx-license-list/simple';
+import iterateJsdoc from '../iterateJsdoc';
+
+export default iterateJsdoc(({
+  utils,
+  report,
+  context,
+}) => {
+  const options = context.options[0] || {};
+  const {
+    allowedLicenses = null,
+    allowedAuthors = null,
+  } = options;
+
+  utils.forEachPreferredTag('version', (jsdocParameter, targetTagName) => {
+    const version = jsdocParameter.description;
+    if (!version.trim()) {
+      report(
+        `Missing JSDoc @${targetTagName}.`,
+        null,
+        jsdocParameter,
+      );
+    } else if (!semver.valid(version)) {
+      report(
+        `Invalid JSDoc @${targetTagName}: "${jsdocParameter.description}".`,
+        null,
+        jsdocParameter,
+      );
+    }
+  });
+  utils.forEachPreferredTag('since', (jsdocParameter, targetTagName) => {
+    const version = jsdocParameter.description;
+    if (!version.trim()) {
+      report(
+        `Missing JSDoc @${targetTagName}.`,
+        null,
+        jsdocParameter,
+      );
+    } else if (!semver.valid(version)) {
+      report(
+        `Invalid JSDoc @${targetTagName}: "${jsdocParameter.description}".`,
+        null,
+        jsdocParameter,
+      );
+    }
+  });
+  utils.forEachPreferredTag('license', (jsdocParameter, targetTagName) => {
+    const license = jsdocParameter.description;
+    if (!license.trim()) {
+      report(
+        `Missing JSDoc @${targetTagName}.`,
+        null,
+        jsdocParameter,
+      );
+    } else if (allowedLicenses) {
+      if (allowedLicenses !== true && !allowedLicenses.includes(license)) {
+        report(
+          `Invalid JSDoc @${targetTagName}: "${jsdocParameter.description}"; expected one of ${allowedLicenses.join(', ')}.`,
+          null,
+          jsdocParameter,
+        );
+      }
+    } else if (!spdxLicenseList.has(license)) {
+      report(
+        `Invalid JSDoc @${targetTagName}: "${jsdocParameter.description}"; expected SPDX identifier: https://spdx.org/licenses/.`,
+        null,
+        jsdocParameter,
+      );
+    }
+  });
+
+  utils.forEachPreferredTag('author', (jsdocParameter, targetTagName) => {
+    const author = jsdocParameter.description;
+    if (!author.trim()) {
+      report(
+        `Missing JSDoc @${targetTagName}.`,
+        null,
+        jsdocParameter,
+      );
+    } else if (allowedAuthors) {
+      if (!allowedAuthors.includes(author)) {
+        report(
+          `Invalid JSDoc @${targetTagName}: "${jsdocParameter.description}"; expected one of ${allowedAuthors.join(', ')}.`,
+          null,
+          jsdocParameter,
+        );
+      }
+    }
+  });
+}, {
+  iterateAllJsdocs: true,
+  meta: {
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          allowedAuthors: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+          allowedLicenses: {
+            anyOf: [
+              {
+                items: {
+                  type: 'string',
+                },
+                type: 'array',
+              },
+              {
+                type: 'boolean',
+              },
+            ],
+          },
+        },
+        type: 'object',
+      },
+    ],
+    type: 'suggestion',
+  },
+});

--- a/src/rules/emptyTags.js
+++ b/src/rules/emptyTags.js
@@ -1,0 +1,60 @@
+import iterateJsdoc from '../iterateJsdoc';
+
+const defaultEmptyTags = [
+  'abstract', 'async', 'generator', 'global', 'hideconstructor',
+  'ignore', 'inheritdoc', 'inner', 'instance', 'override', 'readonly',
+];
+
+const emptyIfNotClosure = [
+  'package', 'private', 'protected', 'public', 'static',
+];
+
+export default iterateJsdoc(({
+  settings,
+  jsdoc,
+  utils,
+}) => {
+  if (!jsdoc.tags) {
+    return;
+  }
+  const emptyTags = utils.filterTags(({tag: tagName}) => {
+    return defaultEmptyTags.includes(tagName) ||
+      utils.hasOptionTag(tagName) && jsdoc.tags.some(({tag}) => {
+        return tag === tagName;
+      }) ||
+      settings.mode !== 'closure' && emptyIfNotClosure.includes(tagName);
+  });
+  emptyTags.forEach((tag) => {
+    const fix = () => {
+      tag.name = '';
+      tag.description = '';
+      tag.type = '';
+      tag.optional = false;
+      tag.default = undefined;
+    };
+    const content = tag.name || tag.description || tag.type;
+    if (content) {
+      utils.reportJSDoc(`@${tag.tag} should be empty.`, tag, fix);
+    }
+  });
+}, {
+  iterateAllJsdocs: true,
+  meta: {
+    fixable: 'code',
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          tags: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
+    type: 'suggestion',
+  },
+});

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -2,6 +2,14 @@ import _ from 'lodash';
 import {RegExtras} from 'regextras/dist/main-umd';
 import iterateJsdoc from '../iterateJsdoc';
 
+const otherDescriptiveTags = [
+  // 'copyright' and 'see' might be good addition, but as the former may be
+  //   sensitive text, and the latter may have just a link, they are not
+  //   included by default
+  'summary', 'file', 'fileoverview', 'overview', 'classdesc', 'todo',
+  'deprecated', 'throws', 'exception', 'yields', 'yield',
+];
+
 const extractParagraphs = (text) => {
   // Todo [engine:node@>8.11.0]: Uncomment following line with neg. lookbehind instead
   // return text.split(/(?<![;:])\n\n/u);
@@ -132,7 +140,6 @@ export default iterateJsdoc(({
   jsdoc,
   report,
   jsdocNode,
-  context,
   utils,
 }) => {
   if (!jsdoc.tags ||
@@ -148,22 +155,10 @@ export default iterateJsdoc(({
     validateDescription(description, report, jsdocNode, sourceCode, matchingJsdocTag);
   }, true);
 
-  const options = context.options[0] || {};
-
-  const hasOptionTag = (tagName) => {
-    return Boolean(options.tags && options.tags.includes(tagName));
-  };
-
   const {tagsWithNames} = utils.getTagsByType(jsdoc.tags);
   const tagsWithoutNames = utils.filterTags(({tag: tagName}) => {
-    return [
-      // 'copyright' and 'see' might be good addition, but as the former may be
-      //   sensitive text, and the latter may have just a link, they are not
-      //   included by default
-      'summary', 'file', 'fileoverview', 'overview', 'classdesc', 'todo',
-      'deprecated', 'throws', 'exception', 'yields', 'yield',
-    ].includes(tagName) ||
-      hasOptionTag(tagName) && !tagsWithNames.some(({tag}) => {
+    return otherDescriptiveTags.includes(tagName) ||
+      utils.hasOptionTag(tagName) && !tagsWithNames.some(({tag}) => {
         // If user accidentally adds tags with names (or like `returns`
         //  get parsed as having names), do not add to this list
         return tag === tagName;

--- a/test/rules/assertions/checkAccess.js
+++ b/test/rules/assertions/checkAccess.js
@@ -1,0 +1,206 @@
+export default {
+  invalid: [
+    {
+      code: `
+          /**
+           * @access foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing valid JSDoc @access level.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @accessLevel foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing valid JSDoc @accessLevel level.',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            access: 'accessLevel',
+          },
+        },
+      },
+    },
+    {
+      code: `
+          /**
+           * @access
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Unexpected tag `@access`',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            access: false,
+          },
+        },
+      },
+    },
+    {
+      code: `
+      class MyClass {
+        /**
+         * @access
+         */
+        myClassField = 1
+      }
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Missing valid JSDoc @access level.',
+        },
+      ],
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+          /**
+           * @access public
+           * @public
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'The @access tag may not be used with specific access-control tags (@package, @private, @protected, or @public).',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @access public
+           * @access private
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'At most one access-control tag may be present on a jsdoc block.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @public
+           * @private
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'At most one access-control tag may be present on a jsdoc block.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @public
+           * @public
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'At most one access-control tag may be present on a jsdoc block.',
+        },
+      ],
+    },
+  ],
+  valid: [
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @access public
+           */
+          function quux (foo) {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @accessLevel package
+           */
+          function quux (foo) {
+
+          }
+      `,
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            access: 'accessLevel',
+          },
+        },
+      },
+    },
+    {
+      code: `
+      class MyClass {
+        /**
+         * @access private
+         */
+        myClassField = 1
+      }
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+          /**
+           * @public
+           */
+          function quux (foo) {
+
+          }
+      `,
+    },
+  ],
+};

--- a/test/rules/assertions/checkValues.js
+++ b/test/rules/assertions/checkValues.js
@@ -1,0 +1,245 @@
+export default {
+  invalid: [
+    {
+      code: `
+      /**
+       * @version
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing JSDoc @version.',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @version 3.1
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @version: "3.1".',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @since
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing JSDoc @since.',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @since 3.1
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @since: "3.1".',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @license
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing JSDoc @license.',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @license FOO
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @license: "FOO"; expected SPDX identifier: https://spdx.org/licenses/.',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @license FOO
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @license: "FOO"; expected one of BAR, BAX.',
+        },
+      ],
+      options: [
+        {
+          allowedLicenses: ['BAR', 'BAX'],
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @author
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing JSDoc @author.',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @author Brett Zamir
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @author: "Brett Zamir"; expected one of Gajus Kuizinas, golopot.',
+        },
+      ],
+      options: [
+        {
+          allowedAuthors: ['Gajus Kuizinas', 'golopot'],
+        },
+      ],
+    },
+  ],
+  valid: [
+    {
+      code: `
+      /**
+       * @version 3.4.1
+       */
+      function quux (foo) {
+
+      }
+      `,
+    },
+    {
+      code: `
+      /**
+       * @since 3.4.1
+       */
+      function quux (foo) {
+
+      }
+      `,
+    },
+    {
+      code: `
+      /**
+       * @license MIT
+       */
+      function quux (foo) {
+
+      }
+      `,
+    },
+    {
+      code: `
+      /**
+       * @license FOO
+       */
+      function quux (foo) {
+
+      }
+      `,
+      options: [
+        {
+          allowedLicenses: ['FOO', 'BAR', 'BAX'],
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @license FOO
+       */
+      function quux (foo) {
+
+      }
+      `,
+      options: [
+        {
+          allowedLicenses: true,
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @author Gajus Kuizinas
+       */
+      function quux (foo) {
+
+      }
+      `,
+    },
+    {
+      code: `
+      /**
+       * @author Brett Zamir
+       */
+      function quux (foo) {
+
+      }
+      `,
+      options: [
+        {
+          allowedAuthors: ['Gajus Kuizinas', 'golopot', 'Brett Zamir'],
+        },
+      ],
+    },
+  ],
+};

--- a/test/rules/assertions/emptyTags.js
+++ b/test/rules/assertions/emptyTags.js
@@ -1,0 +1,174 @@
+export default {
+  invalid: [
+    {
+      code: `
+          /**
+           * @abstract extra text
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@abstract should be empty.',
+        },
+      ],
+      output: `
+          /**
+           * @abstract
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @abstract extra text
+           * @inheritdoc
+           * @async out of place
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@abstract should be empty.',
+        },
+        {
+          line: 5,
+          message: '@async should be empty.',
+        },
+      ],
+      output: `
+          /**
+           * @abstract
+           * @inheritdoc
+           * @async out of place
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @event anEvent
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@event should be empty.',
+        },
+      ],
+      options: [
+        {
+          tags: ['event'],
+        },
+      ],
+      output: `
+          /**
+           * @event
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+      /**
+       * @private {someType}
+       */
+      function quux () {
+
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@private should be empty.',
+        },
+      ],
+    },
+  ],
+  valid: [
+    {
+      code: `
+          /**
+           * @abstract
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @param aName
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @abstract
+           * @inheritdoc
+           * @async
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+      /**
+       * @private {someType}
+       */
+      function quux () {
+
+      }
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'closure',
+        },
+      },
+    },
+    {
+      code: `
+      /**
+       * @private
+       */
+      function quux () {
+
+      }
+      `,
+    },
+  ],
+};

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -8,6 +8,7 @@ const ruleTester = new RuleTester();
 
 // eslint-disable-next-line no-process-env
 (process.env.npm_config_rule ? process.env.npm_config_rule.split(',') : [
+  'check-access',
   'check-alignment',
   'check-examples',
   'check-indentation',

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -15,6 +15,7 @@ const ruleTester = new RuleTester();
   'check-syntax',
   'check-tag-names',
   'check-types',
+  'empty-tags',
   'implements-on-classes',
   'match-description',
   'newline-after-description',

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -16,6 +16,7 @@ const ruleTester = new RuleTester();
   'check-syntax',
   'check-tag-names',
   'check-types',
+  'check-values',
   'empty-tags',
   'implements-on-classes',
   'match-description',


### PR DESCRIPTION
feat(check-values): Add new rule for checking special tag values (within `version`, `since`, `license`, `author`)

BREAKING CHANGE:

Adds to `recommended`.

1. `@version` - Checks that there is a present and valid
    [semver](https://semver.org/) version value.
2. `@since` - As with `@version`
3. `@license` - Checks that there is a present and valid SPDX identifier
    or is present within an `allowedLicenses` option.
4. `@author` - Checks there is a value present, and if the option
    `allowedAuthors` is present, ensure that the author value is one
    of these array items.