### PR TITLE
Global function checking `no-types` and `implements-on-classes`

### DIFF
--- a/.README/rules/implements-on-classes.md
+++ b/.README/rules/implements-on-classes.md
@@ -9,9 +9,21 @@ To indicate that a function follows another function's signature, one might
 instead use `@type` to indicate the `@function` or `@callback` to which the
 funciton is adhering.
 
+#### Options
+
+##### `contexts`
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied.
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`implements` (prevented)|
 
 <!-- assertions implementsOnClasses -->

--- a/.README/rules/no-types.md
+++ b/.README/rules/no-types.md
@@ -5,9 +5,21 @@ This rule reports types being used on `@param` or `@returns`.
 The rule is intended to prevent the indication of types on tags where
 the type information would be redundant with TypeScript.
 
+#### Options
+
+##### `contexts`
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied.
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`param`, `returns`|
 |Aliases|`arg`, `argument`, `return`|
 

--- a/.README/rules/require-param-description.md
+++ b/.README/rules/require-param-description.md
@@ -2,6 +2,18 @@
 
 Requires that each `@param` tag has a `description` value.
 
+#### Options
+
+##### `contexts`
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied.
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|

--- a/.README/rules/require-param-description.md
+++ b/.README/rules/require-param-description.md
@@ -4,8 +4,9 @@ Requires that each `@param` tag has a `description` value.
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
+|Options|`contexts`|
 
 <!-- assertions requireParamDescription -->

