### PR TITLE
fix:`check-values` for `@version` and `@since` reported invalid version with leading/trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -3891,7 +3891,21 @@ function quux (foo) {
 }
 
 /**
+ * @version      3.4.1
+ */
+function quux (foo) {
+
+}
+
+/**
  * @since 3.4.1
+ */
+function quux (foo) {
+
+}
+
+/**
+ * @since      3.4.1
  */
 function quux (foo) {
 

--- a/src/rules/checkValues.js
+++ b/src/rules/checkValues.js
@@ -15,8 +15,8 @@ export default iterateJsdoc(({
   } = options;
 
   utils.forEachPreferredTag('version', (jsdocParameter, targetTagName) => {
-    const version = jsdocParameter.description;
-    if (!version.trim()) {
+    const version = jsdocParameter.description.trim();
+    if (!version) {
       report(
         `Missing JSDoc @${targetTagName}.`,
         null,
@@ -31,8 +31,8 @@ export default iterateJsdoc(({
     }
   });
   utils.forEachPreferredTag('since', (jsdocParameter, targetTagName) => {
-    const version = jsdocParameter.description;
-    if (!version.trim()) {
+    const version = jsdocParameter.description.trim();
+    if (!version) {
       report(
         `Missing JSDoc @${targetTagName}.`,
         null,

--- a/test/rules/assertions/checkValues.js
+++ b/test/rules/assertions/checkValues.js
@@ -221,7 +221,27 @@ export default {
     {
       code: `
       /**
+       * @version      3.4.1
+       */
+      function quux (foo) {
+
+      }
+      `,
+    },
+    {
+      code: `
+      /**
        * @since 3.4.1
+       */
+      function quux (foo) {
+
+      }
+      `,
+    },
+    {
+      code: `
+      /**
+       * @since      3.4.1
        */
       function quux (foo) {
 


### PR DESCRIPTION
`semver.valid()` requires a trimmed string: with leading or trailing whitespace, `semver.valid()`always returns `false`
