### PR TITLE
`match-description`, `require-description`, `require-example`: "any" for `contexts`

### DIFF
--- a/.README/rules/match-description.md
+++ b/.README/rules/match-description.md
@@ -88,7 +88,8 @@ it by setting it to `false`.
 
 Set this to an array of strings representing the AST context
 where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
-Overrides the default contexts (see below).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files.
 
 |||
 |---|---|

--- a/.README/rules/require-description.md
+++ b/.README/rules/require-description.md
@@ -14,7 +14,8 @@ An options object may have any of the following properties:
 
 - `contexts` - Set to an array of strings representing the AST context
   where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6
-  classes). Overrides the default contexts (see below).
+  classes). Overrides the default contexts (see below).  Set to `"any"` if
+  you want the rule to apply to any jsdoc block throughout your files.
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the
     document block avoids the need for a `@description`. Defaults to an
     empty array.

--- a/.README/rules/require-example.md
+++ b/.README/rules/require-example.md
@@ -24,7 +24,8 @@ Defaults to `false`.
 
 Set this to an array of strings representing the AST context
 where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
-Overrides the default contexts (see below).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files.
 
 #### Fixer
 

--- a/README.md
+++ b/README.md
@@ -3973,7 +3973,8 @@ it by setting it to `false`.
 
 Set this to an array of strings representing the AST context
 where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
-Overrides the default contexts (see below).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files.
 
 |||
 |---|---|
@@ -3993,6 +3994,18 @@ const q = class {
 
 }
 // Options: [{"contexts":["ClassExpression"]}]
+// Message: JSDoc description does not satisfy the regex pattern.
+
+/**
+ * foo.
+ */
+// Options: [{"contexts":["any"]}]
+// Message: JSDoc description does not satisfy the regex pattern.
+
+/**
+ * foo.
+ */
+// Options: [{"contexts":["any"]}]
 // Message: JSDoc description does not satisfy the regex pattern.
 
 /**
@@ -4305,6 +4318,17 @@ function quux (foo) {
 The following patterns are not considered problems:
 
 ````js
+/**
+ *
+ */
+
+/**
+ *
+ */
+ function quux () {
+
+ }
+
 /**
  * @param foo - Foo.
  */
@@ -5952,7 +5976,8 @@ An options object may have any of the following properties:
 
 - `contexts` - Set to an array of strings representing the AST context
   where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6
-  classes). Overrides the default contexts (see below).
+  classes). Overrides the default contexts (see below).  Set to `"any"` if
+  you want the rule to apply to any jsdoc block throughout your files.
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the
     document block avoids the need for a `@description`. Defaults to an
     empty array.
@@ -6005,6 +6030,12 @@ class quux {
 
 }
 // Options: [{"contexts":["ClassDeclaration"],"descriptionStyle":"tag"}]
+// Message: Missing JSDoc @description declaration.
+
+/**
+ *
+ */
+// Options: [{"contexts":["any"],"descriptionStyle":"tag"}]
 // Message: Missing JSDoc @description declaration.
 
 /**
@@ -6103,6 +6134,10 @@ function quux () {
 The following patterns are not considered problems:
 
 ````js
+/**
+ *
+ */
+
 /**
  * @description
  * // arbitrary description content
@@ -6253,7 +6288,8 @@ Defaults to `false`.
 
 Set this to an array of strings representing the AST context
 where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
-Overrides the default contexts (see below).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files.
 
 <a name="eslint-plugin-jsdoc-rules-require-example-fixer"></a>
 #### Fixer
@@ -6325,6 +6361,12 @@ class quux {
 /**
  *
  */
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @example declaration.
+
+/**
+ *
+ */
 function quux () {
 }
 // Options: [{"exemptedBy":["notPresent"]}]
