### PR TITLE
require-returns-check: Skip Closure Structural Interfaces (@record)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9824,6 +9824,18 @@ class Foo {
 }
 
 /**
+ * @record
+ */
+class Foo {
+  /**
+   * @returns {string}
+   */
+  bar () {
+  }
+}
+// Settings: {"jsdoc":{"mode":"closure"}}
+
+/**
  * @returns {undefined} Foo.
  */
 function quux () {

--- a/src/rules/requireReturnsCheck.js
+++ b/src/rules/requireReturnsCheck.js
@@ -1,7 +1,7 @@
 import iterateJsdoc from '../iterateJsdoc';
 
-const canSkip = (utils) => {
-  return utils.hasATag([
+const canSkip = (utils, settings) => {
+  const voidingTags = [
     // An abstract function is by definition incomplete
     // so it is perfectly fine if a return is documented but
     // not present within the function.
@@ -15,14 +15,25 @@ const canSkip = (utils) => {
     'class',
     'constructor',
     'interface',
-  ]) || utils.isConstructor() || utils.classHasTag('interface');
+  ];
+
+  if (settings.mode === 'closure') {
+    // Structural Interface in GCC terms, equivalent to @interface tag as far as this rule is concerned
+    voidingTags.push('record');
+  }
+
+  return utils.hasATag(voidingTags) ||
+    utils.isConstructor() ||
+    utils.classHasTag('interface') ||
+    settings.mode === 'closure' && utils.classHasTag('record');
 };
 
 export default iterateJsdoc(({
   report,
+  settings,
   utils,
 }) => {
-  if (canSkip(utils)) {
+  if (canSkip(utils, settings)) {
     return;
   }
 

--- a/test/rules/assertions/requireReturnsCheck.js
+++ b/test/rules/assertions/requireReturnsCheck.js
@@ -301,6 +301,25 @@ export default {
     {
       code: `
           /**
+           * @record
+           */
+          class Foo {
+            /**
+             * @returns {string}
+             */
+            bar () {
+            }
+          }
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'closure',
+        },
+      },
+    },
+    {
+      code: `
+          /**
            * @returns {undefined} Foo.
            */
           function quux () {


### PR DESCRIPTION
For GCC `@record` tag marks classes/functions as a [Structural Interface](https://github.com/google/closure-compiler/wiki/Structural-Interfaces-in-Closure-Compiler) making it more or less similar to `@interface` tags. Particularly it means `@return` annotation can be present on a function that does not actually have a `return` statement