### PR TITLE
`no-bad-blocks`: rule to check for multi-line-style comments which fail to meet criteria of jsdoc blocks

### DIFF
--- a/.README/rules/no-bad-blocks.md
+++ b/.README/rules/no-bad-blocks.md
@@ -1,0 +1,14 @@
+### `no-bad-blocks`
+
+This rule checks for multi-line-style comments which fail to meet the
+criteria of a jsdoc block, namely that it should begin with two asterisks,
+but which appear to be intended as jsdoc blocks due to the presence
+of whitespace followed by whitespace or asterisks, and
+an at-sign (`@`) and some non-whitespace (as with a jsdoc block tag).
+
+|||
+|---|---|
+|Context|Everywhere|
+|Tags|N/A|
+
+<!-- assertions noBadBlocks -->

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import emptyTags from './rules/emptyTags';
 import implementsOnClasses from './rules/implementsOnClasses';
 import matchDescription from './rules/matchDescription';
 import newlineAfterDescription from './rules/newlineAfterDescription';
+import noBadBlocks from './rules/noBadBlocks';
 import noDefaults from './rules/noDefaults';
 import noTypes from './rules/noTypes';
 import noUndefinedTypes from './rules/noUndefinedTypes';
@@ -55,6 +56,7 @@ export default {
         'jsdoc/implements-on-classes': 'warn',
         'jsdoc/match-description': 'off',
         'jsdoc/newline-after-description': 'warn',
+        'jsdoc/no-bad-blocks': 'off',
         'jsdoc/no-defaults': 'off',
         'jsdoc/no-types': 'off',
         'jsdoc/no-undefined-types': 'warn',
@@ -95,6 +97,7 @@ export default {
     'implements-on-classes': implementsOnClasses,
     'match-description': matchDescription,
     'newline-after-description': newlineAfterDescription,
+    'no-bad-blocks': noBadBlocks,
     'no-defaults': noDefaults,
     'no-types': noTypes,
     'no-undefined-types': noUndefinedTypes,

--- a/src/rules/noBadBlocks.js
+++ b/src/rules/noBadBlocks.js
@@ -1,0 +1,32 @@
+import iterateJsdoc from '../iterateJsdoc';
+
+export default iterateJsdoc(({
+  context,
+  sourceCode,
+  allComments,
+  makeReport,
+}) => {
+  const nonJsdocNodes = allComments.filter((comment) => {
+    return (/^\/\*(?!\*)[\s*]*@\w/).test(sourceCode.getText(comment));
+  });
+  if (!nonJsdocNodes.length) {
+    return;
+  }
+
+  nonJsdocNodes.forEach((node) => {
+    const report = makeReport(context, node);
+
+    const fix = (fixer) => {
+      const text = sourceCode.getText(node);
+
+      return fixer.replaceText(node, text.replace('/*', '/**'));
+    };
+    report('Expected JSDoc-like comment to begin with two asterisks.', fix);
+  });
+}, {
+  checkFile: true,
+  meta: {
+    fixable: 'code',
+    type: 'layout',
+  },
+});

--- a/test/rules/assertions/noBadBlocks.js
+++ b/test/rules/assertions/noBadBlocks.js
@@ -1,0 +1,72 @@
+export default {
+  invalid: [
+    {
+      code: `
+          /*
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Expected JSDoc-like comment to begin with two asterisks.',
+        },
+      ],
+      output: `
+          /**
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /*
+           * @property foo
+           */
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Expected JSDoc-like comment to begin with two asterisks.',
+        },
+      ],
+      output: `
+          /**
+           * @property foo
+           */
+      `,
+    },
+  ],
+  valid: [
+    {
+      code: `
+          /**
+           * @property foo
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @param foo
+           */
+           function quux () {
+
+           }
+      `,
+    },
+    {
+      code: `
+      function quux () {
+
+      }
+      `,
+    },
+  ],
+};

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -22,6 +22,7 @@ const ruleTester = new RuleTester();
   'implements-on-classes',
   'match-description',
   'newline-after-description',
+  'no-bad-blocks',
   'no-defaults',
   'no-types',
   'no-undefined-types',


### PR DESCRIPTION
feat(`no-bad-blocks`): add rule to check for multi-line-style comments which fail to meet criteria of a jsdoc block

Expects jsdoc block to be a multiline-style comment beginning with two asterisks.
If beginning with only one, while having whitespace followed by whitespace or asterisks, and
an at-sign (`@`) and some non-whitespace (as with a jsdoc block tag), then report.

Non-breaking, as haven't added to "recommended".