### PR TITLE
File overview `tags` option

### DIFF
--- a/.README/rules/require-file-overview.md
+++ b/.README/rules/require-file-overview.md
@@ -10,10 +10,68 @@ Checks that:
   as being when the overview tag is not preceded by anything other than
   a comment.
 
+#### Options
+
+##### `tags`
+
+The keys of this object are tag names, and the values are configuration
+objects indicating what will be checked for these whole-file tags.
+
+Each configuration object has the following boolean keys (which default
+to `false` when this option is supplied): `mustExist`, `preventDuplicates`,
+`initialCommentsOnly`. These correspond to the three items above.
+
+When no `tags` is present, the default is:
+
+```json
+{
+  "file": {
+    "initialCommentsOnly": true,
+    "mustExist": true,
+    "preventDuplicates": true,
+  }
+}
+```
+
+You can add additional tag names and/or override `file` if you supply this
+option, e.g., in place of or in addition to `file`, giving other potential
+file global tags like `@license`, `@copyright`, `@author`, `@module` or
+`@exports`, optionally restricting them to a single use or preventing them
+from being preceded by anything besides comments.
+
+For example:
+
+```js
+{
+  "license": {
+    "mustExist": true,
+    "preventDuplicates": true,
+  }
+}
+```
+
+This would require one and only one `@license` in the file, though because
+`initialCommentsOnly` is absent and defaults to `false`, the `@license`
+can be anywhere.
+
+In the case of `@license`, you can use this rule along with the
+`check-values` rule (with its `allowedLicenses` or `licensePattern` options),
+to enforce a license whitelist be present on every JS file.
+
+Note that if you choose to use `preventDuplicates` with `license`, you still
+have a way to allow multiple licenses for the whole page by using the SPDX
+"AND" expression, e.g., `@license (MIT AND GPL-3.0)`.
+
+Note that the tag names are the main jsdoc tag name, so you should use `file`
+in this configuration object regardless of whether you have configured
+`fileoverview` instead of `file` on `tagNamePreference` (i.e., `fileoverview`
+will be checked, but you must use `file` on the configuration object).
+
 |||
 |---|---|
 |Context|Everywhere|
-|Tags|`file`|
+|Tags|`file`; others when `tags` set|
 |Aliases|`fileoverview`, `overview`|
