### PR TITLE
test(no-types): check that the fix for no-types preserves asterisks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5295,6 +5295,17 @@ function quux () {
 
 }
 // Message: Types are not permitted on @returns.
+
+/**
+ * Beep
+ * Boop
+ *
+ * @returns {number}
+ */
+function quux () {
+
+}
+// Message: Types are not permitted on @returns.
 ````
 
 The following patterns are not considered problems:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "http://gajus.com"
   },
   "dependencies": {
-    "comment-parser": "^0.7.2",
+    "comment-parser": "^0.7.4",
     "debug": "^4.1.1",
     "jsdoctypeparser": "^6.1.0",
     "lodash": "^4.17.15",
@@ -16,12 +16,12 @@
   "description": "JSDoc linting rules for ESLint.",
   "devDependencies": {
     "@babel/cli": "^7.8.4",
-    "@babel/core": "^7.9.0",
+    "@babel/core": "^7.9.6",
     "@babel/node": "^7.8.7",
     "@babel/plugin-transform-flow-strip-types": "^7.9.0",
-    "@babel/preset-env": "^7.9.5",
+    "@babel/preset-env": "^7.9.6",
     "@babel/register": "^7.9.0",
-    "@typescript-eslint/parser": "^2.28.0",
+    "@typescript-eslint/parser": "^2.31.0",
     "babel-eslint": "^10.1.0",
     "babel-plugin-add-module-exports": "^1.0.2",
     "babel-plugin-istanbul": "^6.0.0",
@@ -32,10 +32,10 @@
     "gitdown": "^3.1.3",
     "glob": "^7.1.6",
     "husky": "^4.2.5",
-    "mocha": "^7.1.1",
+    "mocha": "^7.1.2",
     "nyc": "^15.0.1",
     "rimraf": "^3.0.2",
-    "semantic-release": "^17.0.6",
+    "semantic-release": "^17.0.7",
     "typescript": "^3.8.3"
   },
   "engines": {

--- a/src/bin/generateReadme.js
+++ b/src/bin/generateReadme.js
@@ -8,7 +8,9 @@ import glob from 'glob';
 import Gitdown from 'gitdown';
 
 const trimCode = (code) => {
-  let lines = code.replace(/^\n/u, '').trimEnd().split('\n');
+  // todo[engine:node@>10]: Change to `trimEnd`
+  // eslint-disable-next-line unicorn/prefer-trim-start-end
+  let lines = code.replace(/^\n/u, '').trimRight().split('\n');
 
   const firsLineIndentation = lines[0].match(/^\s+/u);
   const lastLineIndentation = lines[lines.length - 1].match(/^\s+/u);

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -154,6 +154,10 @@ const getUtils = (
 
   utils.stringify = (tagBlock) => {
     const indent = jsdocUtils.getIndent(sourceCode);
+    if (ruleConfig.noTrim) {
+      const lastTag = tagBlock.tags[tagBlock.tags.length - 1];
+      lastTag.description = lastTag.description.replace(/\n$/, '');
+    }
 
     return commentStringify([tagBlock], {indent}).slice(indent.length - 1);
   };

--- a/src/rules/noTypes.js
+++ b/src/rules/noTypes.js
@@ -36,4 +36,5 @@ export default iterateJsdoc(({
     ],
     type: 'suggestion',
   },
+  noTrim: true,
 });

--- a/test/rules/assertions/noTypes.js
+++ b/test/rules/assertions/noTypes.js
@@ -127,6 +127,35 @@ export default {
           }
       `,
     },
+    {
+      code: `
+          /**
+           * Beep
+           * Boop
+           *
+           * @returns {number}
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Types are not permitted on @returns.',
+        },
+      ],
+      output: `
+          /**
+           * Beep
+           * Boop
+           *
+           * @returns
+           */
+          function quux () {
+
+          }
+      `,
+    },
   ],
   valid: [
     {

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -605,7 +605,6 @@ export default {
       interface ITest {
       /**
        * Test description.
-       *
        * @param id
        */
       TestMethod(id: number): void;
@@ -645,7 +644,6 @@ export default {
       {
       /**
        * A test method.
-       *
        * @param id
        */
       abstract TestFunction(id);
@@ -712,7 +710,6 @@ export default {
       output: `
       /**
        * A test function.
-       *
        * @param id
        */
       declare let TestFunction: (id) => void;
@@ -740,7 +737,6 @@ export default {
       output: `
       /**
        * A test function.
-       *
        * @param id
        */
       let TestFunction: (id) => void;
@@ -772,7 +768,6 @@ export default {
       output: `
       /**
        * A test function.
-       *
        * @param id
        */
        function test(
@@ -807,7 +802,6 @@ export default {
       output: `
       /**
        * A test function.
-       *
        * @param id
        */
        let test = (processor: (id: number) => string) =>
@@ -841,7 +835,6 @@ export default {
       class TestClass {
       /**
        * A class property.
-       *
        * @param id
        */
         public Test: (id: number) => string;
@@ -875,7 +868,6 @@ export default {
       class TestClass {
       /**
        * A class method.
-       *
        * @param id
        */
        public TestMethod(): (id: number) => string
@@ -909,7 +901,6 @@ export default {
       interface TestInterface {
       /**
        * An interface property.
-       *
        * @param id
        */
         public Test: (id: number) => string;
@@ -941,7 +932,6 @@ export default {
       interface TestInterface {
       /**
        * An interface method.
-       *
        * @param id
        */
        public TestMethod(): (id: number) => string;
@@ -970,7 +960,6 @@ export default {
       output: `
       /**
        * A function with return type
-       *
        * @param id
        */
        function test(): (id: number) => string;
@@ -1001,7 +990,6 @@ export default {
       output: `
       /**
        * A function with return type
-       *
        * @param id
        */
        let test = (): (id: number) => string =>


### PR DESCRIPTION
Currently, the fix for `no-types` results in the removal of some asterisks from multiline descriptions. This makes `eslint-plugin-jsdoc` somewhat jarring to adopt.

The proper fix here probably requires https://github.com/syavorsky/comment-parser/pull/74.