### PR TITLE
`check-access` allow `ignorePrivate` setting to work with `access private` tag

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -111,7 +111,7 @@ supplied as the second argument in an array after the error level.
 ### Allow `@private` to disable rules for that comment block
 
 - `settings.jsdoc.ignorePrivate` - Disables all rules for the comment block
-  on which a `@private` tag occurs. Defaults to
+  on which a `@private` tag (or `@access private`) occurs. Defaults to
   `false`. Note: This has no effect with the rule `check-access` (whose
   purpose is to check access modifiers).
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ supplied as the second argument in an array after the error level.
 ### Allow <code>@private</code> to disable rules for that comment block
 
 - `settings.jsdoc.ignorePrivate` - Disables all rules for the comment block
-  on which a `@private` tag occurs. Defaults to
+  on which a `@private` tag (or `@access private`) occurs. Defaults to
   `false`. Note: This has no effect with the rule `check-access` (whose
   purpose is to check access modifiers).
 
@@ -678,6 +678,15 @@ function quux (foo) {}
 /**
   * @param {Number} foo
   * @private
+ */
+function quux (foo) {
+  // with spaces
+}
+// Settings: {"jsdoc":{"ignorePrivate":true}}
+
+/**
+  * @param {Number} foo
+  * @access private
  */
 function quux (foo) {
   // with spaces
@@ -8355,6 +8364,14 @@ class A {
 
 /**
  * @private
+ */
+function quux (foo) {
+
+}
+// Settings: {"jsdoc":{"ignorePrivate":true}}
+
+/**
+ * @access private
  */
 function quux (foo) {
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -450,7 +450,11 @@ const iterate = (
   if (
     settings.ignorePrivate &&
     !ruleConfig.checkPrivate &&
-    utils.hasTag('private')
+    (utils.hasTag('private') || _.filter(jsdoc.tags, {
+      tag: 'access',
+    }).some(({description}) => {
+      return description === 'private';
+    }))
   ) {
     return;
   }

--- a/test/rules/assertions/checkAlignment.js
+++ b/test/rules/assertions/checkAlignment.js
@@ -276,5 +276,21 @@ function quux (foo) {
         },
       },
     },
+    {
+      code: `
+        /**
+          * @param {Number} foo
+          * @access private
+         */
+        function quux (foo) {
+          // with spaces
+        }
+      `,
+      settings: {
+        jsdoc: {
+          ignorePrivate: true,
+        },
+      },
+    },
   ],
 };

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -912,6 +912,21 @@ export default {
     },
     {
       code: `
+          /**
+           * @access private
+           */
+          function quux (foo) {
+
+          }
+      `,
+      settings: {
+        jsdoc: {
+          ignorePrivate: true,
+        },
+      },
+    },
+    {
+      code: `
           // issue 182: optional chaining
           /** @const {boolean} test */
           const test = something?.find(_ => _)


### PR DESCRIPTION
feat(`check-access`): allow `ignorePrivate` setting to work with `access private` tag.

Test a rule with `iterateAllJsocs` and without.

Currently only works with `@private` tag. `@access private` is equivalent.