### PR TITLE
feat(check-values): @throws must not be empty

### DIFF
--- a/.README/rules/check-values.md
+++ b/.README/rules/check-values.md
@@ -10,6 +10,7 @@ This rule checks the values for a handful of tags:
 4. `@author` - Checks there is a value present, and if the option
     `allowedAuthors` is present, ensure that the author value is one
     of these array items.
+5. `@throws` - Checks that there is a value present.
 
 #### Options
 

--- a/README.md
+++ b/README.md
@@ -3742,6 +3742,7 @@ This rule checks the values for a handful of tags:
 4. `@author` - Checks there is a value present, and if the option
     `allowedAuthors` is present, ensure that the author value is one
     of these array items.
+5. `@throws` - Checks that there is a value present.
 
 <a name="eslint-plugin-jsdoc-rules-check-values-options-7"></a>
 #### Options
@@ -3878,6 +3879,14 @@ function quux (foo) {
 }
 // Options: [{"allowedAuthors":["Gajus Kuizinas","golopot"]}]
 // Message: Invalid JSDoc @author: "Brett Zamir"; expected one of Gajus Kuizinas, golopot.
+
+/**
+ * @throws
+ */
+function quux (foo) {
+
+}
+// Message: Missing JSDoc @throws.
 ````
 
 The following patterns are not considered problems:
@@ -3972,6 +3981,13 @@ function quux (foo) {
 
 }
 // Options: [{"allowedAuthors":["Gajus Kuizinas","golopot","Brett Zamir"]}]
+
+/**
+ * @throws {DivideByZero} Argument x must be non-zero.
+ */
+function quux (foo) {
+
+}
 ````
 
 

--- a/src/rules/checkValues.js
+++ b/src/rules/checkValues.js
@@ -95,6 +95,17 @@ export default iterateJsdoc(({
       }
     }
   });
+
+  utils.forEachPreferredTag('throws', (jsdocParameter, targetTagName) => {
+    const throws = jsdocParameter.description.trim();
+    if (!throws) {
+      report(
+        `Missing JSDoc @${targetTagName}.`,
+        null,
+        jsdocParameter,
+      );
+    }
+  });
 }, {
   iterateAllJsdocs: true,
   meta: {

--- a/test/rules/assertions/checkValues.js
+++ b/test/rules/assertions/checkValues.js
@@ -206,6 +206,22 @@ export default {
         },
       ],
     },
+    {
+      code: `
+      /**
+       * @throws
+       */
+      function quux (foo) {
+
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing JSDoc @throws.',
+        },
+      ],
+    },
   ],
   valid: [
     {
@@ -349,6 +365,16 @@ export default {
           allowedAuthors: ['Gajus Kuizinas', 'golopot', 'Brett Zamir'],
         },
       ],
+    },
+    {
+      code: `
+      /**
+       * @throws {DivideByZero} Argument x must be non-zero.
+       */
+      function quux (foo) {
+
+      }
+      `,
     },
   ],
 };


### PR DESCRIPTION
`@throws` requires a value, see <https://jsdoc.app/tags-throws.html>

For example, <https://github.com/autoNumeric/autoNumeric/blob/next/src/AutoNumeric.js> is incorrectly declaring
[`@throws`](https://github.com/autoNumeric/autoNumeric/blob/next/src/AutoNumeric.js#L925) [without](https://github.com/autoNumeric/autoNumeric/blob/next/src/AutoNumeric.js#L2031) [values](https://github.com/autoNumeric/autoNumeric/blob/next/src/AutoNumeric.js#L2174).

