### PR TITLE
feat(`check-examples`): add `no-multiple-empty-lines` by default

### DIFF
--- a/.README/rules/check-examples.md
+++ b/.README/rules/check-examples.md
@@ -107,6 +107,10 @@ decreasing precedence:
   to be desired in sample code as with the code file convention.
 * `no-console` - This rule is unlikely to have inadvertent temporary debugging
   within examples.
+* `no-multiple-empty-lines` - This rule may be problematic for projects which
+  use an initial newline just to start an example. Also, projects may wish to
+  use extra lines within examples just for easier illustration
+  purposes.
 * `no-undef` - Many variables in examples will be `undefined`.
 * `no-unused-vars` - It is common to define variables for clarity without always
   using them within examples.

--- a/README.md
+++ b/README.md
@@ -751,6 +751,10 @@ decreasing precedence:
   to be desired in sample code as with the code file convention.
 * `no-console` - This rule is unlikely to have inadvertent temporary debugging
   within examples.
+* `no-multiple-empty-lines` - This rule may be problematic for projects which
+  use an initial newline just to start an example. Also, projects may wish to
+  use extra lines within examples just for easier illustration
+  purposes.
 * `no-undef` - Many variables in examples will be `undefined`.
 * `no-unused-vars` - It is common to define variables for clarity without always
   using them within examples.
@@ -922,7 +926,7 @@ function quux2 () {
 function quux2 () {
 
 }
-// Message: @example error (no-multiple-empty-lines): Too many blank lines at the beginning of file. Max of 0 allowed.
+// Message: @example warning (id-length): Identifier name 'i' is too short (< 2).
 
 /**
  * @example const i = 5;

--- a/src/rules/checkExamples.js
+++ b/src/rules/checkExamples.js
@@ -69,6 +69,10 @@ export default iterateJsdoc(({
     // Unlikely to have inadvertent debugging within examples
     'no-console': 0,
 
+    // Often wish to start `@example` code after newline; also may use
+    //   empty lines for spacing
+    'no-multiple-empty-lines': 0,
+
     // Many variables in examples will be `undefined`
     'no-undef': 0,
 

--- a/test/rules/assertions/checkExamples.js
+++ b/test/rules/assertions/checkExamples.js
@@ -377,10 +377,6 @@ export default {
       `,
       errors: [
         {
-          line: 3,
-          message: '@example error (no-multiple-empty-lines): Too many blank lines at the beginning of file. Max of 0 allowed.',
-        },
-        {
           line: 4,
           message: '@example warning (id-length): Identifier name \'i\' is too short (< 2).',
         },


### PR DESCRIPTION
With initial newlines now being considered as part of the example code (as of v18.1.6), the rule
may be problematic for projects which use an initial newline just to start an example
(and projects may wish to use extra lines within examples just for easier illustration
purposes), so this PR disables by default.