@@ -6334,6 +6376,10 @@ function quux () {
 The following patterns are not considered problems:
 
 ````js
+/**
+ *
+ */
+
 /**
  * @example
  * // arbitrary example content
@@ -7092,6 +7138,10 @@ const myObject = {
 The following patterns are not considered problems:
 
 ````js
+/**
+ *
+ */
+
 var array = [1,2,3];
 array.forEach(function() {});
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -584,11 +584,18 @@ export default function iterateJsdoc (iterator, ruleConfig) {
      *   a list with parser callback function.
      */
     create (context) {
+      let contexts;
+      if (ruleConfig.contextDefaults) {
+        contexts = jsdocUtils.enforcedContexts(context, ruleConfig.contextDefaults);
+        if (contexts.includes('any')) {
+          return iterateAllJsdocs(iterator, ruleConfig).create(context);
+        }
+      }
+
       const sourceCode = context.getSourceCode();
-
       const settings = getSettings(context);
-
       const {lines} = sourceCode;
+
       const checkJsdoc = (node) => {
         const jsdocNode = getJSDocComment(sourceCode, node, settings);
 
@@ -603,8 +610,6 @@ export default function iterateJsdoc (iterator, ruleConfig) {
       };
 
       if (ruleConfig.contextDefaults) {
-        const contexts = jsdocUtils.enforcedContexts(context, ruleConfig.contextDefaults);
-
         return jsdocUtils.getContextObject(contexts, checkJsdoc);
       }
 

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -120,10 +120,9 @@ export default {
     warnRemovedSettings(context, 'require-jsdoc');
 
     const sourceCode = context.getSourceCode();
+    const settings = getSettings(context);
 
     const {require: requireOption, publicOnly, exemptEmptyFunctions} = getOptions(context);
-
-    const settings = getSettings(context);
 
     const checkJsDoc = (node) => {
       const jsDocNode = getJSDocComment(sourceCode, node, settings);

--- a/test/rules/assertions/matchDescription.js
+++ b/test/rules/assertions/matchDescription.js
@@ -28,6 +28,46 @@ export default {
           /**
            * foo.
            */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'JSDoc description does not satisfy the regex pattern.',
+        },
+      ],
+      options: [
+        {
+          contexts: [
+            'any',
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * foo.
+           */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'JSDoc description does not satisfy the regex pattern.',
+        },
+      ],
+      options: [
+        {
+          contexts: [
+            'any',
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * foo.
+           */
           const q = {
 
           };
@@ -734,6 +774,23 @@ export default {
     },
   ],
   valid: [
+    {
+      code: `
+          /**
+           *
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+           function quux () {
+
+           }
+      `,
+    },
     {
       code: `
           /**

--- a/test/rules/assertions/requireDescription.js
+++ b/test/rules/assertions/requireDescription.js
@@ -86,6 +86,24 @@ export default {
           /**
            *
            */
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @description declaration.',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+          descriptionStyle: 'tag',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
           class quux {
 
           }
@@ -319,6 +337,13 @@ export default {
     },
   ],
   valid: [
+    {
+      code: `
+          /**
+           *
+           */
+      `,
+    },
     {
       code: `
           /**

--- a/test/rules/assertions/requireExample.js
+++ b/test/rules/assertions/requireExample.js
@@ -117,6 +117,23 @@ export default {
           /**
            *
            */
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @example declaration.',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
           function quux () {
           }
       `,
@@ -134,6 +151,13 @@ export default {
     },
   ],
   valid: [
+    {
+      code: `
+          /**
+           *
+           */
+      `,
+    },
     {
       code: `
           /**

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -1143,6 +1143,12 @@ export default {
   ],
   valid: [{
     code: `
+        /**
+         *
+         */
+    `,
+  }, {
+    code: `
       var array = [1,2,3];
       array.forEach(function() {});
 


### PR DESCRIPTION
feat(match-description, require-description, require-example): allow "any" for `contexts`; fixes #325

Since it would have required additional refactoring, I decided against applying to require-jsdoc, for which it would be pretty unusual anyways.