+|Options|`tags`|
 
 <!-- assertions requireFileOverview -->

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -516,6 +516,7 @@ const iterateAllJsdocs = (iterator, ruleConfig) => {
     });
     if (lastCall && ruleConfig.exit) {
       ruleConfig.exit({
+        context,
         state,
         utils,
       });

--- a/src/rules/requireFileOverview.js
+++ b/src/rules/requireFileOverview.js
@@ -24,8 +24,11 @@ export default iterateJsdoc(({
   jsdocNode,
   state,
   utils,
+  context,
 }) => {
-  const tags = defaultTags;
+  const {
+    tags = defaultTags,
+  } = context.options[0] || {};
 
   setDefaults(state);
 
@@ -50,14 +53,16 @@ export default iterateJsdoc(({
     }
   }
 }, {
-  exit ({state, utils}) {
+  exit ({context, state, utils}) {
     setDefaults(state);
-    const tags = defaultTags;
+    const {
+      tags = defaultTags,
+    } = context.options[0] || {};
 
     for (const [tagName, {
-      mustExist,
-      preventDuplicates,
-      initialCommentsOnly,
+      mustExist = false,
+      preventDuplicates = false,
+      initialCommentsOnly = false,
     }] of entries(tags)) {
       const obj = utils.getPreferredTagNameObject({tagName});
       if (obj && obj.blocked) {
@@ -88,6 +93,34 @@ export default iterateJsdoc(({
   iterateAllJsdocs: true,
   meta: {
     fixable: 'code',
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          tags: {
+            patternProperties: {
+              '.*': {
+                additionalProperties: false,
+                properties: {
+                  initialCommentsOnly: {
+                    type: 'boolean',
+                  },
+                  mustExist: {
+                    type: 'boolean',
+                  },
+                  preventDuplicates: {
+                    type: 'boolean',
+                  },
+                },
+                type: 'object',
+              },
+            },
+            type: 'object',
+          },
+        },
+        type: 'object',
+      },
+    ],
     type: 'suggestion',
   },
   nonComment ({state, node}) {

--- a/test/rules/assertions/requireFileOverview.js
+++ b/test/rules/assertions/requireFileOverview.js
@@ -12,6 +12,67 @@ export default {
     },
     {
       code: `
+      `,
+      errors: [
+        {
+          line: 1,
+          message: 'Missing @file',
+        },
+      ],
+      options: [
+        {
+          tags: {
+            file: {
+              initialCommentsOnly: true,
+              mustExist: true,
+              preventDuplicates: true,
+            },
+          },
+        },
+      ],
+    },
+    {
+      code: `
+      `,
+      errors: [
+        {
+          line: 1,
+          message: 'Missing @file',
+        },
+      ],
+      options: [
+        {
+          tags: {
+            file: {
+              mustExist: true,
+            },
+          },
+        },
+      ],
+    },
+    {
+      code: `
+      `,
+      errors: [
+        {
+          line: 1,
+          message: 'Missing @author',
+        },
+      ],
+      options: [
+        {
+          tags: {
+            author: {
+              initialCommentsOnly: false,
+              mustExist: true,
+              preventDuplicates: false,
+            },
+          },
+        },
+      ],
+    },
+    {
+      code: `
       /**
        *
        */
@@ -115,6 +176,39 @@ export default {
             'for the `require-file-overview` rule',
         },
       ],
+      options: [
+        {
+          tags: {
+            file: {
+              initialCommentsOnly: false,
+              mustExist: true,
+              preventDuplicates: false,
+            },
+          },
+        },
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            file: false,
+          },
+        },
+      },
+    },
+    {
+      code: `
+      /**
+       *
+       */
+      function quux () {}
+      `,
+      errors: [
+        {
+          line: 1,
+          message: '`settings.jsdoc.tagNamePreference` cannot block @file ' +
+            'for the `require-file-overview` rule',
+        },
+      ],
       settings: {
         jsdoc: {
           tagNamePreference: {
@@ -177,6 +271,34 @@ export default {
     },
     {
       code: `
+        /**
+         * @copyright
+         */
+
+         /**
+          * @copyright
+          */
+      `,
+      errors: [
+        {
+          line: 1,
+          message: 'Duplicate @copyright',
+        },
+      ],
+      options: [
+        {
+          tags: {
+            copyright: {
+              initialCommentsOnly: false,
+              mustExist: false,
+              preventDuplicates: true,
+            },
+          },
+        },
+      ],
+    },
+    {
+      code: `
         function quux () {
         }
         /**
@@ -190,6 +312,83 @@ export default {
         },
       ],
     },
+    {
+      code: `
+        function quux () {
+        }
+        /**
+         * @license
+         */
+      `,
+      errors: [
+        {
+          line: 1,
+          message: '@license should be at the beginning of the file',
+        },
+      ],
+      options: [
+        {
+          tags: {
+            license: {
+              initialCommentsOnly: true,
+              mustExist: false,
+              preventDuplicates: false,
+            },
+          },
+        },
+      ],
+    },
+    {
+      code: `
+        function quux () {
+        }
+        /**
+         * @license
+         */
+      `,
+      errors: [
+        {
+          line: 1,
+          message: '@license should be at the beginning of the file',
+        },
+      ],
+      options: [
+        {
+          tags: {
+            license: {
+              initialCommentsOnly: true,
+            },
+          },
+        },
+      ],
+    },
+    {
+      code: `
+       /**
+        * @file
+        */
+
+       /**
+        * @file
+        */
+      `,
+      errors: [
+        {
+          line: 1,
+          message: 'Duplicate @file',
+        },
+      ],
+      options: [
+        {
+          tags: {
+            file: {
+              initialCommentsOnly: true,
+              preventDuplicates: true,
+            },
+          },
+        },
+      ],
+    },
   ],
   valid: [
     {
@@ -198,6 +397,27 @@ export default {
          * @file
          */
       `,
+    },
+    {
+      code: `
+       /**
+        * @file
+        */
+
+       /**
+        * @file
+        */
+      `,
+      options: [
+        {
+          tags: {
+            license: {
+              initialCommentsOnly: true,
+              preventDuplicates: true,
+            },
+          },
+        },
+      ],
     },
     {
       code: `
@@ -254,6 +474,90 @@ export default {
          *
          */
       `,
+    },
+    {
+      code: `
+        function quux () {
+        }
+        /**
+         *
+         */
+      `,
+      options: [
+        {
+          tags: {
+            license: {
+              initialCommentsOnly: true,
+              mustExist: false,
+              preventDuplicates: false,
+            },
+          },
+        },
+      ],
+    },
+    {
+      code: `
+        function quux () {
+        }
+        /**
+         *
+         */
+      `,
+      options: [
+        {
+          tags: {
+            license: {
+              initialCommentsOnly: false,
+              mustExist: false,
+              preventDuplicates: false,
+            },
+          },
+        },
+      ],
+    },
+    {
+      code: `
+        function quux () {
+        }
+        /**
+         *
+         */
+      `,
+      options: [
+        {
+          tags: {
+            license: {
+              initialCommentsOnly: false,
+              mustExist: false,
+              preventDuplicates: true,
+            },
+          },
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @license MIT
+       */
+
+       var a
+
+       /**
+        * @type {Array}
+        */
+      `,
+      options: [
+        {
+          tags: {
+            license: {
+              initialCommentsOnly: true,
+              mustExist: false,
+              preventDuplicates: false,
+            },
+          },
+        },
+      ],
     },
   ],
 };


### PR DESCRIPTION
feat(`require-file-overview`): allow user to specify whether checking for tag, duplicates, or preceding non-comments, and for which tags

Allows overriding of default `file` behavior (added in #464) as well as other tags like `copyright`.