### PR TITLE
`require-property`: New rule to check for `@property` on `@typedef` or `@namespace` for plain object type

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -352,6 +352,7 @@ only (e.g., to match `Array` if the type is `Array` vs. `Array.<string>`).
 {"gitdown": "include", "file": "./rules/require-param-name.md"}
 {"gitdown": "include", "file": "./rules/require-param-type.md"}
 {"gitdown": "include", "file": "./rules/require-param.md"}
+{"gitdown": "include", "file": "./rules/require-property.md"}
 {"gitdown": "include", "file": "./rules/require-returns-check.md"}
 {"gitdown": "include", "file": "./rules/require-returns-description.md"}
 {"gitdown": "include", "file": "./rules/require-returns-type.md"}

--- a/.README/rules/require-property.md
+++ b/.README/rules/require-property.md
@@ -1,0 +1,18 @@
+### `require-property`
+
+Requires that all `@typedef` and `@namespace` tags have `@property`
+when their type is a plain `object`, `Object`, or `PlainObject`.
+
+Note that if any other type, including a subtype of object such as
+`object<string, string>`, will not be reported.
+
+#### Fixer
+
+The fixer for `require-example` will add an empty `@property`.
+
+|||
+|---|---|
+|Context|Everywhere|
+|Tags|`typedef`, `namespace`|
+
+<!-- assertions requireProperty -->

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ JSDoc linting rules for ESLint.
         * [`require-param-name`](#eslint-plugin-jsdoc-rules-require-param-name)
         * [`require-param-type`](#eslint-plugin-jsdoc-rules-require-param-type)
         * [`require-param`](#eslint-plugin-jsdoc-rules-require-param)
+        * [`require-property`](#eslint-plugin-jsdoc-rules-require-property)
         * [`require-returns-check`](#eslint-plugin-jsdoc-rules-require-returns-check)
         * [`require-returns-description`](#eslint-plugin-jsdoc-rules-require-returns-description)
         * [`require-returns-type`](#eslint-plugin-jsdoc-rules-require-returns-type)
@@ -8490,6 +8491,104 @@ export abstract class StephanPlugin<O, D> {
     }, defaultOptions: D) {
 
     }
+}
+````
+
+
+<a name="eslint-plugin-jsdoc-rules-require-property"></a>
+### <code>require-property</code>
+
+Requires that all `@typedef` and `@namespace` tags have `@property`
+when their type is a plain `object`, `Object`, or `PlainObject`.
+
+Note that if any other type, including a subtype of object such as
+`object<string, string>`, will not be reported.
+
+<a name="eslint-plugin-jsdoc-rules-require-property-fixer-1"></a>
+#### Fixer
+
+The fixer for `require-example` will add an empty `@property`.
+
+|||
+|---|---|
+|Context|Everywhere|
+|Tags|`typedef`, `namespace`|
+
+The following patterns are considered problems:
+
+````js
+/**
+ * @typedef {object} SomeTypedef
+ */
+// Message: Missing JSDoc @property.
+
+/**
+ * @typedef {PlainObject} SomeTypedef
+ */
+// Settings: {"jsdoc":{"tagNamePreference":{"property":"prop"}}}
+// Message: Missing JSDoc @prop.
+
+/**
+ * @namespace {Object} SomeName
+ */
+// Message: Missing JSDoc @property.
+````
+
+The following patterns are not considered problems:
+
+````js
+/**
+ *
+ */
+
+/**
+ * @property
+ */
+
+/**
+ * @typedef {Object} SomeTypedef
+ * @property {SomeType} propName Prop description
+ */
+
+/**
+ * @typedef {object} SomeTypedef
+ * @prop {SomeType} propName Prop description
+ */
+// Settings: {"jsdoc":{"tagNamePreference":{"property":"prop"}}}
+
+/**
+ * @typedef {object} SomeTypedef
+ * @property
+ * // arbitrary property content
+ */
+
+/**
+ * @typedef {object<string, string>} SomeTypedef
+ */
+
+/**
+ * @typedef {string} SomeTypedef
+ */
+
+/**
+ * @namespace {object} SomeName
+ * @property {SomeType} propName Prop description
+ */
+
+/**
+ * @namespace {object} SomeName
+ * @property
+ * // arbitrary property content
+ */
+
+/**
+ * @typedef {object} SomeTypedef
+ * @property someProp
+ * @property anotherProp This with a description
+ * @property {anotherType} yetAnotherProp This with a type and desc.
+ */
+function quux () {
+
 }
 ````
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ import requireParamName from './rules/requireParamName';
 import requireParam from './rules/requireParam';
 import requireParamDescription from './rules/requireParamDescription';
 import requireParamType from './rules/requireParamType';
+import requireProperty from './rules/requireProperty';
 import requireReturns from './rules/requireReturns';
 import requireReturnsCheck from './rules/requireReturnsCheck';
 import requireReturnsDescription from './rules/requireReturnsDescription';
@@ -60,6 +61,7 @@ export default {
         'jsdoc/require-param-description': 'warn',
         'jsdoc/require-param-name': 'warn',
         'jsdoc/require-param-type': 'warn',
+        'jsdoc/require-property': 'warn',
         'jsdoc/require-returns': 'warn',
         'jsdoc/require-returns-check': 'warn',
         'jsdoc/require-returns-description': 'warn',
@@ -94,6 +96,7 @@ export default {
     'require-param-description': requireParamDescription,
     'require-param-name': requireParamName,
     'require-param-type': requireParamType,
+    'require-property': requireProperty,
     'require-returns': requireReturns,
     'require-returns-check': requireReturnsCheck,
     'require-returns-description': requireReturnsDescription,

--- a/src/rules/requireProperty.js
+++ b/src/rules/requireProperty.js
@@ -1,0 +1,41 @@
+import iterateJsdoc from '../iterateJsdoc';
+
+export default iterateJsdoc(({
+  jsdoc,
+  utils,
+}) => {
+  const propertyAssociatedTags = utils.filterTags(({tag}) => {
+    return ['typedef', 'namespace'].includes(tag);
+  });
+  if (!propertyAssociatedTags.length) {
+    return;
+  }
+  const targetTagName = utils.getPreferredTagName({tagName: 'property'});
+
+  if (utils.hasATag([targetTagName])) {
+    return;
+  }
+
+  propertyAssociatedTags.forEach((propertyAssociatedTag) => {
+    if (!['object', 'Object', 'PlainObject'].includes(propertyAssociatedTag.type)) {
+      return;
+    }
+    utils.reportJSDoc(`Missing JSDoc @${targetTagName}.`, null, () => {
+      const line = jsdoc.tags[jsdoc.tags.length - 1].line + 1;
+      jsdoc.tags.push({
+        description: '',
+        line,
+        name: '',
+        optional: false,
+        tag: targetTagName,
+        type: '',
+      });
+    });
+  });
+}, {
+  iterateAllJsdocs: true,
+  meta: {
+    fixable: 'code',
+    type: 'suggestion',
+  },
+});

--- a/test/rules/assertions/requireProperty.js
+++ b/test/rules/assertions/requireProperty.js
@@ -1,0 +1,157 @@
+export default {
+  invalid: [
+    {
+      code: `
+          /**
+           * @typedef {object} SomeTypedef
+           */
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @property.',
+        },
+      ],
+      output: `
+          /**
+           * @typedef {object} SomeTypedef
+           * @property
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @typedef {PlainObject} SomeTypedef
+           */
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @prop.',
+        },
+      ],
+      output: `
+          /**
+           * @typedef {PlainObject} SomeTypedef
+           * @prop
+           */
+      `,
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            property: 'prop',
+          },
+        },
+      },
+    },
+    {
+      code: `
+          /**
+           * @namespace {Object} SomeName
+           */
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @property.',
+        },
+      ],
+      output: `
+          /**
+           * @namespace {Object} SomeName
+           * @property
+           */
+      `,
+    },
+  ],
+  valid: [
+    {
+      code: `
+        /**
+         *
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @property
+         */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @typedef {Object} SomeTypedef
+           * @property {SomeType} propName Prop description
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @typedef {object} SomeTypedef
+           * @prop {SomeType} propName Prop description
+           */
+      `,
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            property: 'prop',
+          },
+        },
+      },
+    },
+    {
+      code: `
+          /**
+           * @typedef {object} SomeTypedef
+           * @property
+           * // arbitrary property content
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @typedef {object<string, string>} SomeTypedef
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @typedef {string} SomeTypedef
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @namespace {object} SomeName
+           * @property {SomeType} propName Prop description
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @namespace {object} SomeName
+           * @property
+           * // arbitrary property content
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @typedef {object} SomeTypedef
+           * @property someProp
+           * @property anotherProp This with a description
+           * @property {anotherType} yetAnotherProp This with a type and desc.
+           */
+          function quux () {
+
+          }
+      `,
+    },
+  ],
+};

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -33,6 +33,7 @@ const ruleTester = new RuleTester();
   'require-param-description',
   'require-param-name',
   'require-param-type',
+  'require-property',
   'require-returns',
   'require-returns-check',
   'require-returns-description',


### PR DESCRIPTION
feat(`require-property`); add rule to check for `property` on `typedef` or `namespace` where the type is `object`; fixes #410

BREAKING CHANGE:

Adds new rule to `recommended` config.