### PR TITLE
Global function checking

### DIFF
--- a/.README/rules/require-param-description.md
+++ b/.README/rules/require-param-description.md
@@ -2,6 +2,18 @@
 
 Requires that each `@param` tag has a `description` value.
 
+#### Options
+
+##### `contexts`
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied.
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|

--- a/.README/rules/require-param-description.md
+++ b/.README/rules/require-param-description.md
@@ -4,8 +4,9 @@ Requires that each `@param` tag has a `description` value.
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
+|Options|`contexts`|
 
 <!-- assertions requireParamDescription -->

--- a/.README/rules/require-param-name.md
+++ b/.README/rules/require-param-name.md
@@ -11,12 +11,12 @@ Requires that all function parameters have names.
 ##### `contexts`
 
 Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+where you wish the rule to be applied.
 Overrides the default contexts (see below). Set to `"any"` if you want
 the rule to apply to any jsdoc block throughout your files (as is necessary
 for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
 
 |||
 |---|---|

--- a/.README/rules/require-param-name.md
+++ b/.README/rules/require-param-name.md
@@ -6,10 +6,23 @@ Requires that all function parameters have names.
 >
 > [JSDoc](https://jsdoc.app/tags-param.html#overview)
 
+#### Options
+
+##### `contexts`
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
+|Options|`contexts`|
 
 <!-- assertions requireParamName -->

--- a/.README/rules/require-param-type.md
+++ b/.README/rules/require-param-type.md
@@ -2,10 +2,23 @@
 
 Requires that each `@param` tag has a `type` value.
 
+#### Options
+
+##### `contexts`
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
+|Options|`contexts`|
 
 <!-- assertions requireParamType -->

--- a/.README/rules/require-param-type.md
+++ b/.README/rules/require-param-type.md
@@ -7,12 +7,12 @@ Requires that each `@param` tag has a `type` value.
 ##### `contexts`
 
 Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+where you wish the rule to be applied.
 Overrides the default contexts (see below). Set to `"any"` if you want
 the rule to apply to any jsdoc block throughout your files (as is necessary
 for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
 
 |||
 |---|---|

--- a/.README/rules/require-returns-description.md
+++ b/.README/rules/require-returns-description.md
@@ -3,10 +3,23 @@
 Requires that the `@returns` tag has a `description` value. The error
 will not be reported if the return value is `void` or `undefined`.
 
+#### Options
+
+##### `contexts`
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`returns`|
 |Aliases|`return`|
+|Options|`contexts`|
 
 <!-- assertions requireReturnsDescription -->

--- a/.README/rules/require-returns-description.md
+++ b/.README/rules/require-returns-description.md
@@ -8,12 +8,12 @@ will not be reported if the return value is `void` or `undefined`.
 ##### `contexts`
 
 Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+where you wish the rule to be applied.
 Overrides the default contexts (see below). Set to `"any"` if you want
 the rule to apply to any jsdoc block throughout your files (as is necessary
 for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
 
 |||
 |---|---|

--- a/.README/rules/require-returns-type.md
+++ b/.README/rules/require-returns-type.md
@@ -2,10 +2,24 @@
 
 Requires that `@returns` tag has `type` value.
 
+#### Options
+
+##### `contexts`
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`returns`|
 |Aliases|`return`|
+|Options|`contexts`|
+|Options|`contexts`|
 
 <!-- assertions requireReturnsType -->

--- a/.README/rules/require-returns-type.md
+++ b/.README/rules/require-returns-type.md
@@ -7,12 +7,12 @@ Requires that `@returns` tag has `type` value.
 ##### `contexts`
 
 Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+where you wish the rule to be applied.
 Overrides the default contexts (see below). Set to `"any"` if you want
 the rule to apply to any jsdoc block throughout your files (as is necessary
 for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
 
 |||
 |---|---|

--- a/.README/rules/require-returns.md
+++ b/.README/rules/require-returns.md
@@ -18,22 +18,22 @@ Will also report if multiple `@returns` tags are present.
   functions to require return statements by setting `forceReturnsWithAsync`
   to `true` on the options object. This may be useful for flagging that there
   has been consideration of return type. Defaults to `false`.
+- `contexts` - Set this to an array of strings representing the AST context
+  where you wish the rule to be applied.
+  Overrides the default contexts (see below). Set to `"any"` if you want
+  the rule to apply to any jsdoc block throughout your files (as is necessary
+  for finding function blocks not attached to a function declaration or
+  expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+  `@method`) (including those associated with an `@interface`). This
+  rule will only apply on non-default contexts when there is such a tag
+  present and the `forceRequireReturn` option is set or if the
+  `forceReturnsWithAsync` option is set with a present `@async` tag
+  (since we are not checking against the actual `return` values in these
+  cases).
 
 ```js
 'jsdoc/require-returns': ['error', {forceReturnsWithAsync: true}]
 ```
-
-#### Options
-
-##### `contexts`
-
-Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
-Overrides the default contexts (see below). Set to `"any"` if you want
-the rule to apply to any jsdoc block throughout your files (as is necessary
-for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
 
 |||
 |---|---|

--- a/.README/rules/require-returns.md
+++ b/.README/rules/require-returns.md
@@ -23,12 +23,24 @@ Will also report if multiple `@returns` tags are present.
 'jsdoc/require-returns': ['error', {forceReturnsWithAsync: true}]
 ```
 
+#### Options
+
+##### `contexts`
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`returns`|
 |Aliases|`return`|
-|Options|`exemptedBy`, `forceRequireReturn`, `forceReturnsWithAsync`|
+|Options|`contexts`, `exemptedBy`, `forceRequireReturn`, `forceReturnsWithAsync`|
 |Settings|`overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`|
 
 <!-- assertions requireReturns -->

--- a/README.md
+++ b/README.md
@@ -7854,9 +7854,10 @@ Requires that each `@param` tag has a `description` value.
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
+|Options|`contexts`|
 
 The following patterns are considered problems:
 
@@ -7916,11 +7917,26 @@ Requires that all function parameters have names.
 >
 > [JSDoc](https://jsdoc.app/tags-param.html#overview)
 
+<a name="eslint-plugin-jsdoc-rules-require-param-name-options-17"></a>
+#### Options
+
+<a name="eslint-plugin-jsdoc-rules-require-param-name-options-17-contexts-2"></a>
+##### <code>contexts</code>
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
+|Options|`contexts`|
 
 The following patterns are considered problems:
 
@@ -7975,11 +7991,26 @@ function quux (foo) {
 
 Requires that each `@param` tag has a `type` value.
 
+<a name="eslint-plugin-jsdoc-rules-require-param-type-options-18"></a>
+#### Options
+
+<a name="eslint-plugin-jsdoc-rules-require-param-type-options-18-contexts-3"></a>
+##### <code>contexts</code>
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
+|Options|`contexts`|
 
 The following patterns are considered problems:
 
@@ -8035,7 +8066,7 @@ function quux (foo) {
 
 Requires that all function parameters are documented.
 
-<a name="eslint-plugin-jsdoc-rules-require-param-options-17"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-options-19"></a>
 #### Options
 
 An options object accepts one optional property:
@@ -9279,11 +9310,26 @@ function quux () {
 Requires that the `@returns` tag has a `description` value. The error
 will not be reported if the return value is `void` or `undefined`.
 
+<a name="eslint-plugin-jsdoc-rules-require-returns-description-options-20"></a>
+#### Options
+
+<a name="eslint-plugin-jsdoc-rules-require-returns-description-options-20-contexts-4"></a>
+##### <code>contexts</code>
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`returns`|
 |Aliases|`return`|
+|Options|`contexts`|
 
 The following patterns are considered problems:
 
@@ -9361,11 +9407,27 @@ function quux () {
 
 Requires that `@returns` tag has `type` value.
 
+<a name="eslint-plugin-jsdoc-rules-require-returns-type-options-21"></a>
+#### Options
+
+<a name="eslint-plugin-jsdoc-rules-require-returns-type-options-21-contexts-5"></a>
+##### <code>contexts</code>
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`returns`|
 |Aliases|`return`|
+|Options|`contexts`|
+|Options|`contexts`|
 
 The following patterns are considered problems:
 
@@ -9424,7 +9486,7 @@ Requires returns are documented.
 
 Will also report if multiple `@returns` tags are present.
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-options-18"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-options-22"></a>
 #### Options
 
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
@@ -9444,12 +9506,26 @@ Will also report if multiple `@returns` tags are present.
 'jsdoc/require-returns': ['error', {forceReturnsWithAsync: true}]
 ```
 
+<a name="eslint-plugin-jsdoc-rules-require-returns-options-23"></a>
+#### Options
+
+<a name="eslint-plugin-jsdoc-rules-require-returns-options-23-contexts-6"></a>
+##### <code>contexts</code>
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`returns`|
 |Aliases|`return`|
-|Options|`exemptedBy`, `forceRequireReturn`, `forceReturnsWithAsync`|
+|Options|`contexts`, `exemptedBy`, `forceRequireReturn`, `forceReturnsWithAsync`|
 |Settings|`overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`|
 
 The following patterns are considered problems:
@@ -9926,7 +10002,7 @@ Also impacts behaviors on namepath (or event)-defining and pointing tags:
    allow `#`, `.`, or `~` at the end (which is not allowed at the end of
    normal paths).
 
-<a name="eslint-plugin-jsdoc-rules-valid-types-options-19"></a>
+<a name="eslint-plugin-jsdoc-rules-valid-types-options-24"></a>
 #### Options
 
 - `allowEmptyNamepaths` (default: true) - Set to `false` to disallow

--- a/README.md
+++ b/README.md
@@ -7852,6 +7852,20 @@ export default class Foo {
 
 Requires that each `@param` tag has a `description` value.
 
+<a name="eslint-plugin-jsdoc-rules-require-param-description-options-17"></a>
+#### Options
+
+<a name="eslint-plugin-jsdoc-rules-require-param-description-options-17-contexts-2"></a>
+##### <code>contexts</code>
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied.
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
@@ -7917,19 +7931,19 @@ Requires that all function parameters have names.
 >
 > [JSDoc](https://jsdoc.app/tags-param.html#overview)
 
-<a name="eslint-plugin-jsdoc-rules-require-param-name-options-17"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-name-options-18"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-param-name-options-17-contexts-2"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-name-options-18-contexts-3"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+where you wish the rule to be applied.
 Overrides the default contexts (see below). Set to `"any"` if you want
 the rule to apply to any jsdoc block throughout your files (as is necessary
 for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
 
 |||
 |---|---|
@@ -7991,19 +8005,19 @@ function quux (foo) {
 
 Requires that each `@param` tag has a `type` value.
 
-<a name="eslint-plugin-jsdoc-rules-require-param-type-options-18"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-type-options-19"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-param-type-options-18-contexts-3"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-type-options-19-contexts-4"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+where you wish the rule to be applied.
 Overrides the default contexts (see below). Set to `"any"` if you want
 the rule to apply to any jsdoc block throughout your files (as is necessary
 for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
 
 |||
 |---|---|
@@ -8066,7 +8080,7 @@ function quux (foo) {
 
 Requires that all function parameters are documented.
 
-<a name="eslint-plugin-jsdoc-rules-require-param-options-19"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-options-20"></a>
 #### Options
 
 An options object accepts one optional property:
@@ -9310,19 +9324,19 @@ function quux () {
 Requires that the `@returns` tag has a `description` value. The error
 will not be reported if the return value is `void` or `undefined`.
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-description-options-20"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-description-options-21"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-description-options-20-contexts-4"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-description-options-21-contexts-5"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+where you wish the rule to be applied.
 Overrides the default contexts (see below). Set to `"any"` if you want
 the rule to apply to any jsdoc block throughout your files (as is necessary
 for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
 
 |||
 |---|---|
@@ -9407,19 +9421,19 @@ function quux () {
 
 Requires that `@returns` tag has `type` value.
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-type-options-21"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-type-options-22"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-type-options-21-contexts-5"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-type-options-22-contexts-6"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+where you wish the rule to be applied.
 Overrides the default contexts (see below). Set to `"any"` if you want
 the rule to apply to any jsdoc block throughout your files (as is necessary
 for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
 
 |||
 |---|---|
@@ -9486,7 +9500,7 @@ Requires returns are documented.
 
 Will also report if multiple `@returns` tags are present.
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-options-22"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-options-23"></a>
 #### Options
 
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
@@ -9501,24 +9515,22 @@ Will also report if multiple `@returns` tags are present.
   functions to require return statements by setting `forceReturnsWithAsync`
   to `true` on the options object. This may be useful for flagging that there
   has been consideration of return type. Defaults to `false`.
+- `contexts` - Set this to an array of strings representing the AST context
+  where you wish the rule to be applied.
+  Overrides the default contexts (see below). Set to `"any"` if you want
+  the rule to apply to any jsdoc block throughout your files (as is necessary
+  for finding function blocks not attached to a function declaration or
+  expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+  `@method`) (including those associated with an `@interface`). This
+  rule will only apply on non-default contexts when there is such a tag
+  present and the `forceRequireReturn` option is set or if the
+  `forceReturnsWithAsync` option is set with a present `@async` tag
+  (since we are not checking against the actual `return` values in these
+  cases).
 
 ```js
 'jsdoc/require-returns': ['error', {forceReturnsWithAsync: true}]
 ```
-
-<a name="eslint-plugin-jsdoc-rules-require-returns-options-23"></a>
-#### Options
-
-<a name="eslint-plugin-jsdoc-rules-require-returns-options-23-contexts-6"></a>
-##### <code>contexts</code>
-
-Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
-Overrides the default contexts (see below). Set to `"any"` if you want
-the rule to apply to any jsdoc block throughout your files (as is necessary
-for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
 
 |||
 |---|---|

--- a/README.md
+++ b/README.md
@@ -7885,6 +7885,29 @@ function quux (foo) {
 // Message: Missing JSDoc @param "foo" description.
 
 /**
+ * @param foo
+ */
+function quux (foo) {
+
+}
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @param "foo" description.
+
+/**
+ * @function
+ * @param foo
+ */
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @param "foo" description.
+
+/**
+ * @callback
+ * @param foo
+ */
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @param "foo" description.
+
+/**
  * @arg foo
  */
 function quux (foo) {
@@ -7919,6 +7942,24 @@ function quux (foo) {
 function quux (foo) {
 
 }
+
+/**
+ * @param foo Foo.
+ */
+function quux (foo) {
+
+}
+// Options: [{"contexts":["any"]}]
+
+/**
+ * @function
+ * @param foo
+ */
+
+/**
+ * @callback
+ * @param foo
+ */
 ````
 
 
@@ -7972,6 +8013,29 @@ function quux (foo) {
 // Message: There must be an identifier after @param tag.
 
 /**
+ * @param {string}
+ */
+function quux (foo) {
+
+}
+// Options: [{"contexts":["any"]}]
+// Message: There must be an identifier after @param tag.
+
+/**
+ * @function
+ * @param {string}
+ */
+// Options: [{"contexts":["any"]}]
+// Message: There must be an identifier after @param tag.
+
+/**
+ * @callback
+ * @param {string}
+ */
+// Options: [{"contexts":["any"]}]
+// Message: There must be an identifier after @param tag.
+
+/**
  * @param foo
  */
 function quux (foo) {
@@ -7992,11 +8056,29 @@ function quux (foo) {
 }
 
 /**
+ * @param foo
+ */
+function quux (foo) {
+
+}
+// Options: [{"contexts":["any"]}]
+
+/**
  * @param {string} foo
  */
 function quux (foo) {
 
 }
+
+/**
+ * @function
+ * @param
+ */
+
+/**
+ * @callback
+ * @param
+ */
 ````
 
 
@@ -8038,6 +8120,29 @@ function quux (foo) {
 // Message: Missing JSDoc @param "foo" type.
 
 /**
+ * @param foo
+ */
+function quux (foo) {
+
+}
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @param "foo" type.
+
+/**
+ * @function
+ * @param foo
+ */
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @param "foo" type.
+
+/**
+ * @callback
+ * @param foo
+ */
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @param "foo" type.
+
+/**
  * @arg foo
  */
 function quux (foo) {
@@ -8072,6 +8177,24 @@ function quux (foo) {
 function quux (foo) {
 
 }
+
+/**
+ * @param {number} foo
+ */
+function quux (foo) {
+
+}
+// Options: [{"contexts":["any"]}]
+
+/**
+ * @function
+ * @param foo
+ */
+
+/**
+ * @callback
+ * @param foo
+ */
 ````
 
 
@@ -9365,6 +9488,29 @@ function quux (foo) {
 // Message: Missing JSDoc @returns description.
 
 /**
+ * @returns {string}
+ */
+function quux (foo) {
+
+}
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @returns description.
+
+/**
+ * @function
+ * @returns {string}
+ */
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @returns description.
+
+/**
+ * @callback
+ * @returns {string}
+ */
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @returns description.
+
+/**
  * @return
  */
 function quux (foo) {
@@ -9401,6 +9547,14 @@ function quux () {
 }
 
 /**
+ * @returns Foo.
+ */
+function quux () {
+
+}
+// Options: [{"contexts":["any"]}]
+
+/**
  * @returns {undefined}
  */
 function quux () {
@@ -9413,6 +9567,16 @@ function quux () {
 function quux () {
 
 }
+
+/**
+ * @function
+ * @returns
+ */
+
+/**
+ * @callback
+ * @returns
+ */
 ````
 
 
@@ -9463,6 +9627,29 @@ function quux () {
 // Message: Missing JSDoc @returns type.
 
 /**
+ * @returns Foo.
+ */
+function quux () {
+
+}
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @returns type.
+
+/**
+ * @function
+ * @returns Foo.
+ */
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @returns type.
+
+/**
+ * @callback
+ * @returns Foo.
+ */
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @returns type.
+
+/**
  * @return Foo.
  */
 function quux () {
@@ -9490,6 +9677,24 @@ The following patterns are not considered problems:
 function quux () {
 
 }
+
+/**
+ * @returns {number}
+ */
+function quux () {
+
+}
+// Options: [{"contexts":["any"]}]
+
+/**
+ * @function
+ * @returns Foo.
+ */
+
+/**
+ * @callback
+ * @returns Foo.
+ */
 ````
 
 
@@ -9631,6 +9836,26 @@ function quux () {
 // Options: [{"forceRequireReturn":true}]
 // Message: Missing JSDoc @returns declaration.
 
+/**
+ *
+ */
+function quux () {
+}
+// Options: [{"contexts":["any"],"forceRequireReturn":true}]
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ * @function
+ */
+// Options: [{"contexts":["any"],"forceRequireReturn":true}]
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ * @callback
+ */
+// Options: [{"contexts":["any"],"forceRequireReturn":true}]
+// Message: Missing JSDoc @returns declaration.
+
 const language = {
   /**
    * @param {string} name
@@ -9647,6 +9872,20 @@ const language = {
 async function quux () {
 }
 // Options: [{"forceReturnsWithAsync":true}]
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ * @function
+ * @async
+ */
+// Options: [{"contexts":["any"],"forceReturnsWithAsync":true}]
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ * @callback
+ * @async
+ */
+// Options: [{"contexts":["any"],"forceReturnsWithAsync":true}]
 // Message: Missing JSDoc @returns declaration.
 
 /**
@@ -9706,6 +9945,15 @@ function quux () {
 
   return foo;
 }
+
+/**
+ * @returns Foo.
+ */
+function quux () {
+
+  return foo;
+}
+// Options: [{"contexts":["any"]}]
 
 /**
  *
@@ -9976,6 +10224,48 @@ async function foo(a) {
 async function foo(a) {
   return;
 }
+
+/**
+ *
+ */
+// Options: [{"contexts":["any"]}]
+
+/**
+ * @async
+ */
+// Options: [{"contexts":["any"]}]
+
+/**
+ * @function
+ */
+// Options: [{"forceRequireReturn":true}]
+
+/**
+ * @callback
+ */
+// Options: [{"forceRequireReturn":true}]
+
+/**
+ * @function
+ * @async
+ */
+// Options: [{"forceReturnsWithAsync":true}]
+
+/**
+ * @callback
+ * @async
+ */
+// Options: [{"forceReturnsWithAsync":true}]
+
+/**
+ * @function
+ */
+// Options: [{"contexts":["any"],"forceReturnsWithAsync":true}]
+
+/**
+ * @callback
+ */
+// Options: [{"contexts":["any"],"forceReturnsWithAsync":true}]
 ````
 
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -431,7 +431,7 @@ const makeReport = (context, commentNode) => {
 
 const iterate = (
   ruleConfig, context, lines, jsdocNode, node, settings,
-  sourceCode, iterator, state,
+  sourceCode, iterator, state, iteratingAll,
 ) => {
   const sourceLine = lines[jsdocNode.loc.start.line - 1];
   const indent = sourceLine.charAt(0).repeat(jsdocNode.loc.start.column);
@@ -462,6 +462,7 @@ const iterate = (
   iterator({
     context,
     indent,
+    iteratingAll,
     jsdoc,
     jsdocNode,
     node,
@@ -496,7 +497,7 @@ const iterateAllJsdocs = (iterator, ruleConfig) => {
       iterate(
         ruleConfig, context, lines, jsdocNode, node,
         settings, sourceCode, iterator,
-        state,
+        state, true,
       );
     });
     if (lastCall && ruleConfig.exit) {

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -147,11 +147,11 @@ const getUtils = (
   };
 
   utils.isConstructor = () => {
-    return node.parent && node.parent.kind === 'constructor';
+    return node && node.parent && node.parent.kind === 'constructor';
   };
 
   utils.isSetter = () => {
-    return node.parent.kind === 'set';
+    return node && node.parent.kind === 'set';
   };
 
   utils.getJsdocNamesDeep = (tagName) => {

--- a/src/rules/requireParamDescription.js
+++ b/src/rules/requireParamDescription.js
@@ -14,7 +14,22 @@ export default iterateJsdoc(({
     }
   });
 }, {
+  contextDefaults: true,
   meta: {
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          contexts: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
     type: 'suggestion',
   },
 });

--- a/src/rules/requireParamName.js
+++ b/src/rules/requireParamName.js
@@ -14,7 +14,22 @@ export default iterateJsdoc(({
     }
   });
 }, {
+  contextDefaults: true,
   meta: {
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          contexts: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
     type: 'suggestion',
   },
 });

--- a/src/rules/requireParamType.js
+++ b/src/rules/requireParamType.js
@@ -14,7 +14,22 @@ export default iterateJsdoc(({
     }
   });
 }, {
+  contextDefaults: true,
   meta: {
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          contexts: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
     type: 'suggestion',
   },
 });

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -75,7 +75,7 @@ export default iterateJsdoc(({
     'ArrowFunctionExpression',
     'FunctionDeclaration',
     'FunctionExpression',
-  ].includes(node.type);
+  ].includes(node && node.type);
 
   // In case the code returns something, we expect a return value in JSDoc.
   const [tag] = tags;
@@ -93,7 +93,7 @@ export default iterateJsdoc(({
     }
 
     const isAsync = !iteratingFunction && utils.hasTag('async') ||
-      iteratingFunction && (utils.hasTag('async') || utils.isAsync());
+      iteratingFunction && utils.isAsync();
 
     if (forceReturnsWithAsync && isAsync) {
       return true;

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -95,11 +95,18 @@ export default iterateJsdoc(({
     report(`Missing JSDoc @${tagName} declaration.`);
   }
 }, {
+  contextDefaults: true,
   meta: {
     schema: [
       {
         additionalProperties: false,
         properties: {
+          contexts: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
           exemptedBy: {
             items: {
               type: 'string',

--- a/src/rules/requireReturnsDescription.js
+++ b/src/rules/requireReturnsDescription.js
@@ -16,7 +16,22 @@ export default iterateJsdoc(({
     }
   });
 }, {
+  contextDefaults: true,
   meta: {
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          contexts: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
     type: 'suggestion',
   },
 });

--- a/src/rules/requireReturnsType.js
+++ b/src/rules/requireReturnsType.js
@@ -10,7 +10,22 @@ export default iterateJsdoc(({
     }
   });
 }, {
+  contextDefaults: true,
   meta: {
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          contexts: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
     type: 'suggestion',
   },
 });

--- a/test/rules/assertions/requireParamDescription.js
+++ b/test/rules/assertions/requireParamDescription.js
@@ -19,6 +19,59 @@ export default {
     {
       code: `
           /**
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing JSDoc @param "foo" description.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @param foo
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Missing JSDoc @param "foo" description.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @param foo
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Missing JSDoc @param "foo" description.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
            * @arg foo
            */
           function quux (foo) {
@@ -82,6 +135,37 @@ export default {
           function quux (foo) {
 
           }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @param foo Foo.
+           */
+          function quux (foo) {
+
+          }
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @param foo
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @param foo
+           */
       `,
     },
   ],

--- a/test/rules/assertions/requireParamName.js
+++ b/test/rules/assertions/requireParamName.js
@@ -35,6 +35,59 @@ export default {
     {
       code: `
           /**
+           * @param {string}
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'There must be an identifier after @param tag.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @param {string}
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'There must be an identifier after @param tag.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @param {string}
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'There must be an identifier after @param tag.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
            * @param foo
            */
           function quux (foo) {
@@ -70,11 +123,42 @@ export default {
     {
       code: `
           /**
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
            * @param {string} foo
            */
           function quux (foo) {
 
           }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @param
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @param
+           */
       `,
     },
   ],

--- a/test/rules/assertions/requireParamType.js
+++ b/test/rules/assertions/requireParamType.js
@@ -19,6 +19,59 @@ export default {
     {
       code: `
           /**
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing JSDoc @param "foo" type.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @param foo
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Missing JSDoc @param "foo" type.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @param foo
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Missing JSDoc @param "foo" type.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
            * @arg foo
            */
           function quux (foo) {
@@ -82,6 +135,35 @@ export default {
           function quux (foo) {
 
           }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @param {number} foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @param foo
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @param foo
+           */
       `,
     },
   ],

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -209,6 +209,59 @@ export default {
     },
     {
       code: `
+          /**
+           *
+           */
+          function quux () {
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+        forceRequireReturn: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @function
+           */
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+        forceRequireReturn: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           */
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+        forceRequireReturn: true,
+      }],
+    },
+    {
+      code: `
       const language = {
         /**
          * @param {string} name
@@ -245,6 +298,42 @@ export default {
       parserOptions: {
         ecmaVersion: 8,
       },
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @async
+           */
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+        forceReturnsWithAsync: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @async
+           */
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+        forceReturnsWithAsync: true,
+      }],
     },
     {
       code: `
@@ -363,6 +452,22 @@ export default {
             return foo;
           }
       `,
+    },
+    {
+      code: `
+          /**
+           * @returns Foo.
+           */
+          function quux () {
+
+            return foo;
+          }
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
     },
     {
       code: `
@@ -794,6 +899,94 @@ export default {
       parserOptions: {
         ecmaVersion: 8,
       },
+    },
+    {
+      code: `
+          /**
+           *
+           */
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @async
+           */
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @function
+           */
+      `,
+      options: [{
+        forceRequireReturn: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           */
+      `,
+      options: [{
+        forceRequireReturn: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @async
+           */
+      `,
+      options: [{
+        forceReturnsWithAsync: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @async
+           */
+      `,
+      options: [{
+        forceReturnsWithAsync: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @function
+           */
+      `,
+      options: [{
+        contexts: ['any'],
+        forceReturnsWithAsync: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           */
+      `,
+      options: [{
+        contexts: ['any'],
+        forceReturnsWithAsync: true,
+      }],
     },
   ],
 };

--- a/test/rules/assertions/requireReturnsDescription.js
+++ b/test/rules/assertions/requireReturnsDescription.js
@@ -35,6 +35,65 @@ export default {
     {
       code: `
           /**
+           * @returns {string}
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing JSDoc @returns description.',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @returns {string}
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Missing JSDoc @returns description.',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @returns {string}
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Missing JSDoc @returns description.',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
            * @return
            */
           function quux (foo) {
@@ -102,6 +161,21 @@ export default {
     {
       code: `
           /**
+           * @returns Foo.
+           */
+          function quux () {
+
+          }
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
            * @returns {undefined}
            */
           function quux () {
@@ -117,6 +191,22 @@ export default {
           function quux () {
 
           }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @returns
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @returns
+           */
       `,
     },
   ],

--- a/test/rules/assertions/requireReturnsType.js
+++ b/test/rules/assertions/requireReturnsType.js
@@ -35,6 +35,65 @@ export default {
     {
       code: `
           /**
+           * @returns Foo.
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing JSDoc @returns type.',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @returns Foo.
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Missing JSDoc @returns type.',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @returns Foo.
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Missing JSDoc @returns type.',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
            * @return Foo.
            */
           function quux () {
@@ -87,6 +146,37 @@ export default {
           function quux () {
 
           }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @returns {number}
+           */
+          function quux () {
+
+          }
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @returns Foo.
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @returns Foo.
+           */
       `,
     },
   ],


### PR DESCRIPTION
Builds on #459, #462, and #464 (depends on some refactoring), so probably easier to review those first.

feat(`require-param-*`, `require-returns-*`, `require-returns`): allows `contexts` option to be set to "any" to check virtual function docs like `@callback` or `@function` with `@interface`; fixes #406

(Since it allows `contexts`, whose behavior in other functions is to override, if a project does not wish docs on all function types, they can now do so as well.)
