### PR TITLE
`require-description-complete-sentence`: `abbreviations` option

### DIFF
--- a/.README/rules/require-description-complete-sentence.md
+++ b/.README/rules/require-description-complete-sentence.md
@@ -10,6 +10,9 @@ tag descriptions are written in complete sentences, i.e.,
   character must be preceded by a line ending with a period.
 * A colon or semi-colon followed by two line breaks is still part of the
   containing paragraph (unlike normal dual line breaks).
+* Text within inline tags `{...}` are not checked for sentence divisions.
+* Periods after items within the `abbreviations` option array are not treated
+  as sentence endings.
 
 #### Options
 
@@ -34,10 +37,16 @@ its "description" (e.g., for `@returns {someType} some description`, the
 description is `some description` while for `@some-tag xyz`, the description
 is `xyz`).
 
+##### `abbreviations`
+
+You can provide an `abbreviations` options array to avoid such strings of text
+being treated as sentence endings when followed by dots. The `.` is not
+necessary at the end of the array items.
+
 |||
 |---|---|
 |Context|everywhere|
 |Tags|doc block, `param`, `returns`, `description`, `property`, `summary`, `file`, `classdesc`, `todo`, `deprecated`, `throws`, 'yields' and others added by `tags`|
 |Aliases|`arg`, `argument`, `return`, `desc`, `prop`, `fileoverview`, `overview`, `exception`, `yield`|
-|Options|`tags`|
+|Options|`tags`, `abbreviations`|
 <!-- assertions requireDescriptionCompleteSentence -->

--- a/README.md
+++ b/README.md
@@ -5226,6 +5226,9 @@ tag descriptions are written in complete sentences, i.e.,
   character must be preceded by a line ending with a period.
 * A colon or semi-colon followed by two line breaks is still part of the
   containing paragraph (unlike normal dual line breaks).
+* Text within inline tags `{...}` are not checked for sentence divisions.
+* Periods after items within the `abbreviations` option array are not treated
+  as sentence endings.
 
 <a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-11"></a>
 #### Options
@@ -5252,12 +5255,19 @@ its "description" (e.g., for `@returns {someType} some description`, the
 description is `some description` while for `@some-tag xyz`, the description
 is `xyz`).
 
+<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-11-abbreviations"></a>
+##### <code>abbreviations</code>
+
+You can provide an `abbreviations` options array to avoid such strings of text
+being treated as sentence endings when followed by dots. The `.` is not
+necessary at the end of the array items.
+
 |||
 |---|---|
 |Context|everywhere|
 |Tags|doc block, `param`, `returns`, `description`, `property`, `summary`, `file`, `classdesc`, `todo`, `deprecated`, `throws`, 'yields' and others added by `tags`|
 |Aliases|`arg`, `argument`, `return`, `desc`, `prop`, `fileoverview`, `overview`, `exception`, `yield`|
-|Options|`tags`|
+|Options|`tags`, `abbreviations`|
 The following patterns are considered problems:
 
 ````js
@@ -5471,6 +5481,86 @@ function quux (foo) {
 // Settings: {"jsdoc":{"tagNamePreference":{"description":false}}}
 // Options: [{"tags":["param"]}]
 // Message: Sentence must end with a period.
+
+/**
+ * Sorry, but this isn't a complete sentence, Mr.
+ */
+function quux () {
+
+}
+// Options: [{"abbreviations":["Mr"]}]
+// Message: Sentence must end with a period.
+
+/**
+ * Sorry, but this isn't a complete sentence Mr.
+ */
+function quux () {
+
+}
+// Options: [{"abbreviations":["Mr."]}]
+// Message: Sentence must end with a period.
+
+/**
+ * Sorry, but this isn't a complete sentence Mr. 
+ */
+function quux () {
+
+}
+// Options: [{"abbreviations":["Mr"]}]
+// Message: Sentence must end with a period.
+
+/**
+ * Sorry, but this isn't a complete sentence Mr. and Mrs.
+ */
+function quux () {
+
+}
+// Options: [{"abbreviations":["Mr","Mrs"]}]
+// Message: Sentence must end with a period.
+
+/**
+ * This is a complete sentence. But this isn't, Mr.
+ */
+function quux () {
+
+}
+// Options: [{"abbreviations":["Mr"]}]
+// Message: Sentence must end with a period.
+
+/**
+ * This is a complete Mr. sentence. But this isn't, Mr.
+ */
+function quux () {
+
+}
+// Options: [{"abbreviations":["Mr"]}]
+// Message: Sentence must end with a period.
+
+/**
+ * This is a complete Mr. sentence.
+ */
+function quux () {
+
+}
+// Message: Sentence should start with an uppercase character.
+
+/**
+ * This is fun, i.e. enjoyable, but not superlatively so, e.g. not
+ * super, wonderful, etc..
+ */
+function quux () {
+
+}
+// Message: Sentence should start with an uppercase character.
+
+/**
+ * Do not have dynamic content; e.g. homepage. Here a simple unique id
+ * suffices.
+ */
+ function quux () {
+
+ }
+// Message: Sentence should start with an uppercase character.
 ````
 
 The following patterns are not considered problems:
@@ -5704,6 +5794,85 @@ function quux () {
 function quux () {
 
 }
+
+/**
+ * Sorry, but this isn't a complete sentence, Mr.
+ */
+function quux () {
+
+}
+
+/**
+ * Sorry, but this isn't a complete sentence Mr..
+ */
+function quux () {
+
+}
+// Options: [{"abbreviations":["Mr."]}]
+
+/**
+ * Sorry, but this isn't a complete sentence Mr. 
+ */
+function quux () {
+
+}
+
+/**
+ * Sorry, but this isn't a complete sentence Mr. and Mrs..
+ */
+function quux () {
+
+}
+// Options: [{"abbreviations":["Mr","Mrs"]}]
+
+/**
+ * This is a complete sentence aMr.
+ */
+function quux () {
+
+}
+// Options: [{"abbreviations":["Mr"]}]
+
+/**
+ * This is a complete sentence. But this isn't, Mr.
+ */
+function quux () {
+
+}
+
+/**
+ * This is a complete Mr. Sentence. But this isn't, Mr.
+ */
+function quux () {
+
+}
+
+/**
+ * This is a complete Mr. sentence.
+ */
+function quux () {
+
+}
+// Options: [{"abbreviations":["Mr"]}]
+
+/**
+ * This is fun, i.e. enjoyable, but not superlatively so, e.g. not
+ * super, wonderful, etc..
+ */
+function quux () {
+
+}
+// Options: [{"abbreviations":["etc","e.g.","i.e."]}]
+
+
+**
+* Do not have dynamic content; e.g. homepage. Here a simple unique id
+* suffices.
+*/
+function quux () {
+
+}
+// Options: [{"abbreviations":["etc","e.g.","i.e."]}]
 ````
 
 

--- a/test/rules/assertions/requireDescriptionCompleteSentence.js
+++ b/test/rules/assertions/requireDescriptionCompleteSentence.js
@@ -594,6 +594,170 @@ export default {
         },
       },
     },
