### PR TITLE
Refactor jsdoc iteration to walk through nodes comments are associated with

### DIFF
--- a/README.md
+++ b/README.md
@@ -5044,6 +5044,22 @@ class Foo {
 // Settings: {"jsdoc":{"mode":"closure"}}
 
 /**
+ * @template TEMPLATE_TYPE
+ */
+class Foo {
+  /**
+   * @return {TEMPLATE_TYPE}
+   */
+  bar () {}
+
+  /**
+   * @return {TEMPLATE_TYPE}
+   */
+  baz () {}
+}
+// Settings: {"jsdoc":{"mode":"closure"}}
+
+/**
  * @template TEMPLATE_TYPE_A, TEMPLATE_TYPE_B
  */
 class Foo {

--- a/src/eslint/getJSDocComment.js
+++ b/src/eslint/getJSDocComment.js
@@ -127,6 +127,7 @@ const getJSDocComment = function (sourceCode, node, settings) {
   };
 
   const reducedNode = getReducedASTNode(node, sourceCode);
+  /* istanbul ignore next */
   if (!reducedNode) {
     return null;
   }
@@ -134,4 +135,5 @@ const getJSDocComment = function (sourceCode, node, settings) {
   return findJSDocComment(reducedNode);
 };
 
+export {getReducedASTNode};
 export default getJSDocComment;

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -2,7 +2,7 @@
 import {default as commentParser, stringify as commentStringify} from 'comment-parser';
 import _ from 'lodash';
 import jsdocUtils from './jsdocUtils';
-import getJSDocComment from './eslint/getJSDocComment';
+import getJSDocComment, {getReducedASTNode} from './eslint/getJSDocComment';
 
 const skipSeeLink = (parser) => {
   return (str, data) => {
@@ -263,22 +263,18 @@ const getUtils = (
   };
 
   utils.getClassNode = () => {
-    // Ancestors missing in `Program` comment iteration
-    const greatGrandParent = ancestors.length ?
-      ancestors.slice(-3)[0] :
-      jsdocUtils.getAncestor(sourceCode, jsdocNode, 3);
-
-    const greatGrandParentValue = greatGrandParent && sourceCode.getFirstToken(greatGrandParent).value;
-
-    if (greatGrandParentValue === 'class') {
-      return greatGrandParent;
-    }
-
-    return false;
+    return [...ancestors, node].reverse().find((parent) => {
+      return parent && ['ClassDeclaration', 'ClassExpression'].includes(parent.type);
+    }) || null;
   };
 
   utils.getClassJsdoc = () => {
     const classNode = utils.getClassNode();
+
+    if (!classNode) {
+      return null;
+    }
+
     const classJsdocNode = getJSDocComment(sourceCode, classNode, {
       maxLines,
       minLines,
@@ -296,7 +292,7 @@ const getUtils = (
   utils.classHasTag = (tagName) => {
     const classJsdoc = utils.getClassJsdoc();
 
-    return classJsdoc && jsdocUtils.hasTag(classJsdoc, tagName);
+    return Boolean(classJsdoc) && jsdocUtils.hasTag(classJsdoc, tagName);
   };
 
   utils.forEachPreferredTag = (tagName, arrayHandler, skipReportingBlockedTag = false) => {
@@ -421,36 +417,60 @@ const makeReport = (context, commentNode) => {
  * @param {{meta: any}} ruleConfig
  */
 const iterateAllJsdocs = (iterator, ruleConfig) => {
+  const trackedJsdocs = [];
+
+  const callIterator = (context, node, jsdocNode) => {
+    const sourceCode = context.getSourceCode();
+    if (!(/^\/\*\*\s/).test(sourceCode.getText(jsdocNode))) {
+      return;
+    }
+    const sourceLine = sourceCode.lines[jsdocNode.loc.start.line - 1];
+    const indent = sourceLine.charAt(0).repeat(jsdocNode.loc.start.column);
+    const jsdoc = parseComment(jsdocNode, indent, !ruleConfig.noTrim);
+    const settings = getSettings(context);
+    const report = makeReport(context, jsdocNode);
+
+    iterator({
+      context,
+      indent,
+      jsdoc,
+      jsdocNode,
+      node,
+      report,
+      settings,
+      sourceCode,
+      utils: getUtils(node, jsdoc, jsdocNode, settings, report, context),
+    });
+  };
+
   return {
     create (context) {
       return {
-        'Program' () {
+        '*:not(Program)' (node) {
           const sourceCode = context.getSourceCode();
-          const comments = sourceCode.getAllComments();
+          const reducedNode = getReducedASTNode(node, sourceCode);
 
-          comments.forEach((comment) => {
-            if (!(/^\/\*\*\s/).test(sourceCode.getText(comment))) {
-              return;
-            }
+          if (node !== reducedNode) {
+            return;
+          }
 
-            const sourceLine = sourceCode.lines[comment.loc.start.line - 1];
-            const indent = sourceLine.charAt(0).repeat(comment.loc.start.column);
-            const jsdoc = parseComment(comment, indent, !ruleConfig.noTrim);
-            const settings = getSettings(context);
-            const report = makeReport(context, comment);
-            const jsdocNode = comment;
+          const comment = getJSDocComment(sourceCode, node, getSettings(context));
+          if (!comment || trackedJsdocs.includes(comment)) {
+            return;
+          }
 
-            iterator({
-              context,
-              indent,
-              jsdoc,
-              jsdocNode,
-              node: null,
-              report,
-              settings,
-              sourceCode,
-              utils: getUtils(null, jsdoc, jsdocNode, settings, report, context),
-            });
+          trackedJsdocs.push(comment);
+          callIterator(context, node, comment);
+        },
+        'Program:exit' () {
+          const sourceCode = context.getSourceCode();
+          const allJsdocs = sourceCode.getAllComments();
+          const untrackedJSdoc = allJsdocs.filter((node) => {
+            return !trackedJsdocs.includes(node);
+          });
+
+          untrackedJSdoc.forEach((comment) => {
+            callIterator(context, null, comment);
           });
         },
       };

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -514,18 +514,6 @@ const getTagsByType = (context, mode, tags, tagPreference) => {
   };
 };
 
-const getAncestor = (sourceCode, nde, depth, idx = 0) => {
-  if (idx === depth) {
-    return nde;
-  }
-  const prevToken = sourceCode.getTokenBefore(nde);
-  if (prevToken) {
-    return getAncestor(sourceCode, prevToken, depth, idx + 1);
-  }
-
-  return null;
-};
-
 const getIndent = (sourceCode) => {
   let indent = sourceCode.text.match(/^\n*([ \t]+)/u);
   /* istanbul ignore next */
@@ -537,7 +525,6 @@ const getIndent = (sourceCode) => {
 export default {
   enforcedContexts,
   filterTags,
-  getAncestor,
   getContextObject,
   getFunctionParameterNames,
   getIndent,

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -586,6 +586,29 @@ export default {
     {
       code: `
       /**
+       * @template TEMPLATE_TYPE
+       */
+      class Foo {
+        /**
+         * @return {TEMPLATE_TYPE}
+         */
+        bar () {}
+
+        /**
+         * @return {TEMPLATE_TYPE}
+         */
+        baz () {}
+      }
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'closure',
+        },
+      },
+    },
+    {
+      code: `
+      /**
        * @template TEMPLATE_TYPE_A, TEMPLATE_TYPE_B
        */
       class Foo {


### PR DESCRIPTION
In attempt to fix #363 I changed the way iterating over jsdoc comments works.
Previously, `iterateJsdoc` walked over comment nodes and processed them without regards of their context and most importantly, the AST node they're describing.
I changed this to iterate overs all js AST nodes, then selecting ones that have JSDoc comments and processing those along with js their node. This allowed to implement `getClassNode` properly and should probably allow more context-aware checks.

Some JSDoc comments are not associated with any nodes however and so they warranted a second pass on `Program:exit`.
Also `getJSDocComment` attributes JSDoc to several nodes, for example here:

```js
/**
 * Comment.
 */
const foo = {
   bar: 'baz'
}
```
`getJSDocComment` will return the JSDoc node for both `Identifier` and `ObjectExpression`, unlike base eslint `SourceCode.getJSDocComment`. I'm not sure if this is the intended behaviour or nor.
Because of this two things I had to keep track of JSDoc nodes processed while iterating js nodes.

This ended up being a major change in internal behaviour, but I believe it should be backwards compatible. 
Another negative consequence is that it increased processing time. Linting one of my JSDoc heavy GCC project now takes 2 seconds longer (14 from 12). But tests run as fast as previously, so exact impact depends on complexity of the code.