### PR TITLE
Require file overview

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -345,6 +345,7 @@ only (e.g., to match `Array` if the type is `Array` vs. `Array.<string>`).
 {"gitdown": "include", "file": "./rules/require-description-complete-sentence.md"}
 {"gitdown": "include", "file": "./rules/require-description.md"}
 {"gitdown": "include", "file": "./rules/require-example.md"}
+{"gitdown": "include", "file": "./rules/require-file-overview.md"}
 {"gitdown": "include", "file": "./rules/require-hyphen-before-param-description.md"}
 {"gitdown": "include", "file": "./rules/require-jsdoc.md"}
 {"gitdown": "include", "file": "./rules/require-param-description.md"}

--- a/.README/rules/require-file-overview.md
+++ b/.README/rules/require-file-overview.md
@@ -1,0 +1,18 @@
+### `require-file-overview`
+
+Requires that all files have a `@file`, `@fileoverview`, or `@overview` tag.
+
+#### Fixer
+
+The fixer for `require-example` will add an empty `@file`. Note that if you
+need to report a missing description for `file`, you can add `file` on
+the `tags` option with `match-description` (and the `contexts` option
+set to "any").
+
+|||
+|---|---|
+|Context|Everywhere|
+|Tags|`file`|
+|Aliases|`fileoverview`, `overview`|
+
+<!-- assertions requireFileOverview -->

--- a/.README/rules/require-file-overview.md
+++ b/.README/rules/require-file-overview.md
@@ -2,6 +2,12 @@
 
 Requires that all files have a `@file`, `@fileoverview`, or `@overview` tag.
 
