### PR TITLE
Hyphens on property descs

### DIFF
--- a/.README/rules/require-hyphen-before-param-description.md
+++ b/.README/rules/require-hyphen-before-param-description.md
@@ -4,13 +4,22 @@ Requires a hyphen before the `@param` description.
 
 #### Options
 
-This rule takes one optional string argument. If it is `"always"` then a problem is raised when there is no hyphen before the description. If it is `"never"` then a problem is raised when there is a hyphen before the description. The default value is `"always"`.
+This rule takes one optional string argument and an optional options object.
+
+If the string is `"always"` then a problem is raised when there is no hyphen
+before the description. If it is `"never"` then a problem is raised when there
+is a hyphen before the description. The default value is `"always"`.
+
+The options object may have the following properties:
+
+- `checkProperties` - Boolean on whether to also apply the rule to `@property`
+  tags.
 
 |||
 |---|---|
 |Context|everywhere|
-|Tags|`param`|
-|Aliases|`arg`, `argument`|
-|Options|(a string matching `"always"|"never"`)|
+|Tags|`param` and optionally `property`|
+|Aliases|`arg`, `argument`; optionally `prop`|
+|Options|(a string matching `"always"|"never"`) and an optional object with a `checkProperties` property|
 
 <!-- assertions requireHyphenBeforeParamDescription -->

--- a/README.md
+++ b/README.md
@@ -7181,14 +7181,23 @@ Requires a hyphen before the `@param` description.
 <a name="eslint-plugin-jsdoc-rules-require-hyphen-before-param-description-options-18"></a>
 #### Options
 
-This rule takes one optional string argument. If it is `"always"` then a problem is raised when there is no hyphen before the description. If it is `"never"` then a problem is raised when there is a hyphen before the description. The default value is `"always"`.
+This rule takes one optional string argument and an optional options object.
+
+If the string is `"always"` then a problem is raised when there is no hyphen
+before the description. If it is `"never"` then a problem is raised when there
+is a hyphen before the description. The default value is `"always"`.
+
+The options object may have the following properties:
+
+- `checkProperties` - Boolean on whether to also apply the rule to `@property`
+  tags.
 
 |||
 |---|---|
 |Context|everywhere|
-|Tags|`param`|
-|Aliases|`arg`, `argument`|
-|Options|(a string matching `"always"|"never"`)|
+|Tags|`param` and optionally `property`|
+|Aliases|`arg`, `argument`; optionally `prop`|
+|Options|(a string matching `"always"|"never"`) and an optional object with a `checkProperties` property|
 
 The following patterns are considered problems:
 
@@ -7248,6 +7257,20 @@ function quux (foo) {
 }
 // Settings: {"jsdoc":{"tagNamePreference":{"param":false}}}
 // Message: Unexpected tag `@param`
+
+/**
+ * @typedef {SomeType} ATypeDefName
+ * @property foo Foo.
+ */
+// Options: ["always",{"checkProperties":true}]
+// Message: There must be a hyphen before @property description.
+
+/**
+ * @typedef {SomeType} ATypeDefName
+ * @property foo - Foo.
+ */
+// Options: ["never",{"checkProperties":true}]
+// Message: There must be no hyphen before @property description.
 ````
 
 The following patterns are not considered problems:
@@ -7275,6 +7298,18 @@ function quux () {
 function quux () {
 
 }
+
+/**
+ * @typedef {SomeType} ATypeDefName
+ * @property foo - Foo.
+ */
+// Options: ["always",{"checkProperties":true}]
+
+/**
+ * @typedef {SomeType} ATypeDefName
+ * @property foo Foo.
+ */
+// Options: ["never",{"checkProperties":true}]
 ````
 
 

--- a/src/rules/requireHyphenBeforeParamDescription.js
+++ b/src/rules/requireHyphenBeforeParamDescription.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import iterateJsdoc from '../iterateJsdoc';
 
 export default iterateJsdoc(({
@@ -8,14 +7,10 @@ export default iterateJsdoc(({
   context,
   jsdocNode,
 }) => {
-  let always;
-  if (_.has(context.options, 0)) {
-    always = context.options[0] === 'always';
-  } else {
-    always = true;
-  }
+  const [circumstance, {checkProperties} = {}] = context.options;
+  const always = !circumstance || circumstance === 'always';
 
-  utils.forEachPreferredTag('param', (jsdocTag, targetTagName) => {
+  const checkHyphens = (jsdocTag, targetTagName) => {
     if (!jsdocTag.description) {
       return;
     }
@@ -49,7 +44,12 @@ export default iterateJsdoc(({
         return fixer.replaceText(jsdocNode, replacement);
       }, jsdocTag);
     }
-  });
+  };
+
+  utils.forEachPreferredTag('param', checkHyphens);
+  if (checkProperties) {
+    utils.forEachPreferredTag('property', checkHyphens);
+  }
 }, {
   iterateAllJsdocs: true,
   meta: {
@@ -58,6 +58,16 @@ export default iterateJsdoc(({
       {
         enum: ['always', 'never'],
         type: 'string',
+      },
+      {
+        additionalProperties: false,
+        properties: {
+          checkProperties: {
+            default: false,
+            type: 'boolean',
+          },
+        },
+        type: 'object',
       },
     ],
     type: 'layout',

--- a/test/rules/assertions/requireHyphenBeforeParamDescription.js
+++ b/test/rules/assertions/requireHyphenBeforeParamDescription.js
@@ -160,6 +160,52 @@ export default {
         },
       },
     },
+    {
+      code: `
+          /**
+           * @typedef {SomeType} ATypeDefName
+           * @property foo Foo.
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'There must be a hyphen before @property description.',
+        },
+      ],
+      options: [
+        'always', {checkProperties: true},
+      ],
+      output: `
+          /**
+           * @typedef {SomeType} ATypeDefName
+           * @property foo - Foo.
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @typedef {SomeType} ATypeDefName
+           * @property foo - Foo.
+           */
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'There must be no hyphen before @property description.',
+        },
+      ],
+      options: [
+        'never', {checkProperties: true},
+      ],
+      output: `
+          /**
+           * @typedef {SomeType} ATypeDefName
+           * @property foo Foo.
+           */
+      `,
+    },
   ],
   valid: [
     {
@@ -197,6 +243,28 @@ export default {
 
           }
       `,
+    },
+    {
+      code: `
+          /**
+           * @typedef {SomeType} ATypeDefName
+           * @property foo - Foo.
+           */
+      `,
+      options: [
+        'always', {checkProperties: true},
+      ],
+    },
+    {
+      code: `
+          /**
+           * @typedef {SomeType} ATypeDefName
+           * @property foo Foo.
+           */
+      `,
+      options: [
+        'never', {checkProperties: true},
+      ],
     },
   ],
 };


### PR DESCRIPTION
Based on top of #475.

feat(`require-hyphen-before-param-description`): add option to support checking `property`/`prop`