### PR TITLE
`check-values`: add `licensePattern` option

### DIFF
--- a/.README/rules/check-values.md
+++ b/.README/rules/check-values.md
@@ -23,11 +23,19 @@ be checked for.
 An array of allowable license values or `true` to allow any license text.
 If present as an array, will be used in place of SPDX identifiers.
 
+##### `licensePattern`
+
+A string to be converted into a `RegExp` (with `u` flag) and whose first
+parenthetical grouping, if present, will match the portion of the license
+description to check (if no grouping is present, then the whole portion
+matched will be used). Defaults to `([^\n]*)`, i.e., the SPDX expression
+is expected before any line breaks.
+
 |||
 |---|---|
 |Context|everywhere|
 |Tags|`@version`, `@since`, `@license`, `@author`|
-|Options|`allowedAuthors`, `allowedLicenses`|
+|Options|`allowedAuthors`, `allowedLicenses`, `licensePattern`|
 |Settings|`tagNamePreference`|
 
 <!-- assertions checkValues -->

--- a/README.md
+++ b/README.md
@@ -3156,11 +3156,20 @@ be checked for.
 An array of allowable license values or `true` to allow any license text.
 If present as an array, will be used in place of SPDX identifiers.
 
+<a name="eslint-plugin-jsdoc-rules-check-values-options-5-licensepattern"></a>
+##### <code>licensePattern</code>
+
+A string to be converted into a `RegExp` (with `u` flag) and whose first
+parenthetical grouping, if present, will match the portion of the license
+description to check (if no grouping is present, then the whole portion
+matched will be used). Defaults to `([^\n]*)`, i.e., the SPDX expression
+is expected before any line breaks.
+
 |||
 |---|---|
 |Context|everywhere|
 |Tags|`@version`, `@since`, `@license`, `@author`|
-|Options|`allowedAuthors`, `allowedLicenses`|
+|Options|`allowedAuthors`, `allowedLicenses`, `licensePattern`|
 |Settings|`tagNamePreference`|
 
 The following patterns are considered problems:
@@ -3224,6 +3233,15 @@ function quux (foo) {
 // Message: Invalid JSDoc @license: "FOO"; expected one of BAR, BAX.
 
 /**
+ * @license MIT-7
+ * Some extra text...
+ */
+function quux (foo) {
+
+}
+// Message: Invalid JSDoc @license: "MIT-7"; expected SPDX expression: https://spdx.org/licenses/.
+
+/**
  * @license (MIT OR GPL-2.5)
  */
 function quux (foo) {
@@ -3268,6 +3286,14 @@ function quux (foo) {
 
 /**
  * @license MIT
+ */
+function quux (foo) {
+
+}
+
+/**
+ * @license MIT
+ * Some extra text...
  */
 function quux (foo) {
 

--- a/README.md
+++ b/README.md
@@ -3250,6 +3250,17 @@ function quux (foo) {
 // Message: Invalid JSDoc @license: "(MIT OR GPL-2.5)"; expected SPDX expression: https://spdx.org/licenses/.
 
 /**
+ * @license MIT
+ * Some extra text
+ */
+function quux (foo) {
+
+}
+// Options: [{"licensePattern":"[\\s\\S]*"}]
+// Message: Invalid JSDoc @license: "MIT
+Some extra text"; expected SPDX expression: https://spdx.org/licenses/.
+
+/**
  * @author
  */
 function quux (foo) {
@@ -3321,6 +3332,15 @@ function quux (foo) {
 
 }
 // Options: [{"allowedLicenses":true}]
+
+/**
+ * @license MIT
+ * Some extra text
+ */
+function quux (foo) {
+
+}
+// Options: [{"licensePattern":"[^\n]*"}]
 
 /**
  * @author Gajus Kuizinas

--- a/src/rules/checkValues.js
+++ b/src/rules/checkValues.js
@@ -11,6 +11,7 @@ export default iterateJsdoc(({
   const {
     allowedLicenses = null,
     allowedAuthors = null,
+    licensePattern = '([^\n]*)',
   } = options;
 
   utils.forEachPreferredTag('version', (jsdocParameter, targetTagName) => {
@@ -46,7 +47,9 @@ export default iterateJsdoc(({
     }
   });
   utils.forEachPreferredTag('license', (jsdocParameter, targetTagName) => {
-    const license = jsdocParameter.description;
+    const licenseRegex = new RegExp(licensePattern, 'g');
+    const match = jsdocParameter.description.match(licenseRegex);
+    const license = match && match[1] || match[0];
     if (!license.trim()) {
       report(
         `Missing JSDoc @${targetTagName}.`,

--- a/test/rules/assertions/checkValues.js
+++ b/test/rules/assertions/checkValues.js
@@ -151,6 +151,27 @@ export default {
     {
       code: `
       /**
+       * @license MIT
+       * Some extra text
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @license: "MIT\nSome extra text"; expected SPDX expression: https://spdx.org/licenses/.',
+        },
+      ],
+      options: [
+        {
+          licensePattern: '[\\s\\S]*',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
        * @author
        */
       function quux (foo) {
@@ -265,6 +286,22 @@ export default {
       options: [
         {
           allowedLicenses: true,
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @license MIT
+       * Some extra text
+       */
+      function quux (foo) {
+
+      }
+      `,
+      options: [
+        {
+          licensePattern: '[^\n]*',
         },
       ],
     },

--- a/test/rules/assertions/checkValues.js
+++ b/test/rules/assertions/checkValues.js
@@ -120,6 +120,22 @@ export default {
     {
       code: `
       /**
+       * @license MIT-7
+       * Some extra text...
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          message: 'Invalid JSDoc @license: "MIT-7"; expected SPDX expression: https://spdx.org/licenses/.',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
        * @license (MIT OR GPL-2.5)
        */
       function quux (foo) {
@@ -195,6 +211,17 @@ export default {
       code: `
       /**
        * @license MIT
+       */
+      function quux (foo) {
+
+      }
+      `,
+    },
+    {
+      code: `
+      /**
+       * @license MIT
+       * Some extra text...
        */
       function quux (foo) {
 


### PR DESCRIPTION
feat(`check-values`): add `licensePattern` option to allow delimiting portion of license description to extract

Thereby can allow extra descriptive text before or after a license pattern.