### PR TITLE
New rule require-deprecated-description

### DIFF
--- a/.README/rules/require-deprecated-description.md
+++ b/.README/rules/require-deprecated-description.md
@@ -1,0 +1,5 @@
+### `require-deprecated-description`
+
+Requires that each `@deprecated` tag has a `description` value.
+
+<!-- assertions requireDeprecatedDescription -->

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import noBadBlocks from './rules/noBadBlocks';
 import noDefaults from './rules/noDefaults';
 import noTypes from './rules/noTypes';
 import noUndefinedTypes from './rules/noUndefinedTypes';
+import requireDeprecatedDescription from './rules/requireDeprecatedDescription';
 import requireDescriptionCompleteSentence from './rules/requireDescriptionCompleteSentence';
 import requireDescription from './rules/requireDescription';
 import requireExample from './rules/requireExample';
@@ -60,6 +61,7 @@ export default {
         'jsdoc/no-defaults': 'off',
         'jsdoc/no-types': 'off',
         'jsdoc/no-undefined-types': 'warn',
+        'jsdoc/require-deprecated-description': 'warn',
         'jsdoc/require-description': 'off',
         'jsdoc/require-description-complete-sentence': 'off',
         'jsdoc/require-example': 'off',
@@ -101,6 +103,7 @@ export default {
     'no-defaults': noDefaults,
     'no-types': noTypes,
     'no-undefined-types': noUndefinedTypes,
+    'require-deprecated-description': requireDeprecatedDescription,
     'require-description': requireDescription,
     'require-description-complete-sentence': requireDescriptionCompleteSentence,
     'require-example': requireExample,

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -44,6 +44,7 @@ const parseComment = (commentNode, indent, trim = true) => {
             'example', 'return', 'returns', 'throws', 'exception',
             'access', 'version', 'since', 'license', 'author',
             'default', 'defaultvalue',
+            'deprecated',
           ].includes(data.tag)) {
             return null;
           }

--- a/src/rules/requireDeprecatedDescription.js
+++ b/src/rules/requireDeprecatedDescription.js
@@ -1,0 +1,21 @@
+import iterateJsdoc from '../iterateJsdoc';
+
+export default iterateJsdoc(({
+  report,
+  utils,
+}) => {
+  utils.forEachPreferredTag('deprecated', (jsdocTag) => {
+    if (!jsdocTag.description) {
+      report(
+        'Missing deprecation description.',
+        null,
+        jsdocTag,
+      );
+    }
+  });
+}, {
+  iterateAllJsdocs: true,
+  meta: {
+    type: 'suggestion',
+  },
+});

--- a/test/rules/assertions/requireDeprecatedDescription.js
+++ b/test/rules/assertions/requireDeprecatedDescription.js
@@ -1,0 +1,62 @@
+export default {
+  invalid: [
+    {
+      code: `
+          /**
+           * @deprecated
+           */
+          function foo () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing deprecation description.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @deprecated
+           */
+          Foo.prototype.bar
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing deprecation description.',
+        },
+      ],
+    },
+  ],
+  valid: [
+    {
+      code: `
+          /**
+           * @deprecated - Use bar() instead
+           */
+          function foo () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @deprecated Permanently removed as unsafe
+           */
+          Foo.prototype.bar
+      `,
+    },
+    {
+      code: `
+          /**
+           * @deprecated oneWordShouldNotBeParsedAsName
+           */
+          var FOO;
+      `,
+    },
+  ],
+};

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -26,6 +26,7 @@ const ruleTester = new RuleTester();
   'no-defaults',
   'no-types',
   'no-undefined-types',
+  'require-deprecated-description',
   'require-description',
   'require-description-complete-sentence',
   'require-example',


### PR DESCRIPTION
`@deprecated` annotations without description about the reasoning behind deprecation and instructions on what to do to avoid deprecated apis can be very frustrating. This rule aims to help to document more helpful deprecation messages.

Functionally it's pretty similar to `require-param-description`, except without context parameter.