### PR TITLE
feat(`require-description-complete-sentence`): tighten constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -5376,6 +5376,22 @@ function quux (foo) {
  * |   1  | do it       |
  * |   2  | do it again |
  */
+
+/**
+ * This is something that
+ * I want to test.
+ */
+function quux () {
+
+}
+
+/**
+ * When making HTTP requests, the
+ * URL is super important.
+ */
+function quux () {
+
+}
 ````
 
 

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -45,7 +45,7 @@ const isNewLinePrecededByAPeriod = (text) => {
   const lines = text.split('\n');
 
   return !lines.some((line) => {
-    if (typeof lastLineEndsSentence === 'boolean' && !lastLineEndsSentence && /^[A-Z]/u.test(line)) {
+    if (typeof lastLineEndsSentence === 'boolean' && !lastLineEndsSentence && /^[A-Z][a-z]/u.test(line)) {
       return true;
     }
 

--- a/test/rules/assertions/requireDescriptionCompleteSentence.js
+++ b/test/rules/assertions/requireDescriptionCompleteSentence.js
@@ -909,5 +909,27 @@ export default {
        */
       `,
     },
+    {
+      code: `
+          /**
+           * This is something that
+           * I want to test.
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * When making HTTP requests, the
+           * URL is super important.
+           */
+          function quux () {
+
+          }
+      `,
+    },
   ],
 };


### PR DESCRIPTION
Currently it is possible to experience a false positive with the
`jsdoc/require-description-complete-sentence` rule.

The false positive is caused by starting a new line with a capital
letter when the previous line does not end with a period. Normally, this
is the correct behaviour, however, English sentences are more nuanced
than that.

The problem arises when using a word that starts with a capital letter
that just so happens to be at the start of a line. For instance, `I`, or
a programmatic word like `XMLHttpRequest`.

This PR tightens the constraint of the `isNewLinePrecededByAPeriod`
Function by checking for a lowercase letter immediately after an
uppercase letter.

This will still produce false positives if the new line starts with
`UserInterface` for example.