--- a/.README/rules/require-param-name.md
+++ b/.README/rules/require-param-name.md
@@ -11,12 +11,12 @@ Requires that all function parameters have names.
 ##### `contexts`
 
 Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+where you wish the rule to be applied.
 Overrides the default contexts (see below). Set to `"any"` if you want
 the rule to apply to any jsdoc block throughout your files (as is necessary
 for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
 
 |||
 |---|---|

--- a/.README/rules/require-param-name.md
+++ b/.README/rules/require-param-name.md
@@ -6,10 +6,23 @@ Requires that all function parameters have names.
 >
 > [JSDoc](https://jsdoc.app/tags-param.html#overview)
 
+#### Options
+
+##### `contexts`
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
+|Options|`contexts`|
 
 <!-- assertions requireParamName -->

--- a/.README/rules/require-param-type.md
+++ b/.README/rules/require-param-type.md
@@ -2,10 +2,23 @@
 
 Requires that each `@param` tag has a `type` value.
 
+#### Options
+
+##### `contexts`
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
+|Options|`contexts`|
 
 <!-- assertions requireParamType -->

--- a/.README/rules/require-param-type.md
+++ b/.README/rules/require-param-type.md
@@ -7,12 +7,12 @@ Requires that each `@param` tag has a `type` value.
 ##### `contexts`
 
 Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+where you wish the rule to be applied.
 Overrides the default contexts (see below). Set to `"any"` if you want
 the rule to apply to any jsdoc block throughout your files (as is necessary
 for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
 
 |||
 |---|---|

--- a/.README/rules/require-returns-description.md
+++ b/.README/rules/require-returns-description.md
@@ -3,10 +3,23 @@
 Requires that the `@returns` tag has a `description` value. The error
 will not be reported if the return value is `void` or `undefined`.
 
+#### Options
+
+##### `contexts`
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`returns`|
 |Aliases|`return`|
+|Options|`contexts`|
 
 <!-- assertions requireReturnsDescription -->

--- a/.README/rules/require-returns-description.md
+++ b/.README/rules/require-returns-description.md
@@ -8,12 +8,12 @@ will not be reported if the return value is `void` or `undefined`.
 ##### `contexts`
 
 Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+where you wish the rule to be applied.
 Overrides the default contexts (see below). Set to `"any"` if you want
 the rule to apply to any jsdoc block throughout your files (as is necessary
 for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
 
 |||
 |---|---|

--- a/.README/rules/require-returns-type.md
+++ b/.README/rules/require-returns-type.md
@@ -2,10 +2,24 @@
 
 Requires that `@returns` tag has `type` value.
 
+#### Options
+
+##### `contexts`
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`returns`|
 |Aliases|`return`|
+|Options|`contexts`|
+|Options|`contexts`|
 
 <!-- assertions requireReturnsType -->

--- a/.README/rules/require-returns-type.md
+++ b/.README/rules/require-returns-type.md
@@ -7,12 +7,12 @@ Requires that `@returns` tag has `type` value.
 ##### `contexts`
 
 Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+where you wish the rule to be applied.
 Overrides the default contexts (see below). Set to `"any"` if you want
 the rule to apply to any jsdoc block throughout your files (as is necessary
 for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
 
 |||
 |---|---|

--- a/.README/rules/require-returns.md
+++ b/.README/rules/require-returns.md
@@ -18,22 +18,22 @@ Will also report if multiple `@returns` tags are present.
   functions to require return statements by setting `forceReturnsWithAsync`
   to `true` on the options object. This may be useful for flagging that there
   has been consideration of return type. Defaults to `false`.
+- `contexts` - Set this to an array of strings representing the AST context
+  where you wish the rule to be applied.
+  Overrides the default contexts (see below). Set to `"any"` if you want
+  the rule to apply to any jsdoc block throughout your files (as is necessary
+  for finding function blocks not attached to a function declaration or
+  expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+  `@method`) (including those associated with an `@interface`). This
+  rule will only apply on non-default contexts when there is such a tag
+  present and the `forceRequireReturn` option is set or if the
+  `forceReturnsWithAsync` option is set with a present `@async` tag
+  (since we are not checking against the actual `return` values in these
+  cases).
 
 ```js
 'jsdoc/require-returns': ['error', {forceReturnsWithAsync: true}]
 ```
-
-#### Options
-
-##### `contexts`
-
-Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
-Overrides the default contexts (see below). Set to `"any"` if you want
-the rule to apply to any jsdoc block throughout your files (as is necessary
-for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
 
 |||
 |---|---|

--- a/.README/rules/require-returns.md
+++ b/.README/rules/require-returns.md
@@ -23,12 +23,24 @@ Will also report if multiple `@returns` tags are present.
 'jsdoc/require-returns': ['error', {forceReturnsWithAsync: true}]
 ```
 
+#### Options
+
+##### `contexts`
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`returns`|
 |Aliases|`return`|
-|Options|`exemptedBy`, `forceRequireReturn`, `forceReturnsWithAsync`|
+|Options|`contexts`, `exemptedBy`, `forceRequireReturn`, `forceReturnsWithAsync`|
 |Settings|`overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`|
 
 <!-- assertions requireReturns -->

--- a/README.md
+++ b/README.md
@@ -7854,9 +7854,10 @@ Requires that each `@param` tag has a `description` value.
 
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
+|Options|`contexts`|
 
 The following patterns are considered problems:
 
@@ -7916,11 +7917,26 @@ Requires that all function parameters have names.
 >
 > [JSDoc](https://jsdoc.app/tags-param.html#overview)
 
+<a name="eslint-plugin-jsdoc-rules-require-param-name-options-17"></a>
+#### Options
+
+<a name="eslint-plugin-jsdoc-rules-require-param-name-options-17-contexts-2"></a>
+##### <code>contexts</code>
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
+|Options|`contexts`|
 
 The following patterns are considered problems:
 
@@ -7975,11 +7991,26 @@ function quux (foo) {
 
 Requires that each `@param` tag has a `type` value.
 
+<a name="eslint-plugin-jsdoc-rules-require-param-type-options-18"></a>
+#### Options
+
+<a name="eslint-plugin-jsdoc-rules-require-param-type-options-18-contexts-3"></a>
+##### <code>contexts</code>
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
+|Options|`contexts`|
 
 The following patterns are considered problems:
 
@@ -8035,7 +8066,7 @@ function quux (foo) {
 
 Requires that all function parameters are documented.
 
-<a name="eslint-plugin-jsdoc-rules-require-param-options-17"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-options-19"></a>
 #### Options
 
 An options object accepts one optional property:
@@ -9279,11 +9310,26 @@ function quux () {
 Requires that the `@returns` tag has a `description` value. The error
 will not be reported if the return value is `void` or `undefined`.
 
+<a name="eslint-plugin-jsdoc-rules-require-returns-description-options-20"></a>
+#### Options
+
+<a name="eslint-plugin-jsdoc-rules-require-returns-description-options-20-contexts-4"></a>
+##### <code>contexts</code>
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`returns`|
 |Aliases|`return`|
+|Options|`contexts`|
 
 The following patterns are considered problems:
 
@@ -9361,11 +9407,27 @@ function quux () {
 
 Requires that `@returns` tag has `type` value.
 
+<a name="eslint-plugin-jsdoc-rules-require-returns-type-options-21"></a>
+#### Options
+
+<a name="eslint-plugin-jsdoc-rules-require-returns-type-options-21-contexts-5"></a>
+##### <code>contexts</code>
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`returns`|
 |Aliases|`return`|
+|Options|`contexts`|
+|Options|`contexts`|
 
 The following patterns are considered problems:
 
@@ -9424,7 +9486,7 @@ Requires returns are documented.
 
 Will also report if multiple `@returns` tags are present.
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-options-18"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-options-22"></a>
 #### Options
 
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
@@ -9444,12 +9506,26 @@ Will also report if multiple `@returns` tags are present.
 'jsdoc/require-returns': ['error', {forceReturnsWithAsync: true}]
 ```
 
+<a name="eslint-plugin-jsdoc-rules-require-returns-options-23"></a>
+#### Options
+
+<a name="eslint-plugin-jsdoc-rules-require-returns-options-23-contexts-6"></a>
+##### <code>contexts</code>
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression such as `@callback` or `@function` (including those associated
+with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`returns`|
 |Aliases|`return`|
-|Options|`exemptedBy`, `forceRequireReturn`, `forceReturnsWithAsync`|
+|Options|`contexts`, `exemptedBy`, `forceRequireReturn`, `forceReturnsWithAsync`|
 |Settings|`overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`|
 
 The following patterns are considered problems:
@@ -9926,7 +10002,7 @@ Also impacts behaviors on namepath (or event)-defining and pointing tags:
    allow `#`, `.`, or `~` at the end (which is not allowed at the end of
    normal paths).
 
-<a name="eslint-plugin-jsdoc-rules-valid-types-options-19"></a>
+<a name="eslint-plugin-jsdoc-rules-valid-types-options-24"></a>
 #### Options
 
 - `allowEmptyNamepaths` (default: true) - Set to `false` to disallow

--- a/README.md
+++ b/README.md
@@ -7852,6 +7852,20 @@ export default class Foo {
 
 Requires that each `@param` tag has a `description` value.
 
+<a name="eslint-plugin-jsdoc-rules-require-param-description-options-17"></a>
+#### Options
+
+<a name="eslint-plugin-jsdoc-rules-require-param-description-options-17-contexts-2"></a>
+##### <code>contexts</code>
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied.
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
@@ -7917,19 +7931,19 @@ Requires that all function parameters have names.
 >
 > [JSDoc](https://jsdoc.app/tags-param.html#overview)
 
-<a name="eslint-plugin-jsdoc-rules-require-param-name-options-17"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-name-options-18"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-param-name-options-17-contexts-2"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-name-options-18-contexts-3"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+where you wish the rule to be applied.
 Overrides the default contexts (see below). Set to `"any"` if you want
 the rule to apply to any jsdoc block throughout your files (as is necessary
 for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
 
 |||
 |---|---|
@@ -7991,19 +8005,19 @@ function quux (foo) {
 
 Requires that each `@param` tag has a `type` value.
 
-<a name="eslint-plugin-jsdoc-rules-require-param-type-options-18"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-type-options-19"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-param-type-options-18-contexts-3"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-type-options-19-contexts-4"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+where you wish the rule to be applied.
 Overrides the default contexts (see below). Set to `"any"` if you want
 the rule to apply to any jsdoc block throughout your files (as is necessary
 for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
 
 |||
 |---|---|
@@ -8066,7 +8080,7 @@ function quux (foo) {
 
 Requires that all function parameters are documented.
 
-<a name="eslint-plugin-jsdoc-rules-require-param-options-19"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-options-20"></a>
 #### Options
 
 An options object accepts one optional property:
@@ -9310,19 +9324,19 @@ function quux () {
 Requires that the `@returns` tag has a `description` value. The error
 will not be reported if the return value is `void` or `undefined`.
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-description-options-20"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-description-options-21"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-description-options-20-contexts-4"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-description-options-21-contexts-5"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+where you wish the rule to be applied.
 Overrides the default contexts (see below). Set to `"any"` if you want
 the rule to apply to any jsdoc block throughout your files (as is necessary
 for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
 
 |||
 |---|---|
@@ -9407,19 +9421,19 @@ function quux () {
 
 Requires that `@returns` tag has `type` value.
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-type-options-21"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-type-options-22"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-type-options-21-contexts-5"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-type-options-22-contexts-6"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
+where you wish the rule to be applied.
 Overrides the default contexts (see below). Set to `"any"` if you want
 the rule to apply to any jsdoc block throughout your files (as is necessary
 for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
 
 |||
 |---|---|
@@ -9486,7 +9500,7 @@ Requires returns are documented.
 
 Will also report if multiple `@returns` tags are present.
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-options-22"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-options-23"></a>
 #### Options
 
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
@@ -9501,24 +9515,22 @@ Will also report if multiple `@returns` tags are present.
   functions to require return statements by setting `forceReturnsWithAsync`
   to `true` on the options object. This may be useful for flagging that there
   has been consideration of return type. Defaults to `false`.
+- `contexts` - Set this to an array of strings representing the AST context
+  where you wish the rule to be applied.
+  Overrides the default contexts (see below). Set to `"any"` if you want
+  the rule to apply to any jsdoc block throughout your files (as is necessary
+  for finding function blocks not attached to a function declaration or
+  expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+  `@method`) (including those associated with an `@interface`). This
+  rule will only apply on non-default contexts when there is such a tag
+  present and the `forceRequireReturn` option is set or if the
+  `forceReturnsWithAsync` option is set with a present `@async` tag
+  (since we are not checking against the actual `return` values in these
+  cases).
 
 ```js
 'jsdoc/require-returns': ['error', {forceReturnsWithAsync: true}]
 ```
-
-<a name="eslint-plugin-jsdoc-rules-require-returns-options-23"></a>
-#### Options
-
-<a name="eslint-plugin-jsdoc-rules-require-returns-options-23-contexts-6"></a>
-##### <code>contexts</code>
-
-Set this to an array of strings representing the AST context
-where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes).
-Overrides the default contexts (see below). Set to `"any"` if you want
-the rule to apply to any jsdoc block throughout your files (as is necessary
-for finding function blocks not attached to a function declaration or
-expression such as `@callback` or `@function` (including those associated
-with an `@interface`).
 
 |||
 |---|---|

--- a/README.md
+++ b/README.md
@@ -3911,9 +3911,23 @@ To indicate that a function follows another function's signature, one might
 instead use `@type` to indicate the `@function` or `@callback` to which the
 funciton is adhering.
 
+<a name="eslint-plugin-jsdoc-rules-implements-on-classes-options-9"></a>
+#### Options
+
+<a name="eslint-plugin-jsdoc-rules-implements-on-classes-options-9-contexts"></a>
+##### <code>contexts</code>
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied.
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`implements` (prevented)|
 
 The following patterns are considered problems:
@@ -3925,6 +3939,32 @@ The following patterns are considered problems:
 function quux () {
 
 }
+// Message: @implements used on a non-constructor function
+
+/**
+ * @implements {SomeClass}
+ */
+function quux () {
+
+}
+// Options: [{"contexts":["any"]}]
+// Message: @implements used on a non-constructor function
+
+/**
+ * @function
+ * @implements {SomeClass}
+ */
+function quux () {
+
+}
+// Options: [{"contexts":["any"]}]
+// Message: @implements used on a non-constructor function
+
+/**
+ * @callback
+ * @implements {SomeClass}
+ */
+// Options: [{"contexts":["any"]}]
 // Message: @implements used on a non-constructor function
 
 /**
@@ -3947,6 +3987,20 @@ The following patterns are not considered problems:
 function quux () {
 
 }
+
+/**
+ * @implements {SomeClass}
+ * @class
+ */
+function quux () {
+
+}
+// Options: [{"contexts":["any"]}]
+
+/**
+ * @implements {SomeClass}
+ */
+// Options: [{"contexts":["any"]}]
 
 /**
  * @implements {SomeClass}
@@ -3994,6 +4048,16 @@ function quux () {
 
 }
 // Settings: {"jsdoc":{"tagNamePreference":{"implements":false}}}
+
+/**
+ * @function
+ * @implements {SomeClass}
+ */
+
+/**
+ * @callback
+ * @implements {SomeClass}
+ */
 ````
 
 
@@ -4011,10 +4075,10 @@ by our supported Node versions):
 Applies to the jsdoc block description and `@description` (or `@desc`)
 by default but the `tags` option (see below) may be used to match other tags.
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-9"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-10"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-9-matchdescription"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-10-matchdescription"></a>
 ##### <code>matchDescription</code>
 
 You can supply your own expression to override the default, passing a
@@ -4029,7 +4093,7 @@ You can supply your own expression to override the default, passing a
 As with the default, the supplied regular expression will be applied with the
 Unicode (`"u"`) flag and is *not* case-insensitive.
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-9-tags-1"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-10-tags-1"></a>
 ##### <code>tags</code>
 
 If you want different regular expressions to apply to tags, you may use
@@ -4066,7 +4130,7 @@ its "description" (e.g., for `@returns {someType} some description`, the
 description is `some description` while for `@some-tag xyz`, the description
 is `xyz`).
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-9-maindescription"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-10-maindescription"></a>
 ##### <code>mainDescription</code>
 
 If you wish to override the main function description without changing the
@@ -4088,7 +4152,7 @@ There is no need to add `mainDescription: true`, as by default, the main
 function (and only the main function) is linted, though you may disable checking
 it by setting it to `false`.
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-9-contexts"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-10-contexts-1"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
@@ -4732,7 +4796,7 @@ function quux () {
 
 Enforces a consistent padding of the block description.
 
-<a name="eslint-plugin-jsdoc-rules-newline-after-description-options-10"></a>
+<a name="eslint-plugin-jsdoc-rules-newline-after-description-options-11"></a>
 #### Options
 
 This rule allows one optional string argument. If it is `"always"` then a problem is raised when there is no newline after the description. If it is `"never"` then a problem is raised when there is a newline after the description. The default value is `"always"`.
@@ -4935,9 +4999,23 @@ This rule reports types being used on `@param` or `@returns`.
 The rule is intended to prevent the indication of types on tags where
 the type information would be redundant with TypeScript.
 
+<a name="eslint-plugin-jsdoc-rules-no-types-options-12"></a>
+#### Options
+
+<a name="eslint-plugin-jsdoc-rules-no-types-options-12-contexts-2"></a>
+##### <code>contexts</code>
+
+Set this to an array of strings representing the AST context
+where you wish the rule to be applied.
+Overrides the default contexts (see below). Set to `"any"` if you want
+the rule to apply to any jsdoc block throughout your files (as is necessary
+for finding function blocks not attached to a function declaration or
+expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+`@method`) (including those associated with an `@interface`).
+
 |||
 |---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`param`, `returns`|
 |Aliases|`arg`, `argument`, `return`|
 
@@ -4950,6 +5028,29 @@ The following patterns are considered problems:
 function quux (foo) {
 
 }
+// Message: Types are not permitted on @param.
+
+/**
+ * @param {number} foo
+ */
+function quux (foo) {
+
+}
+// Options: [{"contexts":["any"]}]
+// Message: Types are not permitted on @param.
+
+/**
+ * @function
+ * @param {number} foo
+ */
+// Options: [{"contexts":["any"]}]
+// Message: Types are not permitted on @param.
+
+/**
+ * @callback
+ * @param {number} foo
+ */
+// Options: [{"contexts":["any"]}]
 // Message: Types are not permitted on @param.
 
 /**
@@ -4970,6 +5071,21 @@ The following patterns are not considered problems:
 function quux (foo) {
 
 }
+
+/**
+ * @param foo
+ */
+// Options: [{"contexts":["any"]}]
+
+/**
+ * @function
+ * @param {number} foo
+ */
+
+/**
+ * @callback
+ * @param {number} foo
+ */
 ````
 
 
@@ -5003,7 +5119,7 @@ The following types are always considered defined.
 Note that preferred types indicated within `settings.jsdoc.preferredTypes` will
 also be assumed to be defined.
 
-<a name="eslint-plugin-jsdoc-rules-no-undefined-types-options-11"></a>
+<a name="eslint-plugin-jsdoc-rules-no-undefined-types-options-13"></a>
 #### Options
 
 An option object may have the following key:
@@ -5432,10 +5548,10 @@ tag descriptions are written in complete sentences, i.e.,
 * Periods after items within the `abbreviations` option array are not treated
   as sentence endings.
 
-<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-12"></a>
+<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-14"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-12-tags-2"></a>
+<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-14-tags-2"></a>
 ##### <code>tags</code>
 
 If you want additional tags to be checked for their descriptions, you may
@@ -5457,7 +5573,7 @@ its "description" (e.g., for `@returns {someType} some description`, the
 description is `some description` while for `@some-tag xyz`, the description
 is `xyz`).
 
-<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-12-abbreviations"></a>
+<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-14-abbreviations"></a>
 ##### <code>abbreviations</code>
 
 You can provide an `abbreviations` options array to avoid such strings of text
@@ -6089,7 +6205,7 @@ Requires that all functions have a description.
   `"tag"`) must have a non-empty description that explains the purpose of the
   method.
 
-<a name="eslint-plugin-jsdoc-rules-require-description-options-13"></a>
+<a name="eslint-plugin-jsdoc-rules-require-description-options-15"></a>
 #### Options
 
 An options object may have any of the following properties:
@@ -6385,25 +6501,25 @@ Requires that all functions have examples.
 * All functions must have one or more `@example` tags.
 * Every example tag must have a non-empty description that explains the method's usage.
 
-<a name="eslint-plugin-jsdoc-rules-require-example-options-14"></a>
+<a name="eslint-plugin-jsdoc-rules-require-example-options-16"></a>
 #### Options
 
 This rule has an object option.
 
-<a name="eslint-plugin-jsdoc-rules-require-example-options-14-exemptedby"></a>
+<a name="eslint-plugin-jsdoc-rules-require-example-options-16-exemptedby"></a>
 ##### <code>exemptedBy</code>
 
 Array of tags (e.g., `['type']`) whose presence on the document
 block avoids the need for an `@example`. Defaults to an empty array.
 
-<a name="eslint-plugin-jsdoc-rules-require-example-options-14-avoidexampleonconstructors"></a>
+<a name="eslint-plugin-jsdoc-rules-require-example-options-16-avoidexampleonconstructors"></a>
 ##### <code>avoidExampleOnConstructors</code>
 
 Set to `true` to avoid the need for an example on a constructor (whether
 indicated as such by a jsdoc tag or by being within an ES6 `class`).
 Defaults to `false`.
 
-<a name="eslint-plugin-jsdoc-rules-require-example-options-14-contexts-1"></a>
+<a name="eslint-plugin-jsdoc-rules-require-example-options-16-contexts-3"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
@@ -6728,7 +6844,7 @@ function quux () {
 
 Requires a hyphen before the `@param` description.
 
-<a name="eslint-plugin-jsdoc-rules-require-hyphen-before-param-description-options-15"></a>
+<a name="eslint-plugin-jsdoc-rules-require-hyphen-before-param-description-options-17"></a>
 #### Options
 
 This rule takes one optional string argument. If it is `"always"` then a problem is raised when there is no hyphen before the description. If it is `"never"` then a problem is raised when there is a hyphen before the description. The default value is `"always"`.
@@ -6834,7 +6950,7 @@ function quux () {
 Checks for presence of jsdoc comments, on class declarations as well as
 functions.
 
-<a name="eslint-plugin-jsdoc-rules-require-jsdoc-options-16"></a>
+<a name="eslint-plugin-jsdoc-rules-require-jsdoc-options-18"></a>
 #### Options
 
 Accepts one optional options object with the following optional keys.
@@ -7852,10 +7968,10 @@ export default class Foo {
 
 Requires that each `@param` tag has a `description` value.
 
-<a name="eslint-plugin-jsdoc-rules-require-param-description-options-17"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-description-options-19"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-param-description-options-17-contexts-2"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-description-options-19-contexts-4"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
@@ -7972,10 +8088,10 @@ Requires that all function parameters have names.
 >
 > [JSDoc](https://jsdoc.app/tags-param.html#overview)
 
-<a name="eslint-plugin-jsdoc-rules-require-param-name-options-18"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-name-options-20"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-param-name-options-18-contexts-3"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-name-options-20-contexts-5"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
@@ -8087,10 +8203,10 @@ function quux (foo) {
 
 Requires that each `@param` tag has a `type` value.
 
-<a name="eslint-plugin-jsdoc-rules-require-param-type-options-19"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-type-options-21"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-param-type-options-19-contexts-4"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-type-options-21-contexts-6"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
@@ -8203,7 +8319,7 @@ function quux (foo) {
 
 Requires that all function parameters are documented.
 
-<a name="eslint-plugin-jsdoc-rules-require-param-options-20"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-options-22"></a>
 #### Options
 
 An options object accepts one optional property:
@@ -9447,10 +9563,10 @@ function quux () {
 Requires that the `@returns` tag has a `description` value. The error
 will not be reported if the return value is `void` or `undefined`.
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-description-options-21"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-description-options-23"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-description-options-21-contexts-5"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-description-options-23-contexts-7"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
@@ -9585,10 +9701,10 @@ function quux () {
 
 Requires that `@returns` tag has `type` value.
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-type-options-22"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-type-options-24"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-type-options-22-contexts-6"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-type-options-24-contexts-8"></a>
 ##### <code>contexts</code>
 
 Set this to an array of strings representing the AST context
@@ -9705,7 +9821,7 @@ Requires returns are documented.
 
 Will also report if multiple `@returns` tags are present.
 
-<a name="eslint-plugin-jsdoc-rules-require-returns-options-23"></a>
+<a name="eslint-plugin-jsdoc-rules-require-returns-options-25"></a>
 #### Options
 
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
@@ -10304,7 +10420,7 @@ Also impacts behaviors on namepath (or event)-defining and pointing tags:
    allow `#`, `.`, or `~` at the end (which is not allowed at the end of
    normal paths).
 
-<a name="eslint-plugin-jsdoc-rules-valid-types-options-24"></a>
+<a name="eslint-plugin-jsdoc-rules-valid-types-options-26"></a>
 #### Options
 
 - `allowEmptyNamepaths` (default: true) - Set to `false` to disallow

--- a/README.md
+++ b/README.md
@@ -7885,6 +7885,29 @@ function quux (foo) {
 // Message: Missing JSDoc @param "foo" description.
 
 /**
+ * @param foo
+ */
+function quux (foo) {
+
+}
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @param "foo" description.
+
+/**
+ * @function
+ * @param foo
+ */
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @param "foo" description.
+
+/**
+ * @callback
+ * @param foo
+ */
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @param "foo" description.
+
+/**
  * @arg foo
  */
 function quux (foo) {
@@ -7919,6 +7942,24 @@ function quux (foo) {
 function quux (foo) {
 
 }
+
+/**
+ * @param foo Foo.
+ */
+function quux (foo) {
+
+}
+// Options: [{"contexts":["any"]}]
+
+/**
+ * @function
+ * @param foo
+ */
+
+/**
+ * @callback
+ * @param foo
+ */
 ````
 
 
@@ -7972,6 +8013,29 @@ function quux (foo) {
 // Message: There must be an identifier after @param tag.
 
 /**
+ * @param {string}
+ */
+function quux (foo) {
+
+}
+// Options: [{"contexts":["any"]}]
+// Message: There must be an identifier after @param tag.
+
+/**
+ * @function
+ * @param {string}
+ */
+// Options: [{"contexts":["any"]}]
+// Message: There must be an identifier after @param tag.
+
+/**
+ * @callback
+ * @param {string}
+ */
+// Options: [{"contexts":["any"]}]
+// Message: There must be an identifier after @param tag.
+
+/**
  * @param foo
  */
 function quux (foo) {
@@ -7992,11 +8056,29 @@ function quux (foo) {
 }
 
 /**
+ * @param foo
+ */
+function quux (foo) {
+
+}
+// Options: [{"contexts":["any"]}]
+
+/**
  * @param {string} foo
  */
 function quux (foo) {
 
 }
+
+/**
+ * @function
+ * @param
+ */
+
+/**
+ * @callback
+ * @param
+ */
 ````
 
 
@@ -8038,6 +8120,29 @@ function quux (foo) {
 // Message: Missing JSDoc @param "foo" type.
 
 /**
+ * @param foo
+ */
+function quux (foo) {
+
+}
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @param "foo" type.
+
+/**
+ * @function
+ * @param foo
+ */
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @param "foo" type.
+
+/**
+ * @callback
+ * @param foo
+ */
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @param "foo" type.
+
+/**
  * @arg foo
  */
 function quux (foo) {
@@ -8072,6 +8177,24 @@ function quux (foo) {
 function quux (foo) {
 
 }
+
+/**
+ * @param {number} foo
+ */
+function quux (foo) {
+
+}
+// Options: [{"contexts":["any"]}]
+
+/**
+ * @function
+ * @param foo
+ */
+
+/**
+ * @callback
+ * @param foo
+ */
 ````
 
 
@@ -9365,6 +9488,29 @@ function quux (foo) {
 // Message: Missing JSDoc @returns description.
 
 /**
+ * @returns {string}
+ */
+function quux (foo) {
+
+}
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @returns description.
+
+/**
+ * @function
+ * @returns {string}
+ */
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @returns description.
+
+/**
+ * @callback
+ * @returns {string}
+ */
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @returns description.
+
+/**
  * @return
  */
 function quux (foo) {
@@ -9401,6 +9547,14 @@ function quux () {
 }
 
 /**
+ * @returns Foo.
+ */
+function quux () {
+
+}
+// Options: [{"contexts":["any"]}]
+
+/**
  * @returns {undefined}
  */
 function quux () {
@@ -9413,6 +9567,16 @@ function quux () {
 function quux () {
 
 }
+
+/**
+ * @function
+ * @returns
+ */
+
+/**
+ * @callback
+ * @returns
+ */
 ````
 
 
@@ -9463,6 +9627,29 @@ function quux () {
 // Message: Missing JSDoc @returns type.
 
 /**
+ * @returns Foo.
+ */
+function quux () {
+
+}
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @returns type.
+
+/**
+ * @function
+ * @returns Foo.
+ */
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @returns type.
+
+/**
+ * @callback
+ * @returns Foo.
+ */
+// Options: [{"contexts":["any"]}]
+// Message: Missing JSDoc @returns type.
+
+/**
  * @return Foo.
  */
 function quux () {
@@ -9490,6 +9677,24 @@ The following patterns are not considered problems:
 function quux () {
 
 }
+
+/**
+ * @returns {number}
+ */
+function quux () {
+
+}
+// Options: [{"contexts":["any"]}]
+
+/**
+ * @function
+ * @returns Foo.
+ */
+
+/**
+ * @callback
+ * @returns Foo.
+ */
 ````
 
 
@@ -9631,6 +9836,26 @@ function quux () {
 // Options: [{"forceRequireReturn":true}]
 // Message: Missing JSDoc @returns declaration.
 
+/**
+ *
+ */
+function quux () {
+}
+// Options: [{"contexts":["any"],"forceRequireReturn":true}]
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ * @function
+ */
+// Options: [{"contexts":["any"],"forceRequireReturn":true}]
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ * @callback
+ */
+// Options: [{"contexts":["any"],"forceRequireReturn":true}]
+// Message: Missing JSDoc @returns declaration.
+
 const language = {
   /**
    * @param {string} name
@@ -9647,6 +9872,20 @@ const language = {
 async function quux () {
 }
 // Options: [{"forceReturnsWithAsync":true}]
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ * @function
+ * @async
+ */
+// Options: [{"contexts":["any"],"forceReturnsWithAsync":true}]
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ * @callback
+ * @async
+ */
+// Options: [{"contexts":["any"],"forceReturnsWithAsync":true}]
 // Message: Missing JSDoc @returns declaration.
 
 /**
@@ -9706,6 +9945,15 @@ function quux () {
 
   return foo;
 }
+
+/**
+ * @returns Foo.
+ */
+function quux () {
+
+  return foo;
+}
+// Options: [{"contexts":["any"]}]
 
 /**
  *
@@ -9976,6 +10224,48 @@ async function foo(a) {
 async function foo(a) {
   return;
 }
+
+/**
+ *
+ */
+// Options: [{"contexts":["any"]}]
+
+/**
+ * @async
+ */
+// Options: [{"contexts":["any"]}]
+
+/**
+ * @function
+ */
+// Options: [{"forceRequireReturn":true}]
+
+/**
+ * @callback
+ */
+// Options: [{"forceRequireReturn":true}]
+
+/**
+ * @function
+ * @async
+ */
+// Options: [{"forceReturnsWithAsync":true}]
+
+/**
+ * @callback
+ * @async
+ */
+// Options: [{"forceReturnsWithAsync":true}]
+
+/**
+ * @function
+ */
+// Options: [{"contexts":["any"],"forceReturnsWithAsync":true}]
+
+/**
+ * @callback
+ */
+// Options: [{"contexts":["any"],"forceReturnsWithAsync":true}]
 ````
 
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -431,7 +431,7 @@ const makeReport = (context, commentNode) => {
 
 const iterate = (
   ruleConfig, context, lines, jsdocNode, node, settings,
-  sourceCode, iterator, state,
+  sourceCode, iterator, state, iteratingAll,
 ) => {
   const sourceLine = lines[jsdocNode.loc.start.line - 1];
   const indent = sourceLine.charAt(0).repeat(jsdocNode.loc.start.column);
@@ -462,6 +462,7 @@ const iterate = (
   iterator({
     context,
     indent,
+    iteratingAll,
     jsdoc,
     jsdocNode,
     node,
@@ -496,7 +497,7 @@ const iterateAllJsdocs = (iterator, ruleConfig) => {
       iterate(
         ruleConfig, context, lines, jsdocNode, node,
         settings, sourceCode, iterator,
-        state,
+        state, true,
       );
     });
     if (lastCall && ruleConfig.exit) {

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -111,6 +111,7 @@ const getUtils = (
   settings,
   report,
   context,
+  iteratingAll,
 ) => {
   const ancestors = context.getAncestors();
   const sourceCode = context.getSourceCode();
@@ -126,6 +127,18 @@ const getUtils = (
     minLines,
     mode,
   } = settings;
+
+  utils.isIteratingFunction = () => {
+    return !iteratingAll || [
+      'ArrowFunctionExpression',
+      'FunctionDeclaration',
+      'FunctionExpression',
+    ].includes(node && node.type);
+  };
+
+  utils.isVirtualFunction = () => {
+    return iteratingAll && utils.hasATag(['callback', 'function', 'func', 'method']);
+  };
 
   utils.stringify = (tagBlock) => {
     const indent = jsdocUtils.getIndent(sourceCode);
@@ -445,6 +458,7 @@ const iterate = (
     settings,
     report,
     context,
+    iteratingAll,
   );
 
   if (

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -147,11 +147,11 @@ const getUtils = (
   };
 
   utils.isConstructor = () => {
-    return node.parent && node.parent.kind === 'constructor';
+    return node && node.parent && node.parent.kind === 'constructor';
   };
 
   utils.isSetter = () => {
-    return node.parent.kind === 'set';
+    return node && node.parent.kind === 'set';
   };
 
   utils.getJsdocNamesDeep = (tagName) => {

--- a/src/rules/implementsOnClasses.js
+++ b/src/rules/implementsOnClasses.js
@@ -4,13 +4,18 @@ export default iterateJsdoc(({
   report,
   utils,
 }) => {
-  if (
-    utils.hasATag([
+  const iteratingFunction = utils.isIteratingFunction();
+
+  if (iteratingFunction) {
+    if (utils.hasATag([
       'class',
       'constructor',
     ]) ||
-    utils.isConstructor()
-  ) {
+      utils.isConstructor()
+    ) {
+      return;
+    }
+  } else if (!utils.isVirtualFunction()) {
     return;
   }
 
@@ -18,7 +23,22 @@ export default iterateJsdoc(({
     report('@implements used on a non-constructor function', null, tag);
   });
 }, {
+  contextDefaults: true,
   meta: {
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          contexts: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
     type: 'suggestion',
   },
 });

--- a/src/rules/noTypes.js
+++ b/src/rules/noTypes.js
@@ -3,6 +3,10 @@ import iterateJsdoc from '../iterateJsdoc';
 export default iterateJsdoc(({
   utils,
 }) => {
+  if (!utils.isIteratingFunction() && !utils.isVirtualFunction()) {
+    return;
+  }
+
   const tags = utils.getPresentTags(['param', 'arg', 'argument', 'returns', 'return']);
 
   tags.forEach((tag) => {
@@ -13,8 +17,23 @@ export default iterateJsdoc(({
     }
   });
 }, {
+  contextDefaults: true,
   meta: {
     fixable: true,
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          contexts: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
     type: 'suggestion',
   },
 });

--- a/src/rules/requireParamDescription.js
+++ b/src/rules/requireParamDescription.js
@@ -14,7 +14,22 @@ export default iterateJsdoc(({
     }
   });
 }, {
+  contextDefaults: true,
   meta: {
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          contexts: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
     type: 'suggestion',
   },
 });

--- a/src/rules/requireParamName.js
+++ b/src/rules/requireParamName.js
@@ -14,7 +14,22 @@ export default iterateJsdoc(({
     }
   });
 }, {
+  contextDefaults: true,
   meta: {
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          contexts: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
     type: 'suggestion',
   },
 });

--- a/src/rules/requireParamType.js
+++ b/src/rules/requireParamType.js
@@ -14,7 +14,22 @@ export default iterateJsdoc(({
     }
   });
 }, {
+  contextDefaults: true,
   meta: {
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          contexts: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
     type: 'suggestion',
   },
 });

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -75,7 +75,7 @@ export default iterateJsdoc(({
     'ArrowFunctionExpression',
     'FunctionDeclaration',
     'FunctionExpression',
-  ].includes(node.type);
+  ].includes(node && node.type);
 
   // In case the code returns something, we expect a return value in JSDoc.
   const [tag] = tags;
@@ -93,7 +93,7 @@ export default iterateJsdoc(({
     }
 
     const isAsync = !iteratingFunction && utils.hasTag('async') ||
-      iteratingFunction && (utils.hasTag('async') || utils.isAsync());
+      iteratingFunction && utils.isAsync();
 
     if (forceReturnsWithAsync && isAsync) {
       return true;

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -44,9 +44,7 @@ const canSkip = (utils) => {
 export default iterateJsdoc(({
   report,
   utils,
-  node,
   context,
-  iteratingAll,
 }) => {
   warnRemovedSettings(context, 'require-returns');
 
@@ -71,11 +69,7 @@ export default iterateJsdoc(({
     report(`Found more than one @${tagName} declaration.`);
   }
 
-  const iteratingFunction = !iteratingAll || [
-    'ArrowFunctionExpression',
-    'FunctionDeclaration',
-    'FunctionExpression',
-  ].includes(node && node.type);
+  const iteratingFunction = utils.isIteratingFunction();
 
   // In case the code returns something, we expect a return value in JSDoc.
   const [tag] = tags;
@@ -87,7 +81,7 @@ export default iterateJsdoc(({
     }
 
     if (forceRequireReturn && (
-      iteratingFunction || utils.hasATag(['callback', 'function', 'func', 'method'])
+      iteratingFunction || utils.isVirtualFunction()
     )) {
       return true;
     }

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -95,11 +95,18 @@ export default iterateJsdoc(({
     report(`Missing JSDoc @${tagName} declaration.`);
   }
 }, {
+  contextDefaults: true,
   meta: {
     schema: [
       {
         additionalProperties: false,
         properties: {
+          contexts: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
           exemptedBy: {
             items: {
               type: 'string',

--- a/src/rules/requireReturnsDescription.js
+++ b/src/rules/requireReturnsDescription.js
@@ -16,7 +16,22 @@ export default iterateJsdoc(({
     }
   });
 }, {
+  contextDefaults: true,
   meta: {
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          contexts: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
     type: 'suggestion',
   },
 });

--- a/src/rules/requireReturnsType.js
+++ b/src/rules/requireReturnsType.js
@@ -10,7 +10,22 @@ export default iterateJsdoc(({
     }
   });
 }, {
+  contextDefaults: true,
   meta: {
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          contexts: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
     type: 'suggestion',
   },
 });

--- a/test/rules/assertions/implementsOnClasses.js
+++ b/test/rules/assertions/implementsOnClasses.js
@@ -18,6 +18,68 @@ export default {
     },
     {
       code: `
+      /**
+       * @implements {SomeClass}
+       */
+      function quux () {
+
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@implements used on a non-constructor function',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @function
+       * @implements {SomeClass}
+       */
+      function quux () {
+
+      }
+      `,
+      errors: [
+        {
+          line: 4,
+          message: '@implements used on a non-constructor function',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @callback
+       * @implements {SomeClass}
+       */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: '@implements used on a non-constructor function',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
         /**
          * @implements {SomeClass}
          */
@@ -51,6 +113,34 @@ export default {
 
       }
       `,
+    },
+    {
+      code: `
+      /**
+       * @implements {SomeClass}
+       * @class
+       */
+      function quux () {
+
+      }
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @implements {SomeClass}
+       */
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
     },
     {
       code: `
@@ -119,6 +209,22 @@ export default {
           },
         },
       },
+    },
+    {
+      code: `
+      /**
+       * @function
+       * @implements {SomeClass}
+       */
+      `,
+    },
+    {
+      code: `
+      /**
+       * @callback
+       * @implements {SomeClass}
+       */
+      `,
     },
   ],
 };

--- a/test/rules/assertions/noTypes.js
+++ b/test/rules/assertions/noTypes.js
@@ -11,6 +11,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Types are not permitted on @param.',
         },
       ],
@@ -26,6 +27,85 @@ export default {
     {
       code: `
           /**
+           * @param {number} foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Types are not permitted on @param.',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+      output: `
+          /**
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @param {number} foo
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Types are not permitted on @param.',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+      output: `
+          /**
+           * @function
+           * @param foo
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @param {number} foo
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Types are not permitted on @param.',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+      output: `
+          /**
+           * @callback
+           * @param foo
+           */
+      `,
+    },
+    {
+      code: `
+          /**
            * @returns {number}
            */
           function quux () {
@@ -34,6 +114,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Types are not permitted on @returns.',
         },
       ],
@@ -56,6 +137,34 @@ export default {
           function quux (foo) {
 
           }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @param foo
+           */
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @param {number} foo
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @param {number} foo
+           */
       `,
     },
   ],

--- a/test/rules/assertions/requireParamDescription.js
+++ b/test/rules/assertions/requireParamDescription.js
@@ -19,6 +19,59 @@ export default {
     {
       code: `
           /**
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing JSDoc @param "foo" description.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @param foo
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Missing JSDoc @param "foo" description.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @param foo
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Missing JSDoc @param "foo" description.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
            * @arg foo
            */
           function quux (foo) {
@@ -82,6 +135,37 @@ export default {
           function quux (foo) {
 
           }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @param foo Foo.
+           */
+          function quux (foo) {
+
+          }
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @param foo
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @param foo
+           */
       `,
     },
   ],

--- a/test/rules/assertions/requireParamName.js
+++ b/test/rules/assertions/requireParamName.js
@@ -35,6 +35,59 @@ export default {
     {
       code: `
           /**
+           * @param {string}
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'There must be an identifier after @param tag.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @param {string}
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'There must be an identifier after @param tag.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @param {string}
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'There must be an identifier after @param tag.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
            * @param foo
            */
           function quux (foo) {
@@ -70,11 +123,42 @@ export default {
     {
       code: `
           /**
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
            * @param {string} foo
            */
           function quux (foo) {
 
           }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @param
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @param
+           */
       `,
     },
   ],

--- a/test/rules/assertions/requireParamType.js
+++ b/test/rules/assertions/requireParamType.js
@@ -19,6 +19,59 @@ export default {
     {
       code: `
           /**
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing JSDoc @param "foo" type.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @param foo
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Missing JSDoc @param "foo" type.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @param foo
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Missing JSDoc @param "foo" type.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
            * @arg foo
            */
           function quux (foo) {
@@ -82,6 +135,35 @@ export default {
           function quux (foo) {
 
           }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @param {number} foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      options: [{
+        contexts: ['any'],
+      }],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @param foo
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @param foo
+           */
       `,
     },
   ],

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -209,6 +209,59 @@ export default {
     },
     {
       code: `
+          /**
+           *
+           */
+          function quux () {
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+        forceRequireReturn: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @function
+           */
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+        forceRequireReturn: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           */
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+        forceRequireReturn: true,
+      }],
+    },
+    {
+      code: `
       const language = {
         /**
          * @param {string} name
@@ -245,6 +298,42 @@ export default {
       parserOptions: {
         ecmaVersion: 8,
       },
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @async
+           */
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+        forceReturnsWithAsync: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @async
+           */
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+        forceReturnsWithAsync: true,
+      }],
     },
     {
       code: `
@@ -363,6 +452,22 @@ export default {
             return foo;
           }
       `,
+    },
+    {
+      code: `
+          /**
+           * @returns Foo.
+           */
+          function quux () {
+
+            return foo;
+          }
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
     },
     {
       code: `
@@ -794,6 +899,94 @@ export default {
       parserOptions: {
         ecmaVersion: 8,
       },
+    },
+    {
+      code: `
+          /**
+           *
+           */
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @async
+           */
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @function
+           */
+      `,
+      options: [{
+        forceRequireReturn: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           */
+      `,
+      options: [{
+        forceRequireReturn: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @async
+           */
+      `,
+      options: [{
+        forceReturnsWithAsync: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @async
+           */
+      `,
+      options: [{
+        forceReturnsWithAsync: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @function
+           */
+      `,
+      options: [{
+        contexts: ['any'],
+        forceReturnsWithAsync: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           */
+      `,
+      options: [{
+        contexts: ['any'],
+        forceReturnsWithAsync: true,
+      }],
     },
   ],
 };

--- a/test/rules/assertions/requireReturnsDescription.js
+++ b/test/rules/assertions/requireReturnsDescription.js
@@ -35,6 +35,65 @@ export default {
     {
       code: `
           /**
+           * @returns {string}
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing JSDoc @returns description.',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @returns {string}
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Missing JSDoc @returns description.',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @returns {string}
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Missing JSDoc @returns description.',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
            * @return
            */
           function quux (foo) {
@@ -102,6 +161,21 @@ export default {
     {
       code: `
           /**
+           * @returns Foo.
+           */
+          function quux () {
+
+          }
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
            * @returns {undefined}
            */
           function quux () {
@@ -117,6 +191,22 @@ export default {
           function quux () {
 
           }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @returns
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @returns
+           */
       `,
     },
   ],

--- a/test/rules/assertions/requireReturnsType.js
+++ b/test/rules/assertions/requireReturnsType.js
@@ -35,6 +35,65 @@ export default {
     {
       code: `
           /**
+           * @returns Foo.
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing JSDoc @returns type.',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @returns Foo.
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Missing JSDoc @returns type.',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @returns Foo.
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Missing JSDoc @returns type.',
+        },
+      ],
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
            * @return Foo.
            */
           function quux () {
@@ -87,6 +146,37 @@ export default {
           function quux () {
 
           }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @returns {number}
+           */
+          function quux () {
+
+          }
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @returns Foo.
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @returns Foo.
+           */
       `,
     },
   ],


### PR DESCRIPTION
Builds on #465

feat(`no-types`, `implements-on-classes`): add `contexts` option which if set to `any` will allow checking of virtual functions

Reuse of the `contexts` option would allow these contexts to be narrowed beyond the defaults if a project might so desire.