+Duplicate file overview tags will be reported as will file overview tags
+which are not, as per [the docs](https://jsdoc.app/tags-file.html),
+"at the beginning of the file", where beginning of the file is interpreted
+in this rule as being when the overview tag is not preceded by
+anything other than a comment.
+
 #### Fixer
 
 The fixer for `require-example` will add an empty `@file`. Note that if you

--- a/.README/rules/require-file-overview.md
+++ b/.README/rules/require-file-overview.md
@@ -1,12 +1,14 @@
 ### `require-file-overview`
 
-Requires that all files have a `@file`, `@fileoverview`, or `@overview` tag.
+Checks that:
 
-Duplicate file overview tags will be reported as will file overview tags
-which are not, as per [the docs](https://jsdoc.app/tags-file.html),
-"at the beginning of the file", where beginning of the file is interpreted
-in this rule as being when the overview tag is not preceded by
-anything other than a comment.
+1. All files have a `@file`, `@fileoverview`, or `@overview` tag.
+2. Duplicate file overview tags within a given file will be reported
+3. File overview tags will be reported which are not, as per
+  [the docs](https://jsdoc.app/tags-file.html), "at the beginning of
+  the file"–where beginning of the file is interpreted in this rule
+  as being when the overview tag is not preceded by anything other than
+  a comment.
 
 #### Fixer
 

--- a/README.md
+++ b/README.md
@@ -6199,6 +6199,12 @@ function quux () {
 
 Requires that all files have a `@file`, `@fileoverview`, or `@overview` tag.
 
+Duplicate file overview tags will be reported as will file overview tags
+which are not, as per [the docs](https://jsdoc.app/tags-file.html),
+"at the beginning of the file", where beginning of the file is interpreted
+in this rule as being when the overview tag is not preceded by
+anything other than a comment.
+
 <a name="eslint-plugin-jsdoc-rules-require-file-overview-fixer-1"></a>
 #### Fixer
 
@@ -6245,6 +6251,20 @@ function quux () {}
 // Message: Missing @overview
 
 /**
+ *
+ */
+function quux () {}
+// Settings: {"jsdoc":{"tagNamePreference":{"file":false}}}
+// Message: `settings.jsdoc.tagNamePreference` cannot block @file for the `require-file-overview` rule
+
+/**
+ *
+ */
+function quux () {}
+// Settings: {"jsdoc":{"tagNamePreference":{"file":{"message":"Don't use file"}}}}
+// Message: `settings.jsdoc.tagNamePreference` cannot block @file for the `require-file-overview` rule
+
+/**
  * @param a
  */
 function quux (a) {}
@@ -6260,11 +6280,32 @@ function quux (a) {}
  */
 function bar (b) {}
 // Message: Missing @file
+
+/**
+ * @file
+ */
+
+ /**
+  * @file
+  */
+// Message: Duplicate @file
+
+function quux () {
+}
+/**
+ * @file
+ */
+// Message: @file should be at the beginning of the file
 ````
 
 The following patterns are not considered problems:
 
 ````js
+/**
+ * @file
+ */
+
+// Ok preceded by comment
 /**
  * @file
  */
@@ -6281,6 +6322,16 @@ The following patterns are not considered problems:
 
 /**
  * @file Description of file
+ */
+
+/**
+ * @file Description of file
+ */
+function quux () {
+}
+
+/**
+ *
  */
 ````
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ JSDoc linting rules for ESLint.
         * [`require-description-complete-sentence`](#eslint-plugin-jsdoc-rules-require-description-complete-sentence)
         * [`require-description`](#eslint-plugin-jsdoc-rules-require-description)
         * [`require-example`](#eslint-plugin-jsdoc-rules-require-example)
+        * [`require-file-overview`](#eslint-plugin-jsdoc-rules-require-file-overview)
         * [`require-hyphen-before-param-description`](#eslint-plugin-jsdoc-rules-require-hyphen-before-param-description)
         * [`require-jsdoc`](#eslint-plugin-jsdoc-rules-require-jsdoc)
         * [`require-param-description`](#eslint-plugin-jsdoc-rules-require-param-description)
@@ -6190,6 +6191,97 @@ function quux () {
 
 }
 // Options: [{"contexts":["ClassDeclaration"]}]
+````
+
+
+<a name="eslint-plugin-jsdoc-rules-require-file-overview"></a>
+### <code>require-file-overview</code>
+
+Requires that all files have a `@file`, `@fileoverview`, or `@overview` tag.
+
+<a name="eslint-plugin-jsdoc-rules-require-file-overview-fixer-1"></a>
+#### Fixer
+
+The fixer for `require-example` will add an empty `@file`. Note that if you
+need to report a missing description for `file`, you can add `file` on
+the `tags` option with `match-description` (and the `contexts` option
+set to "any").
+
+|||
+|---|---|
+|Context|Everywhere|
+|Tags|`file`|
+|Aliases|`fileoverview`, `overview`|
+
+The following patterns are considered problems:
+
+````js
+
+// Message: Missing @file
+
+/**
+ *
+ */
+// Message: Missing @file
+
+/**
+ *
+ */
+function quux () {}
+// Message: Missing @file
+
+/**
+ *
+ */
+function quux () {}
+// Settings: {"jsdoc":{"tagNamePreference":{"file":"fileoverview"}}}
+// Message: Missing @fileoverview
+
+/**
+ *
+ */
+function quux () {}
+// Settings: {"jsdoc":{"tagNamePreference":{"file":"overview"}}}
+// Message: Missing @overview
+
+/**
+ * @param a
+ */
+function quux (a) {}
+// Message: Missing @file
+
+/**
+ * @param a
+ */
+function quux (a) {}
+
+/**
+ * @param b
+ */
+function bar (b) {}
+// Message: Missing @file
+````
+
+The following patterns are not considered problems:
+
+````js
+/**
+ * @file
+ */
+
+/**
+ * @fileoverview
+ */
+// Settings: {"jsdoc":{"tagNamePreference":{"file":"fileoverview"}}}
+
+/**
+ * @overview
+ */
+// Settings: {"jsdoc":{"tagNamePreference":{"file":"overview"}}}
+
+/**
+ * @file Description of file
+ */
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -6197,13 +6197,15 @@ function quux () {
 <a name="eslint-plugin-jsdoc-rules-require-file-overview"></a>
 ### <code>require-file-overview</code>
 
-Requires that all files have a `@file`, `@fileoverview`, or `@overview` tag.
+Checks that:
 
-Duplicate file overview tags will be reported as will file overview tags
-which are not, as per [the docs](https://jsdoc.app/tags-file.html),
-"at the beginning of the file", where beginning of the file is interpreted
-in this rule as being when the overview tag is not preceded by
-anything other than a comment.
+1. All files have a `@file`, `@fileoverview`, or `@overview` tag.
+2. Duplicate file overview tags within a given file will be reported
+3. File overview tags will be reported which are not, as per
+  [the docs](https://jsdoc.app/tags-file.html), "at the beginning of
+  the file"–where beginning of the file is interpreted in this rule
+  as being when the overview tag is not preceded by anything other than
+  a comment.
 
 <a name="eslint-plugin-jsdoc-rules-require-file-overview-fixer-1"></a>
 #### Fixer

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import noUndefinedTypes from './rules/noUndefinedTypes';
 import requireDescriptionCompleteSentence from './rules/requireDescriptionCompleteSentence';
 import requireDescription from './rules/requireDescription';
 import requireExample from './rules/requireExample';
+import requireFileOverview from './rules/requireFileOverview';
 import requireHyphenBeforeParamDescription from './rules/requireHyphenBeforeParamDescription';
 import requireParamName from './rules/requireParamName';
 import requireParam from './rules/requireParam';
@@ -52,6 +53,7 @@ export default {
         'jsdoc/require-description': 'off',
         'jsdoc/require-description-complete-sentence': 'off',
         'jsdoc/require-example': 'off',
+        'jsdoc/require-file-overview': 'off',
         'jsdoc/require-hyphen-before-param-description': 'off',
         'jsdoc/require-jsdoc': 'warn',
         'jsdoc/require-param': 'warn',
@@ -85,6 +87,7 @@ export default {
     'require-description': requireDescription,
     'require-description-complete-sentence': requireDescriptionCompleteSentence,
     'require-example': requireExample,
+    'require-file-overview': requireFileOverview,
     'require-hyphen-before-param-description': requireHyphenBeforeParamDescription,
     'require-jsdoc': requireJsdoc,
     'require-param': requireParam,

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -520,6 +520,10 @@ const iterateAllJsdocs = (iterator, ruleConfig) => {
 
           const comment = getJSDocComment(sourceCode, node, settings);
           if (!comment || trackedJsdocs.includes(comment)) {
+            if (!comment && ruleConfig.nonComment) {
+              ruleConfig.nonComment({state});
+            }
+
             return;
           }
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -431,7 +431,7 @@ const makeReport = (context, commentNode) => {
 
 const iterate = (
   ruleConfig, context, lines, jsdocNode, node, settings,
-  sourceCode, iterator, state, exit,
+  sourceCode, iterator, state,
 ) => {
   const sourceLine = lines[jsdocNode.loc.start.line - 1];
   const indent = sourceLine.charAt(0).repeat(jsdocNode.loc.start.column);
@@ -457,7 +457,6 @@ const iterate = (
 
   iterator({
     context,
-    exit,
     indent,
     jsdoc,
     jsdocNode,

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -97,7 +97,7 @@ const getPreferredTagName = (
   mode : ParserMode,
   name : string,
   tagPreference : Object = {},
-) : string => {
+) : string|Object => {
   const prefValues = _.values(tagPreference);
   if (prefValues.includes(name) || prefValues.some((prefVal) => {
     return prefVal && typeof prefVal === 'object' && prefVal.replacement === name;

--- a/src/rules/requireFileOverview.js
+++ b/src/rules/requireFileOverview.js
@@ -1,0 +1,35 @@
+import iterateJsdoc from '../iterateJsdoc';
+
+export default iterateJsdoc(({
+  state,
+  utils,
+}) => {
+  if (state.hasFileOverview) {
+    return;
+  }
+  const targetTagName = utils.getPreferredTagName({tagName: 'file'});
+
+  // Can we somehow prevent repeating execution of this non-exiting
+  //  iterator instead of repeatedly checking the value above?
+  state.hasFileOverview = targetTagName && utils.hasTag(targetTagName);
+}, {
+  exit ({state, utils}) {
+    if (state.hasFileOverview) {
+      return;
+    }
+    const obj = utils.getPreferredTagNameObject({tagName: 'file'});
+    if (obj && obj.blocked) {
+      utils.reportSettings(
+        `\`settings.jsdoc.tagNamePreference\` cannot block @${obj.tagName} ` +
+        'for the `require-file-overview` rule',
+      );
+    } else {
+      utils.reportSettings(`Missing @${obj && obj.replacement || obj}`);
+    }
+  },
+  iterateAllJsdocs: true,
+  meta: {
+    fixable: 'code',
+    type: 'suggestion',
+  },
+});

--- a/src/rules/requireFileOverview.js
+++ b/src/rules/requireFileOverview.js
@@ -17,7 +17,9 @@ export default iterateJsdoc(({
   state.hasFileOverview = hasFileOverview;
 }, {
   exit ({state, utils}) {
-    if (state.hasFileOverview && !state.hasDuplicate) {
+    if (state.hasFileOverview && !state.hasDuplicate &&
+      !state.hasNonCommentBeforeFileOverview
+    ) {
       return;
     }
     const obj = utils.getPreferredTagNameObject({tagName: 'file'});
@@ -32,6 +34,12 @@ export default iterateJsdoc(({
         utils.reportSettings(
           `Duplicate @${targetTagName}`,
         );
+      } else if (state.hasFileOverview &&
+          state.hasNonCommentBeforeFileOverview
+      ) {
+        utils.reportSettings(
+          `@${targetTagName} should be at the beginning of the file`,
+        );
       } else {
         utils.reportSettings(`Missing @${targetTagName}`);
       }
@@ -41,5 +49,8 @@ export default iterateJsdoc(({
   meta: {
     fixable: 'code',
     type: 'suggestion',
+  },
+  nonComment ({state}) {
+    state.hasNonCommentBeforeFileOverview = !state.hasFileOverview;
   },
 });

--- a/test/rules/assertions/requireFileOverview.js
+++ b/test/rules/assertions/requireFileOverview.js
@@ -175,10 +175,33 @@ export default {
         },
       ],
     },
+    {
+      code: `
+        function quux () {
+        }
+        /**
+         * @file
+         */
+      `,
+      errors: [
+        {
+          line: 1,
+          message: '@file should be at the beginning of the file',
+        },
+      ],
+    },
   ],
   valid: [
     {
       code: `
+        /**
+         * @file
+         */
+      `,
+    },
+    {
+      code: `
+        // Ok preceded by comment
         /**
          * @file
          */

--- a/test/rules/assertions/requireFileOverview.js
+++ b/test/rules/assertions/requireFileOverview.js
@@ -1,0 +1,219 @@
+export default {
+  invalid: [
+    {
+      code: `
+      `,
+      errors: [
+        {
+          line: 1,
+          message: 'Missing @file',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       *
+       */
+      `,
+      errors: [
+        {
+          line: 1,
+          message: 'Missing @file',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       *
+       */
+      function quux () {}
+      `,
+      errors: [
+        {
+          line: 1,
+          message: 'Missing @file',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       *
+       */
+      function quux () {}
+      `,
+      errors: [
+        {
+          line: 1,
+          message: 'Missing @fileoverview',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            file: 'fileoverview',
+          },
+        },
+      },
+    },
+    {
+      code: `
+      /**
+       *
+       */
+      function quux () {}
+      `,
+      errors: [
+        {
+          line: 1,
+          message: 'Missing @overview',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            file: 'overview',
+          },
+        },
+      },
+    },
+    {
+      code: `
+      /**
+       *
+       */
+      function quux () {}
+      `,
+      errors: [
+        {
+          line: 1,
+          message: '`settings.jsdoc.tagNamePreference` cannot block @file ' +
+            'for the `require-file-overview` rule',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            file: false,
+          },
+        },
+      },
+    },
+    {
+      code: `
+      /**
+       *
+       */
+      function quux () {}
+      `,
+      errors: [
+        {
+          line: 1,
+          message: '`settings.jsdoc.tagNamePreference` cannot block @file ' +
+            'for the `require-file-overview` rule',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            file: {
+              message: 'Don\'t use file',
+            },
+          },
+        },
+      },
+    },
+    {
+      code: `
+      /**
+       * @param a
+       */
+      function quux (a) {}
+      `,
+      errors: [
+        {
+          line: 1,
+          message: 'Missing @file',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @param a
+       */
+      function quux (a) {}
+
+      /**
+       * @param b
+       */
+      function bar (b) {}
+      `,
+      errors: [
+        {
+          line: 1,
+          message: 'Missing @file',
+        },
+      ],
+    },
+  ],
+  valid: [
+    {
+      code: `
+        /**
+         * @file
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @fileoverview
+         */
+      `,
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            file: 'fileoverview',
+          },
+        },
+      },
+    },
+    {
+      code: `
+        /**
+         * @overview
+         */
+      `,
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            file: 'overview',
+          },
+        },
+      },
+    },
+    {
+      code: `
+        /**
+         * @file Description of file
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @file Description of file
+         */
+        function quux () {
+        }
+
+        /**
+         *
+         */
+      `,
+    },
+  ],
+};

--- a/test/rules/assertions/requireFileOverview.js
+++ b/test/rules/assertions/requireFileOverview.js
@@ -158,6 +158,23 @@ export default {
         },
       ],
     },
+    {
+      code: `
+        /**
+         * @file
+         */
+
+         /**
+          * @file
+          */
+      `,
+      errors: [
+        {
+          line: 1,
+          message: 'Duplicate @file',
+        },
+      ],
+    },
   ],
   valid: [
     {

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -26,6 +26,7 @@ const ruleTester = new RuleTester();
   'require-description',
   'require-description-complete-sentence',
   'require-example',
+  'require-file-overview',
   'require-hyphen-before-param-description',
   'require-jsdoc',
   'require-param',


### PR DESCRIPTION
Report when `@file` (or if stated under `settings.jsdoc.tagNamePreference` as `@overview` or `@fileoverview`) is missing, duplicated, or preceded by anything besides a comment.

Fixes #55 .