+    {
+      code: `
+          /**
+           * Sorry, but this isn't a complete sentence, Mr.
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Sentence must end with a period.',
+        },
+      ],
+      options: [{
+        abbreviations: ['Mr'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * Sorry, but this isn't a complete sentence Mr.
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Sentence must end with a period.',
+        },
+      ],
+      options: [{
+        abbreviations: ['Mr.'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * Sorry, but this isn't a complete sentence Mr.\u0020
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Sentence must end with a period.',
+        },
+      ],
+      options: [{
+        abbreviations: ['Mr'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * Sorry, but this isn't a complete sentence Mr. and Mrs.
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Sentence must end with a period.',
+        },
+      ],
+      options: [{
+        abbreviations: ['Mr', 'Mrs'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * This is a complete sentence. But this isn't, Mr.
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Sentence must end with a period.',
+        },
+      ],
+      options: [{
+        abbreviations: ['Mr'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * This is a complete Mr. sentence. But this isn't, Mr.
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Sentence must end with a period.',
+        },
+      ],
+      options: [{
+        abbreviations: ['Mr'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * This is a complete Mr. sentence.
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Sentence should start with an uppercase character.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * This is fun, i.e. enjoyable, but not superlatively so, e.g. not
+           * super, wonderful, etc..
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Sentence should start with an uppercase character.',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * Do not have dynamic content; e.g. homepage. Here a simple unique id
+       * suffices.
+       */
+       function quux () {
+
+       }
+       `,
+      errors: [
+        {
+          line: 3,
+          message: 'Sentence should start with an uppercase character.',
+        },
+      ],
+    },
   ],
   valid: [
     {
@@ -930,6 +1094,127 @@ export default {
 
           }
       `,
+    },
+    {
+      code: `
+          /**
+           * Sorry, but this isn't a complete sentence, Mr.
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * Sorry, but this isn't a complete sentence Mr..
+           */
+          function quux () {
+
+          }
+      `,
+      options: [{
+        abbreviations: ['Mr.'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * Sorry, but this isn't a complete sentence Mr.\u0020
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * Sorry, but this isn't a complete sentence Mr. and Mrs..
+           */
+          function quux () {
+
+          }
+      `,
+      options: [{
+        abbreviations: ['Mr', 'Mrs'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * This is a complete sentence aMr.
+           */
+          function quux () {
+
+          }
+      `,
+      options: [{
+        abbreviations: ['Mr'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * This is a complete sentence. But this isn't, Mr.
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * This is a complete Mr. Sentence. But this isn't, Mr.
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * This is a complete Mr. sentence.
+           */
+          function quux () {
+
+          }
+      `,
+      options: [{
+        abbreviations: ['Mr'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * This is fun, i.e. enjoyable, but not superlatively so, e.g. not
+           * super, wonderful, etc..
+           */
+          function quux () {
+
+          }
+      `,
+      options: [{
+        abbreviations: ['etc', 'e.g.', 'i.e.'],
+      }],
+    },
+    {
+      code: `
+
+      /**
+       * Do not have dynamic content; e.g. homepage. Here a simple unique id
+       * suffices.
+       */
+       function quux () {
+
+       }
+       `,
+      options: [{
+        abbreviations: ['etc', 'e.g.', 'i.e.'],
+      }],
     },
   ],
 };


### PR DESCRIPTION
feat(`require-description-complete-sentence`): add `abbreviations` option; fixes #424

I haven't added any abbreviations by default, figuring we might first get some experience with it. But I've added a fair number of test cases (and if we do change the default, then the tests I added at least will need abbreviations specifically disabled).