### PR TITLE
Doc revisions

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -25,7 +25,11 @@ npm install --save-dev eslint-plugin-jsdoc
 
 ## Configuration
 
-Add `plugins` section and specify `eslint-plugin-jsdoc` as a plugin.
+To enable rules, you may use either of the following approaches in setting
+up your ESLint configuration file.
+
+1. A `plugins` section, specifying `jsdoc` as a plugin. You will then
+  need to opt in to any `jsdoc` rules you wish to use (see below for the list):
 
 ```json
 {
@@ -35,43 +39,12 @@ Add `plugins` section and specify `eslint-plugin-jsdoc` as a plugin.
 }
 ```
 
-Finally, enable all of the rules that you would like to use.
+OR:
 
-```javascript
-{
-    "rules": {
-        "jsdoc/check-alignment": 1, // Recommended
-        "jsdoc/check-examples": 1,
-        "jsdoc/check-indentation": 1,
-        "jsdoc/check-param-names": 1, // Recommended
-        "jsdoc/check-syntax": 1,
-        "jsdoc/check-tag-names": 1, // Recommended
-        "jsdoc/check-types": 1, // Recommended
-        "jsdoc/implements-on-classes": 1, // Recommended
-        "jsdoc/match-description": 1,
-        "jsdoc/newline-after-description": 1, // Recommended
-        "jsdoc/no-types": 1,
-        "jsdoc/no-undefined-types": 1, // Recommended
-        "jsdoc/require-description": 1,
-        "jsdoc/require-description-complete-sentence": 1,
-        "jsdoc/require-example": 1,
-        "jsdoc/require-hyphen-before-param-description": 1,
-        "jsdoc/require-jsdoc": 1, // Recommended
-        "jsdoc/require-param": 1, // Recommended
-        "jsdoc/require-param-description": 1, // Recommended
-        "jsdoc/require-param-name": 1, // Recommended
-        "jsdoc/require-param-type": 1, // Recommended
-        "jsdoc/require-returns": 1, // Recommended
-        "jsdoc/require-returns-check": 1, // Recommended
-        "jsdoc/require-returns-description": 1, // Recommended
-        "jsdoc/require-returns-type": 1, // Recommended
-        "jsdoc/valid-types": 1 // Recommended
-    }
-}
-```
-
-Or you can simply use the following which enables the rules commented
-above as "recommended":
+2. Add `plugin:jsdoc/recommended` to `extends` to automatically enable rules
+  that report common problems. These have a check mark :heavy_check_mark: in
+  the list below. You can then selectively add to or override these recommended
+  rules.
 
 ```json
 {
@@ -79,15 +52,71 @@ above as "recommended":
 }
 ```
 
-You can then selectively add to or override the recommended rules.
+Here is an example of rule setting:
+
+```javascript
+{
+    "rules": {
+        "jsdoc/check-alignment": ["warn"],
+        "jsdoc/check-examples": ["error"]
+    }
+},
+```
+
+Note that the rules may have options or global settings which may impact the
+behavior of the rules. These are explained in more detail below, in both the
+general sections about options and settings and with each respective rule.
+
+## Rule summary
+
+Problems reported by rules which have a wrench :wrench: below can be fixed automatically by running ESLint on the command line with `--fix` option.
+
+|recommended|fixable|rule|description|
+|-|-|-|-|
+|:heavy_check_mark:|| [check-access](#eslint-plugin-jsdoc-rules-check-access) | Enforces valid `@access` tags|
+|:heavy_check_mark:|:wrench:| [check-alignment](#eslint-plugin-jsdoc-rules-check-alignment)|Enforces alignment of JSDoc block asterisks|
+|||[check-examples](#eslint-plugin-jsdoc-rules-check-examples)|Linting of JavaScript within `@example`|
+|||[check-indentation](#eslint-plugin-jsdoc-rules-check-indentation)|Checks for invalid padding inside JSDoc blocks|
+|:heavy_check_mark:|:wrench:|[check-param-names](#eslint-plugin-jsdoc-rules-check-param-names)|Checks for dupe `@param` names, that nested param names have roots, and that parameter names in function declarations match jsdoc param names.|
+|:heavy_check_mark:|:wrench:|[check-property-names](#eslint-plugin-jsdoc-rules-check-property-names)|Checks for dupe `@property` names, that nested property names have roots|
+|||[check-syntax](#eslint-plugin-jsdoc-rules-check-syntax)|Reports use against current mode (currently only prohibits Closure-specific syntax)|
+|:heavy_check_mark:|:wrench:|[check-tag-names](#eslint-plugin-jsdoc-rules-check-tag-names)|Reports invalid jsdoc (block) tag names|
+|:heavy_check_mark:|:wrench:|[check-types](#eslint-plugin-jsdoc-rules-check-types)|Reports types deemed invalid (customizable and with defaults, for preventing and/or recommending replacements)|
+|:heavy_check_mark:||[check-values](#eslint-plugin-jsdoc-rules-check-values)|Checks for expected content within some miscellaneous tags (`@version`, `@since`, `@license`, `@author`)|
+|:heavy_check_mark:|:wrench:|[empty-tags](#eslint-plugin-jsdoc-rules-empty-tags)|Checks tags that are expected to be empty (e.g., `@abstract` or `@async`), reporting if they have content|
+|:heavy_check_mark:||[implements-on-classes](#eslint-plugin-jsdoc-rules-implements-on-classes)|Prohibits use of `@implements` on non-constructor functions (to enforce the tag only being used on classes/constructors)|
+|||[match-description](#eslint-plugin-jsdoc-rules-match-description)|Defines customizable regular expression rules for your tag descriptions|
+|:heavy_check_mark:|:wrench:|[newline-after-description](#eslint-plugin-jsdoc-rules-newline-after-description)|Requires or prohibits newlines after the description portion of a jsdoc block|
+||:wrench:|[no-types](#eslint-plugin-jsdoc-rules-no-types)|Prohibits types on `@param` or `@returns` (redundant with TypeScript)|
+|:heavy_check_mark:||[no-undefined-types](#eslint-plugin-jsdoc-rules-no-undefined-types)|Besides some expected built-in types, prohibits any types not specified as globals or within `@typedef` |
+|||[require-description](#eslint-plugin-jsdoc-rules-require-description)|Requires that all functions (and potentially other contexts) have a description.|
+||:wrench:|[require-description-complete-sentence](#eslint-plugin-jsdoc-rules-require-description-complete-sentence)|Requires that block description, explicit `@description`, and `@param`/`@returns` tag descriptions are written in complete sentences|
+||:wrench:|[require-example](#eslint-plugin-jsdoc-rules-require-example)|Requires that all functions (and potentially other contexts) have examples.|
+|||[require-file-overview](#eslint-plugin-jsdoc-rules-require-file-overview)|By default, requires a single `@file` tag at the beginning of each linted file|
+||:wrench:|[require-hyphen-before-param-description](#eslint-plugin-jsdoc-rules-require-hyphen-before-param-description)|Requires a hyphen before `@param` descriptions (and optionally before `@property` descriptions)|
+|:heavy_check_mark:|:wrench:|[require-jsdoc](#eslint-plugin-jsdoc-rules-require-jsdoc)|Checks for presence of jsdoc comments, on functions and potentially other contexts (optionally limited to exports).|
+|:heavy_check_mark:|:wrench:|[require-param](#eslint-plugin-jsdoc-rules-require-param)|Requires that all function parameters are documented with a `@param` tag.|
+|:heavy_check_mark:||[require-param-description](#eslint-plugin-jsdoc-rules-require-param-description)|Requires that each `@param` tag has a `description` value.|
+|:heavy_check_mark:||[require-param-name](#eslint-plugin-jsdoc-rules-require-param-name)|Requires that all `@param` tags have names.|
+|:heavy_check_mark:||[require-param-type](#eslint-plugin-jsdoc-rules-require-param-type)|Requires that each `@param` tag has a type value (within curly brackets).|
+|:heavy_check_mark:|:wrench:|[require-property](#eslint-plugin-jsdoc-rules-require-property)|Requires that all `@typedef` and `@namespace` tags have `@property` tags when their type is a plain `object`, `Object`, or `PlainObject`.|
+|:heavy_check_mark:||[require-property-description](#eslint-plugin-jsdoc-rules-require-property-description)|Requires that each `@property` tag has a `description` value.|
+|:heavy_check_mark:||[require-property-name](#eslint-plugin-jsdoc-rules-require-property-name)|Requires that all `@property` tags have names.|
+|:heavy_check_mark:||[require-property-type](#eslint-plugin-jsdoc-rules-require-property-type)|Requires that each `@property` tag has a type value (within curly brackets).|
+|:heavy_check_mark:||[require-returns](#eslint-plugin-jsdoc-rules-require-returns)|Requires that return statements are documented.|
+|:heavy_check_mark:||[require-returns-check](#eslint-plugin-jsdoc-rules-require-returns-check)|Requires a return statement be present in a function body if a `@returns` tag is specified in the jsdoc comment block (and reports if multiple `@returns` tags are present).|
+|:heavy_check_mark:||[require-returns-description](#eslint-plugin-jsdoc-rules-require-returns-description)|Requires that the `@returns` tag has a `description` value (not including `void`/`undefined` type returns).|
+|:heavy_check_mark:||[require-returns-type](#eslint-plugin-jsdoc-rules-require-returns-type)|Requires that `@returns` tag has a type value (in curly brackets).|
+|:heavy_check_mark:||[valid-types](#eslint-plugin-jsdoc-rules-valid-types)|Requires all types/namepaths to be valid JSDoc, Closure compiler, or TypeScript types (configurable in settings)|
 
 ## Options
 
 Rules may, as per the [ESLint user guide](https://eslint.org/docs/user-guide/configuring), have their own individual options. In `eslint-plugin-jsdoc`, a few options,
 such as, `exemptedBy` and `contexts`, may be used across different rules.
 
-`eslint-plugin-jsdoc` options, if present, are in the form of an object
-supplied as the second argument in an array after the error level.
+`eslint-plugin-jsdoc` options, if present, are generally in the form of an
+object supplied as the second argument in an array after the error level.
+
 
 ```js
 // `.eslintrc.js`

--- a/.README/README.md
+++ b/.README/README.md
@@ -137,14 +137,14 @@ object supplied as the second argument in an array after the error level.
 
 ## Settings
 
-### Allow `@private` to disable rules for that comment block
+### Allow `@private` to disable rules for that comment block (`ignorePrivate`)
 
 - `settings.jsdoc.ignorePrivate` - Disables all rules for the comment block
   on which a `@private` tag (or `@access private`) occurs. Defaults to
   `false`. Note: This has no effect with the rule `check-access` (whose
   purpose is to check access modifiers).
 
-### `maxLines` and `minLines`
+#### Controlling spacing between code and comment blocks (`maxLines` and `minLines`)
 
 One can use `minLines` and `maxLines` to indicate how many line breaks
 (if any) will be checked to find a jsdoc comment block before the given
@@ -155,7 +155,7 @@ be enforced so as to report problems if a jsdoc block is not found within
 the specified boundaries. The settings are also used in the fixer to determine
 how many line breaks to add when a block is missing.
 
-### Mode
+### Linting mode (`mode`)
 
 - `settings.jsdoc.mode` - Set to `jsdoc` (the default), `typescript`, or `closure`.
   Currently is used for the following:
@@ -167,7 +167,7 @@ how many line breaks to add when a block is missing.
     so these tags will additionally be checked in "closure" mode)
   - Check preferred tag names
 
-### Alias Preference
+### Alias Preference (`tagNamePreference`)
 
 Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a JSDoc tag. The format of the configuration is: `<primary tag name>: <preferred alias name>`, e.g.
 
@@ -281,7 +281,7 @@ This setting is utilized by the the rule for tag name checking
 - `require-returns-description`
 - `require-returns-type`
 
-### `@override`/`@augments`/`@extends`/`@implements` Without Accompanying `@param`/`@description`/`@example`/`@returns`
+### `@override`/`@augments`/`@extends`/`@implements` Without Accompanying `@param`/`@description`/`@example`/`@returns` (`overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`)
 
 The following settings allows the element(s) they reference to be omitted
 on the JSDoc comment block of the function or that of its parent class
@@ -307,7 +307,7 @@ The format of the configuration is as follows:
 }
 ```
 
-### Settings to Configure `check-types` and `no-undefined-types`
+### Settings to Configure `check-types` and `no-undefined-types` (`preferredTypes`)
 
 - `settings.jsdoc.preferredTypes` An option map to indicate preferred
   or forbidden types (if default types are indicated here, these will

--- a/.README/README.md
+++ b/.README/README.md
@@ -137,6 +137,8 @@ object supplied as the second argument in an array after the error level.
 
 ## Settings
 
+{"gitdown": "contents", "rootId": "settings"}
+
 ### Allow `@private` to disable rules for that comment block (`ignorePrivate`)
 
 - `settings.jsdoc.ignorePrivate` - Disables all rules for the comment block

--- a/.README/README.md
+++ b/.README/README.md
@@ -23,7 +23,7 @@ If you have installed `ESLint` globally, you have to install JSDoc plugin global
 npm install --save-dev eslint-plugin-jsdoc
 ```
 
-## Configuration
+## Configuration introduction
 
 To enable rules, you may use either of the following approaches in setting
 up your ESLint configuration file.
@@ -109,7 +109,7 @@ Problems reported by rules which have a wrench :wrench: below can be fixed autom
 |:heavy_check_mark:||[require-returns-type](#eslint-plugin-jsdoc-rules-require-returns-type)|Requires that `@returns` tag has a type value (in curly brackets).|
 |:heavy_check_mark:||[valid-types](#eslint-plugin-jsdoc-rules-valid-types)|Requires all types/namepaths to be valid JSDoc, Closure compiler, or TypeScript types (configurable in settings)|
 
-## Options
+## Options overview
 
 Rules may, as per the [ESLint user guide](https://eslint.org/docs/user-guide/configuring), have their own individual options. In `eslint-plugin-jsdoc`, a few options,
 such as, `exemptedBy` and `contexts`, may be used across different rules.

--- a/.README/README.md
+++ b/.README/README.md
@@ -137,7 +137,7 @@ object supplied as the second argument in an array after the error level.
 
 ## Settings
 
-{"gitdown": "contents", "rootId": "settings"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-settings"}
 
 ### Allow `@private` to disable rules for that comment block (`ignorePrivate`)
 

--- a/.README/rules/check-access.md
+++ b/.README/rules/check-access.md
@@ -1,5 +1,7 @@
 ### `check-access`
 
+{"gitdown": "contents", "rootId": "check-access"}
+
 Checks that `@access` tags use one of the following values:
 
 - "package", "private", "protected", "public"

--- a/.README/rules/check-access.md
+++ b/.README/rules/check-access.md
@@ -13,6 +13,8 @@ Also reports:
 - Use of multiple instances of `@access` (or the `@public`, etc. style tags)
   on the same doc block.
 
+#### Context and settings
+
 |||
 |---|---|
 |Context|everywhere|
@@ -20,4 +22,10 @@ Also reports:
 |Settings||
 |Options||
 
-<!-- assertions checkAccess -->
+#### Failing examples
+
+<!-- assertions-failing checkAccess -->
+
+#### Passing examples
+
+<!-- assertions-passing checkAccess -->

--- a/.README/rules/check-alignment.md
+++ b/.README/rules/check-alignment.md
@@ -1,5 +1,7 @@
 ### `check-alignment`
 
+{"gitdown": "contents", "rootId": "check-alignment"}
+
 Reports invalid alignment of JSDoc block asterisks.
 
 |||

--- a/.README/rules/check-alignment.md
+++ b/.README/rules/check-alignment.md
@@ -1,12 +1,24 @@
 ### `check-alignment`
 
-{"gitdown": "contents", "rootId": "check-alignment"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-check-alignment"}
 
 Reports invalid alignment of JSDoc block asterisks.
+
+#### Fixer
+
+Fixes alignment.
+
+#### Context and settings
 
 |||
 |---|---|
 |Context|everywhere|
 |Tags|N/A|
 
-<!-- assertions checkAlignment -->
+#### Failing examples
+
+<!-- assertions-failing checkAlignment -->
+
+#### Passing examples
+
+<!-- assertions-passing checkAlignment -->

--- a/.README/rules/check-examples.md
+++ b/.README/rules/check-examples.md
@@ -1,6 +1,6 @@
 ### `check-examples`
 
-{"gitdown": "contents", "rootId": "check-examples"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-check-examples"}
 
 Ensures that (JavaScript) examples within JSDoc adhere to ESLint rules.
 
@@ -136,10 +136,18 @@ decreasing precedence:
 * `node/no-missing-import` - See `import/no-unresolved`.
 * `node/no-missing-require` -  See `import/no-unresolved`.
 
+#### Context and settings
+
 |||
 |---|---|
 |Context|everywhere|
 |Tags|`example`|
 |Options| *See above* |
 
-<!-- assertions checkExamples -->
+#### Failing examples
+
+<!-- assertions-failing checkExamples -->
+
+#### Passing examples
+
+<!-- assertions-passing checkExamples -->

--- a/.README/rules/check-examples.md
+++ b/.README/rules/check-examples.md
@@ -1,5 +1,7 @@
 ### `check-examples`
 
+{"gitdown": "contents", "rootId": "check-examples"}
+
 Ensures that (JavaScript) examples within JSDoc adhere to ESLint rules.
 
 #### Options

--- a/.README/rules/check-indentation.md
+++ b/.README/rules/check-indentation.md
@@ -1,6 +1,6 @@
 ### `check-indentation`
 
-{"gitdown": "contents", "rootId": "check-indentation"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-check-indentation"}
 
 Reports invalid padding inside JSDoc blocks.
 
@@ -44,10 +44,18 @@ report a padding issue:
  */
 ```
 
+#### Context and settings
+
 |||
 |---|---|
 |Context|everywhere|
 |Tags|N/A|
 |Options| `excludeTags` |
 
-<!-- assertions checkIndentation -->
+#### Failing examples
+
+<!-- assertions-failing checkIndentation -->
+
+#### Passing examples
+
+<!-- assertions-passing checkIndentation -->

--- a/.README/rules/check-indentation.md
+++ b/.README/rules/check-indentation.md
@@ -1,5 +1,7 @@
 ### `check-indentation`
 
+{"gitdown": "contents", "rootId": "check-indentation"}
+
 Reports invalid padding inside JSDoc blocks.
 
 Ignores parts enclosed in Markdown "code block"'s. For example,

--- a/.README/rules/check-param-names.md
+++ b/.README/rules/check-param-names.md
@@ -1,8 +1,12 @@
 ### `check-param-names`
 
-{"gitdown": "contents", "rootId": "check-param-names"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-check-param-names"}
 
 Ensures that parameter names in JSDoc match those in the function declaration.
+
+#### Fixer
+
+(Todo)
 
 #### Options
 
@@ -12,14 +16,6 @@ If set to `true`, this option will allow extra `@param` definitions (e.g.,
 representing future expected or virtual params) to be present without needing
 their presence within the function signature. Other inconsistencies between
 `@param`'s and present function parameters will still be reported.
-
-|||
-|---|---|
-|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
-|Options|`allowExtraTrailingParamDocs`|
-|Tags|`param`|
-
-<!-- assertions checkParamNames -->
 
 #### Deconstructing Function Parameter
 
@@ -40,3 +36,19 @@ function quux ({
 `{a, b}` is an [`ObjectPattern`](https://github.com/estree/estree/blob/master/es2015.md#objectpattern) AST type and does not have a name. Therefore, the associated parameter in JSDoc block can have any name.
 
 Likewise for the pattern `[a, b]` which is an [`ArrayPattern`](https://github.com/estree/estree/blob/master/es2015.md#arraypattern).
+
+#### Context and settings
+
+|||
+|---|---|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Options|`allowExtraTrailingParamDocs`|
+|Tags|`param`|
+
+#### Failing examples
+
+<!-- assertions-failing checkParamNames -->
+
+#### Passing examples
+
+<!-- assertions-passing checkParamNames -->

--- a/.README/rules/check-param-names.md
+++ b/.README/rules/check-param-names.md
@@ -1,5 +1,7 @@
 ### `check-param-names`
 
+{"gitdown": "contents", "rootId": "check-param-names"}
+
 Ensures that parameter names in JSDoc match those in the function declaration.
 
 #### Options

--- a/.README/rules/check-property-names.md
+++ b/.README/rules/check-property-names.md
@@ -1,15 +1,25 @@
 ### `check-property-names`
 
-{"gitdown": "contents", "rootId": "check-property-names"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-check-property-names"}
 
 Ensures that property names in JSDoc are not duplicated on the same block
 and that nested properties have defined roots.
 
-#### Options
+#### Fixer
+
+(Todo)
+
+#### Context and settings
 
 |||
 |---|---|
 |Context|Everywhere|
 |Tags|`property`|
 
-<!-- assertions checkPropertyNames -->
+#### Failing examples
+
+<!-- assertions-failing checkPropertyNames -->
+
+#### Passing examples
+
+<!-- assertions-passing checkPropertyNames -->

--- a/.README/rules/check-property-names.md
+++ b/.README/rules/check-property-names.md
@@ -1,5 +1,7 @@
 ### `check-property-names`
 
+{"gitdown": "contents", "rootId": "check-property-names"}
+
 Ensures that property names in JSDoc are not duplicated on the same block
 and that nested properties have defined roots.
 

--- a/.README/rules/check-syntax.md
+++ b/.README/rules/check-syntax.md
@@ -1,12 +1,20 @@
 ### `check-syntax`
 
-{"gitdown": "contents", "rootId": "check-syntax"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-check-syntax"}
 
 Reports against Google Closure Compiler syntax.
+
+#### Context and settings
 
 |||
 |---|---|
 |Context|everywhere|
 |Tags|N/A|
 
-<!-- assertions checkSyntax -->
+#### Failing examples
+
+<!-- assertions-failing checkSyntax -->
+
+#### Passing examples
+
+<!-- assertions-passing checkSyntax -->

--- a/.README/rules/check-syntax.md
+++ b/.README/rules/check-syntax.md
@@ -1,5 +1,7 @@
 ### `check-syntax`
 
+{"gitdown": "contents", "rootId": "check-syntax"}
+
 Reports against Google Closure Compiler syntax.
 
 |||

--- a/.README/rules/check-tag-names.md
+++ b/.README/rules/check-tag-names.md
@@ -1,6 +1,6 @@
 ### `check-tag-names`
 
-{"gitdown": "contents", "rootId": "check-tag-names"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-check-tag-names"}
 
 Reports invalid block tag names.
 
@@ -156,6 +156,10 @@ wizaction
 
 Note that the tags indicated as replacements in `settings.jsdoc.tagNamePreference` will automatically be considered as valid.
 
+#### Fixer
+
+(Todo)
+
 #### Options
 
 ##### `definedTags`
@@ -169,6 +173,8 @@ The format is as follows:
 }
 ```
 
+#### Context and settings
+
 |||
 |---|---|
 |Context|everywhere|
@@ -176,4 +182,10 @@ The format is as follows:
 |Options|`definedTags`|
 |Settings|`tagNamePreference`, `mode`|
 
-<!-- assertions checkTagNames -->
+#### Failing examples
+
+<!-- assertions-failing checkTagNames -->
+
+#### Passing examples
+
+<!-- assertions-passing checkTagNames -->

--- a/.README/rules/check-tag-names.md
+++ b/.README/rules/check-tag-names.md
@@ -1,5 +1,7 @@
 ### `check-tag-names`
 
+{"gitdown": "contents", "rootId": "check-tag-names"}
+
 Reports invalid block tag names.
 
 Valid [JSDoc 3 Block Tags](https://jsdoc.app/#block-tags) are:

--- a/.README/rules/check-types.md
+++ b/.README/rules/check-types.md
@@ -1,5 +1,7 @@
 ### `check-types`
 
+{"gitdown": "contents", "rootId": "check-types"}
+
 Reports invalid types.
 
 By default, ensures that the casing of native types is the same as in this list:

--- a/.README/rules/check-types.md
+++ b/.README/rules/check-types.md
@@ -1,6 +1,6 @@
 ### `check-types`
 
-{"gitdown": "contents", "rootId": "check-types"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-check-types"}
 
 Reports invalid types.
 
@@ -85,6 +85,8 @@ Basically, for primitives, we want to define the type as a primitive, because th
 In short: It's not about consistency, rather about the 99.9% use case. (And some
 functions might not even support the objects if they are checking for identity.)
 
+#### Comparisons
+
 type name | `typeof` | check-types | testcase
 --|--|--|--
 **Array** | object | **Array** | `([]) instanceof Array` -> `true`
@@ -96,6 +98,12 @@ Boolean | **boolean** | **boolean** | `(true) instanceof Boolean` -> **`false`**
 Number | **number** | **number** | `(41) instanceof Number` -> **`false`**
 String | **string** | **string** | `("test") instanceof String` -> **`false`**
 
+#### Fixer
+
+(Todo)
+
+#### Context and settings
+
 |||
 |---|---|
 |Context|everywhere|
@@ -105,4 +113,10 @@ String | **string** | **string** | `("test") instanceof String` -> **`false`**
 |Options|`noDefaults`, `exemptTagContexts`, `unifyParentAndChildTypeChecks`|
 |Settings|`preferredTypes`, `mode`|
 
-<!-- assertions checkTypes -->
+#### Failing examples
+
+<!-- assertions-failing checkTypes -->
+
+#### Passing examples
+
+<!-- assertions-passing checkTypes -->

--- a/.README/rules/check-values.md
+++ b/.README/rules/check-values.md
@@ -1,6 +1,6 @@
 ### `check-values`
 
-{"gitdown": "contents", "rootId": "check-values"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-check-values"}
 
 This rule checks the values for a handful of tags:
 
@@ -33,6 +33,8 @@ description to check (if no grouping is present, then the whole portion
 matched will be used). Defaults to `([^\n]*)`, i.e., the SPDX expression
 is expected before any line breaks.
 
+#### Context and settings
+
 |||
 |---|---|
 |Context|everywhere|
@@ -40,4 +42,10 @@ is expected before any line breaks.
 |Options|`allowedAuthors`, `allowedLicenses`, `licensePattern`|
 |Settings|`tagNamePreference`|
 
-<!-- assertions checkValues -->
+#### Failing examples
+
+<!-- assertions-failing checkValues -->
+
+#### Passing examples
+
+<!-- assertions-passing checkValues -->

--- a/.README/rules/check-values.md
+++ b/.README/rules/check-values.md
@@ -1,5 +1,7 @@
 ### `check-values`
 
+{"gitdown": "contents", "rootId": "check-values"}
+
 This rule checks the values for a handful of tags:
 
 1. `@version` - Checks that there is a present and valid

--- a/.README/rules/empty-tags.md
+++ b/.README/rules/empty-tags.md
@@ -1,5 +1,7 @@
 ### `empty-tags`
 
+{"gitdown": "contents", "rootId": "empty-tags"}
+
 Expects the following tags to be empty of any content:
 
 - `@abstract`

--- a/.README/rules/empty-tags.md
+++ b/.README/rules/empty-tags.md
@@ -1,6 +1,6 @@
 ### `empty-tags`
 
-{"gitdown": "contents", "rootId": "empty-tags"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-empty-tags"}
 
 Expects the following tags to be empty of any content:
 
@@ -42,10 +42,23 @@ add them within this option.
 }
 ```
 
+#### Fixer
+
+(Todo)
+
+#### Context and settings
+
 |||
 |---|---|
 |Context|everywhere|
 |Tags| and others added by `tags`|
 |Aliases||
 |Options|`tags`|
-<!-- assertions emptyTags -->
+
+#### Failing examples
+
+<!-- assertions-failing emptyTags -->
+
+#### Passing examples
+
+<!-- assertions-passing emptyTags -->

--- a/.README/rules/implements-on-classes.md
+++ b/.README/rules/implements-on-classes.md
@@ -1,6 +1,6 @@
 ### `implements-on-classes`
 
-{"gitdown": "contents", "rootId": "implements-on-classes"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-implements-on-classes"}
 
 Reports an issue with any non-constructor function using `@implements`.
 
@@ -23,10 +23,18 @@ for finding function blocks not attached to a function declaration or
 expression, i.e., `@callback` or `@function` (or its aliases `@func` or
 `@method`) (including those associated with an `@interface`).
 
+## Context and settings
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`implements` (prevented)|
 |Options|`contexts`|
 
-<!-- assertions implementsOnClasses -->
+#### Failing examples
+
+<!-- assertions-failing implementsOnClasses -->
+
+#### Passing examples
+
+<!-- assertions-passing implementsOnClasses -->

--- a/.README/rules/implements-on-classes.md
+++ b/.README/rules/implements-on-classes.md
@@ -1,5 +1,7 @@
 ### `implements-on-classes`
 
+{"gitdown": "contents", "rootId": "implements-on-classes"}
+
 Reports an issue with any non-constructor function using `@implements`.
 
 Constructor functions, whether marked with `@class`, `@constructs`, or being

--- a/.README/rules/match-description.md
+++ b/.README/rules/match-description.md
@@ -1,5 +1,7 @@
 ### `match-description`
 
+{"gitdown": "contents", "rootId": "match-description"}
+
 Enforces a regular expression pattern on descriptions.
 
 The default is this basic expression to match English sentences (Support

--- a/.README/rules/match-description.md
+++ b/.README/rules/match-description.md
@@ -1,6 +1,6 @@
 ### `match-description`
 
-{"gitdown": "contents", "rootId": "match-description"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-match-description"}
 
 Enforces a regular expression pattern on descriptions.
 
@@ -93,6 +93,8 @@ where you wish the rule to be applied (e.g., `ClassDeclaration` for ES6 classes)
 Overrides the default contexts (see below). Set to `"any"` if you want
 the rule to apply to any jsdoc block throughout your files.
 
+#### Context and settings
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
@@ -101,4 +103,10 @@ the rule to apply to any jsdoc block throughout your files.
 |Settings||
 |Options|`contexts`, `tags` (accepts tags with names and optional type such as 'param', 'arg', 'argument', 'property', and 'prop', and accepts arbitrary list of other tags with an optional type (but without names), e.g., 'returns', 'return'), `mainDescription`, `matchDescription`|
 
-<!-- assertions matchDescription -->
+#### Failing examples
+
+<!-- assertions-failing matchDescription -->
+
+#### Passing examples
+
+<!-- assertions-passing matchDescription -->

--- a/.README/rules/newline-after-description.md
+++ b/.README/rules/newline-after-description.md
@@ -1,5 +1,7 @@
 ### `newline-after-description`
 
+{"gitdown": "contents", "rootId": "newline-after-description"}
+
 Enforces a consistent padding of the block description.
 
 #### Options

--- a/.README/rules/newline-after-description.md
+++ b/.README/rules/newline-after-description.md
@@ -1,6 +1,6 @@
 ### `newline-after-description`
 
-{"gitdown": "contents", "rootId": "newline-after-description"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-newline-after-description"}
 
 Enforces a consistent padding of the block description.
 
@@ -8,10 +8,22 @@ Enforces a consistent padding of the block description.
 
 This rule allows one optional string argument. If it is `"always"` then a problem is raised when there is no newline after the description. If it is `"never"` then a problem is raised when there is a newline after the description. The default value is `"always"`.
 
+#### Fixer
+
+(Todo)
+
+#### Context and settings
+
 |||
 |---|---|
 |Context|everywhere|
 |Options|(a string matching `"always"|"never"`)|
 |Tags|N/A (doc block)|
 
-<!-- assertions newlineAfterDescription -->
+#### Failing examples
+
+<!-- assertions-failing newlineAfterDescription -->
+
+#### Passing examples
+
+<!-- assertions-passing newlineAfterDescription -->

--- a/.README/rules/no-bad-blocks.md
+++ b/.README/rules/no-bad-blocks.md
@@ -1,6 +1,6 @@
 ### `no-bad-blocks`
 
-{"gitdown": "contents", "rootId": "no-bad-blocks"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-no-bad-blocks"}
 
 This rule checks for multi-line-style comments which fail to meet the
 criteria of a jsdoc block, namely that it should begin with two asterisks,
@@ -8,9 +8,21 @@ but which appear to be intended as jsdoc blocks due to the presence
 of whitespace followed by whitespace or asterisks, and
 an at-sign (`@`) and some non-whitespace (as with a jsdoc block tag).
 
+#### Fixer
+
+Adds the extra asterisk (i.e., from `/*` to `/**`).
+
+#### Context and settings
+
 |||
 |---|---|
 |Context|Everywhere|
 |Tags|N/A|
 
-<!-- assertions noBadBlocks -->
+#### Failing examples
+
+<!-- assertions-failing noBadBlocks -->
+
+#### Passing examples
+
+<!-- assertions-passing noBadBlocks -->

--- a/.README/rules/no-bad-blocks.md
+++ b/.README/rules/no-bad-blocks.md
@@ -1,5 +1,7 @@
 ### `no-bad-blocks`
 
+{"gitdown": "contents", "rootId": "no-bad-blocks"}
+
 This rule checks for multi-line-style comments which fail to meet the
 criteria of a jsdoc block, namely that it should begin with two asterisks,
 but which appear to be intended as jsdoc blocks due to the presence

--- a/.README/rules/no-defaults.md
+++ b/.README/rules/no-defaults.md
@@ -1,6 +1,6 @@
 ### `no-defaults`
 
-{"gitdown": "contents", "rootId": "no-defaults"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-no-defaults"}
 
 This rule reports defaults being used on the relevant portion of `@param`
 or `@default`. It also optionally reports the presence of the
@@ -34,6 +34,14 @@ for finding function blocks not attached to a function declaration or
 expression, i.e., `@callback` or `@function` (or its aliases `@func` or
 `@method`) (including those associated with an `@interface`).
 
+#### Fixer
+
+Will strip the default value (i.e. `defaultValue` within
+`[<name>=<defaultValue>]`) and if `noOptionalParamNames` is set, the optionality
+markers (`[` and `]`) will be stripped as well.
+
+#### Context and settings
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
@@ -41,4 +49,10 @@ expression, i.e., `@callback` or `@function` (or its aliases `@func` or
 |Aliases|`arg`, `argument`, `defaultvalue`|
 |Options|`contexts`, `noOptionalParamNames`|
 
-<!-- assertions noDefaults -->
+#### Failing examples
+
+<!-- assertions-failing noDefaults -->
+
+#### Passing examples
+
+<!-- assertions-passing noDefaults -->

--- a/.README/rules/no-defaults.md
+++ b/.README/rules/no-defaults.md
@@ -1,5 +1,7 @@
 ### `no-defaults`
 
+{"gitdown": "contents", "rootId": "no-defaults"}
+
 This rule reports defaults being used on the relevant portion of `@param`
 or `@default`. It also optionally reports the presence of the
 square-bracketed optional arguments at all.

--- a/.README/rules/no-types.md
+++ b/.README/rules/no-types.md
@@ -1,5 +1,7 @@
 ### `no-types`
 
+{"gitdown": "contents", "rootId": "no-types"}
+
 This rule reports types being used on `@param` or `@returns`.
 
 The rule is intended to prevent the indication of types on tags where

--- a/.README/rules/no-types.md
+++ b/.README/rules/no-types.md
@@ -1,6 +1,6 @@
 ### `no-types`
 
-{"gitdown": "contents", "rootId": "no-types"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-no-types"}
 
 This rule reports types being used on `@param` or `@returns`.
 
@@ -19,6 +19,12 @@ for finding function blocks not attached to a function declaration or
 expression, i.e., `@callback` or `@function` (or its aliases `@func` or
 `@method`) (including those associated with an `@interface`).
 
+#### Fixer
+
+(Todo)
+
+#### Context and settings
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
@@ -26,4 +32,10 @@ expression, i.e., `@callback` or `@function` (or its aliases `@func` or
 |Aliases|`arg`, `argument`, `return`|
 |Options|`contexts`|
 
-<!-- assertions noTypes -->
+#### Failing examples
+
+<!-- assertions-failing noTypes -->
+
+#### Passing examples
+
+<!-- assertions-passing noTypes -->

--- a/.README/rules/no-undefined-types.md
+++ b/.README/rules/no-undefined-types.md
@@ -1,5 +1,7 @@
 ### `no-undefined-types`
 
+{"gitdown": "contents", "rootId": "no-undefined-types"}
+
 Checks that types in jsdoc comments are defined. This can be used to check
 unimported types.
 

--- a/.README/rules/no-undefined-types.md
+++ b/.README/rules/no-undefined-types.md
@@ -1,6 +1,6 @@
 ### `no-undefined-types`
 
-{"gitdown": "contents", "rootId": "no-undefined-types"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-no-undefined-types"}
 
 Checks that types in jsdoc comments are defined. This can be used to check
 unimported types.
@@ -38,6 +38,8 @@ An option object may have the following key:
   are automatically considered as defined (in addition to globals, etc.).
   Defaults to an empty array.
 
+#### Context and settings
+
 |||
 |---|---|
 |Context|everywhere|
@@ -47,4 +49,10 @@ An option object may have the following key:
 |Options|`definedTypes`|
 |Settings|`preferredTypes`, `mode`|
 
-<!-- assertions noUndefinedTypes -->
+#### Failing examples
+
+<!-- assertions-failing noUndefinedTypes -->
+
+#### Passing examples
+
+<!-- assertions-passing noUndefinedTypes -->

--- a/.README/rules/require-description-complete-sentence.md
+++ b/.README/rules/require-description-complete-sentence.md
@@ -1,6 +1,6 @@
 ### `require-description-complete-sentence`
 
-{"gitdown": "contents", "rootId": "require-description-complete-sentence"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-require-description-complete-sentence"}
 
 Requires that block description, explicit `@description`, and `@param`/`@returns`
 tag descriptions are written in complete sentences, i.e.,
@@ -45,10 +45,23 @@ You can provide an `abbreviations` options array to avoid such strings of text
 being treated as sentence endings when followed by dots. The `.` is not
 necessary at the end of the array items.
 
+#### Fixer
+
+(Todo)
+
+#### Context and settings
+
 |||
 |---|---|
 |Context|everywhere|
 |Tags|doc block, `param`, `returns`, `description`, `property`, `summary`, `file`, `classdesc`, `todo`, `deprecated`, `throws`, 'yields' and others added by `tags`|
 |Aliases|`arg`, `argument`, `return`, `desc`, `prop`, `fileoverview`, `overview`, `exception`, `yield`|
 |Options|`tags`, `abbreviations`|
-<!-- assertions requireDescriptionCompleteSentence -->
+
+#### Failing examples
+
+<!-- assertions-failing requireDescriptionCompleteSentence -->
+
+#### Passing examples
+
+<!-- assertions-passing requireDescriptionCompleteSentence -->

--- a/.README/rules/require-description-complete-sentence.md
+++ b/.README/rules/require-description-complete-sentence.md
@@ -1,5 +1,7 @@
 ### `require-description-complete-sentence`
 
+{"gitdown": "contents", "rootId": "require-description-complete-sentence"}
+
 Requires that block description, explicit `@description`, and `@param`/`@returns`
 tag descriptions are written in complete sentences, i.e.,
 

--- a/.README/rules/require-description.md
+++ b/.README/rules/require-description.md
@@ -1,5 +1,7 @@
 ### `require-description`
 
+{"gitdown": "contents", "rootId": "require-description"}
+
 Requires that all functions have a description.
 
 * All functions must have an implicit description or have the option

--- a/.README/rules/require-description.md
+++ b/.README/rules/require-description.md
@@ -1,6 +1,6 @@
 ### `require-description`
 
-{"gitdown": "contents", "rootId": "require-description"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-require-description"}
 
 Requires that all functions have a description.
 
@@ -25,6 +25,8 @@ An options object may have any of the following properties:
     `@description` tags (`"tag"`) as satisfying the rule. Set to `"any"` to
     accept either style. Defaults to `"body"`.
 
+#### Context and settings
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
@@ -33,4 +35,10 @@ An options object may have any of the following properties:
 |Options|`contexts`, `exemptedBy`, `descriptionStyle`|
 |Settings|`overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`|
 
-<!-- assertions requireDescription -->
+#### Failing examples
+
+<!-- assertions-failing requireDescription -->
+
+#### Passing examples
+
+<!-- assertions-passing requireDescription -->

--- a/.README/rules/require-example.md
+++ b/.README/rules/require-example.md
@@ -1,6 +1,6 @@
 ### `require-example`
 
-{"gitdown": "contents", "rootId": "require-example"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-require-example"}
 
 Requires that all functions have examples.
 
@@ -34,6 +34,8 @@ the rule to apply to any jsdoc block throughout your files.
 The fixer for `require-example` will add an empty `@example`, but it will still
 report a missing example description after this is added.
 
+#### Context and settings
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
@@ -41,4 +43,10 @@ report a missing example description after this is added.
 |Options|`exemptedBy`, `avoidExampleOnConstructors`, `contexts`|
 |Settings|`overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`|
 
-<!-- assertions requireExample -->
+#### Failing examples
+
+<!-- assertions-failing requireExample -->
+
+#### Passing examples
+
+<!-- assertions-passing requireExample -->

--- a/.README/rules/require-example.md
+++ b/.README/rules/require-example.md
@@ -1,5 +1,7 @@
 ### `require-example`
 
+{"gitdown": "contents", "rootId": "require-example"}
+
 Requires that all functions have examples.
 
 * All functions must have one or more `@example` tags.

--- a/.README/rules/require-file-overview.md
+++ b/.README/rules/require-file-overview.md
@@ -1,6 +1,6 @@
 ### `require-file-overview`
 
-{"gitdown": "contents", "rootId": "require-file-overview"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-require-file-overview"}
 
 Checks that:
 
@@ -69,6 +69,8 @@ in this configuration object regardless of whether you have configured
 `fileoverview` instead of `file` on `tagNamePreference` (i.e., `fileoverview`
 will be checked, but you must use `file` on the configuration object).
 
+#### Context and settings
+
 |||
 |---|---|
 |Context|Everywhere|
@@ -76,4 +78,10 @@ will be checked, but you must use `file` on the configuration object).
 |Aliases|`fileoverview`, `overview`|
 |Options|`tags`|
 
-<!-- assertions requireFileOverview -->
+#### Failing examples
+
+<!-- assertions-failing requireFileOverview -->
+
+#### Passing examples
+
+<!-- assertions-passing requireFileOverview -->

--- a/.README/rules/require-file-overview.md
+++ b/.README/rules/require-file-overview.md
@@ -1,5 +1,7 @@
 ### `require-file-overview`
 
+{"gitdown": "contents", "rootId": "require-file-overview"}
+
 Checks that:
 
 1. All files have a `@file`, `@fileoverview`, or `@overview` tag.

--- a/.README/rules/require-hyphen-before-param-description.md
+++ b/.README/rules/require-hyphen-before-param-description.md
@@ -1,5 +1,7 @@
 ### `require-hyphen-before-param-description`
 
+{"gitdown": "contents", "rootId": "require-hyphen-before-param-description"}
+
 Requires a hyphen before the `@param` description.
 
 #### Options

--- a/.README/rules/require-hyphen-before-param-description.md
+++ b/.README/rules/require-hyphen-before-param-description.md
@@ -1,6 +1,6 @@
 ### `require-hyphen-before-param-description`
 
-{"gitdown": "contents", "rootId": "require-hyphen-before-param-description"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-require-hyphen-before-param-description"}
 
 Requires a hyphen before the `@param` description.
 
@@ -17,6 +17,12 @@ The options object may have the following properties:
 - `checkProperties` - Boolean on whether to also apply the rule to `@property`
   tags.
 
+#### Fixer
+
+(Todo)
+
+#### Context and settings
+
 |||
 |---|---|
 |Context|everywhere|
@@ -24,4 +30,10 @@ The options object may have the following properties:
 |Aliases|`arg`, `argument`; optionally `prop`|
 |Options|(a string matching `"always"|"never"`) and an optional object with a `checkProperties` property|
 
-<!-- assertions requireHyphenBeforeParamDescription -->
+#### Failing examples
+
+<!-- assertions-failing requireHyphenBeforeParamDescription -->
+
+#### Passing examples
+
+<!-- assertions-passing requireHyphenBeforeParamDescription -->

--- a/.README/rules/require-jsdoc.md
+++ b/.README/rules/require-jsdoc.md
@@ -1,6 +1,6 @@
 ### `require-jsdoc`
 
-{"gitdown": "contents", "rootId": "require-jsdoc"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-require-jsdoc"}
 
 Checks for presence of jsdoc comments, on class declarations as well as
 functions.
@@ -42,10 +42,22 @@ Accepts one optional options object with the following optional keys.
   missing jsdoc blocks above functions/methods with no parameters or return values
   (intended where variable names are sufficient for themselves as documentation).
 
+#### Fixer
+
+(Todo)
+
+#### Context and settings
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `ClassDeclaration`, `ClassExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|N/A|
 |Options|`publicOnly`, `require`, `contexts`, `exemptEmptyFunctions`|
 
-<!-- assertions requireJsdoc -->
+#### Failing examples
+
+<!-- assertions-failing requireJsdoc -->
+
+#### Passing examples
+
+<!-- assertions-passing requireJsdoc -->

--- a/.README/rules/require-jsdoc.md
+++ b/.README/rules/require-jsdoc.md
@@ -1,5 +1,7 @@
 ### `require-jsdoc`
 
+{"gitdown": "contents", "rootId": "require-jsdoc"}
+
 Checks for presence of jsdoc comments, on class declarations as well as
 functions.
 

--- a/.README/rules/require-param-description.md
+++ b/.README/rules/require-param-description.md
@@ -1,5 +1,7 @@
 ### `require-param-description`
 
+{"gitdown": "contents", "rootId": "require-param-description"}
+
 Requires that each `@param` tag has a `description` value.
 
 #### Options

--- a/.README/rules/require-param-description.md
+++ b/.README/rules/require-param-description.md
@@ -1,6 +1,6 @@
 ### `require-param-description`
 
-{"gitdown": "contents", "rootId": "require-param-description"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-require-param-description"}
 
 Requires that each `@param` tag has a `description` value.
 
@@ -16,6 +16,8 @@ for finding function blocks not attached to a function declaration or
 expression, i.e., `@callback` or `@function` (or its aliases `@func` or
 `@method`) (including those associated with an `@interface`).
 
+## Context and settings
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
@@ -23,4 +25,10 @@ expression, i.e., `@callback` or `@function` (or its aliases `@func` or
 |Aliases|`arg`, `argument`|
 |Options|`contexts`|
 
-<!-- assertions requireParamDescription -->
+#### Failing examples
+
+<!-- assertions-failing requireParamDescription -->
+
+#### Passing examples
+
+<!-- assertions-passing requireParamDescription -->

--- a/.README/rules/require-param-name.md
+++ b/.README/rules/require-param-name.md
@@ -1,8 +1,8 @@
 ### `require-param-name`
 
-{"gitdown": "contents", "rootId": "require-param-name"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-require-param-name"}
 
-Requires that all function parameters have names.
+Requires that all `@param` tags have names.
 
 > The `@param` tag requires you to specify the name of the parameter you are documenting. You can also include the parameter's type, enclosed in curly brackets, and a description of the parameter.
 >
@@ -20,6 +20,8 @@ for finding function blocks not attached to a function declaration or
 expression, i.e., `@callback` or `@function` (or its aliases `@func` or
 `@method`) (including those associated with an `@interface`).
 
+#### Context and settings
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
@@ -27,4 +29,10 @@ expression, i.e., `@callback` or `@function` (or its aliases `@func` or
 |Aliases|`arg`, `argument`|
 |Options|`contexts`|
 
-<!-- assertions requireParamName -->
+#### Failing examples
+
+<!-- assertions-failing requireParamName -->
+
+#### Passing examples
+
+<!-- assertions-passing requireParamName -->

--- a/.README/rules/require-param-name.md
+++ b/.README/rules/require-param-name.md
@@ -1,5 +1,7 @@
 ### `require-param-name`
 
+{"gitdown": "contents", "rootId": "require-param-name"}
+
 Requires that all function parameters have names.
 
 > The `@param` tag requires you to specify the name of the parameter you are documenting. You can also include the parameter's type, enclosed in curly brackets, and a description of the parameter.

--- a/.README/rules/require-param-type.md
+++ b/.README/rules/require-param-type.md
@@ -1,5 +1,7 @@
 ### `require-param-type`
 
+{"gitdown": "contents", "rootId": "require-param-type"}
+
 Requires that each `@param` tag has a `type` value.
 
 #### Options

--- a/.README/rules/require-param-type.md
+++ b/.README/rules/require-param-type.md
@@ -1,8 +1,8 @@
 ### `require-param-type`
 
-{"gitdown": "contents", "rootId": "require-param-type"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-require-param-type"}
 
-Requires that each `@param` tag has a `type` value.
+Requires that each `@param` tag has a type value (within curly brackets).
 
 #### Options
 
@@ -16,6 +16,8 @@ for finding function blocks not attached to a function declaration or
 expression, i.e., `@callback` or `@function` (or its aliases `@func` or
 `@method`) (including those associated with an `@interface`).
 
+## Context and settings
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
@@ -23,4 +25,10 @@ expression, i.e., `@callback` or `@function` (or its aliases `@func` or
 |Aliases|`arg`, `argument`|
 |Options|`contexts`|
 
-<!-- assertions requireParamType -->
+#### Failing examples
+
+<!-- assertions-failing requireParamType -->
+
+#### Passing examples
+
+<!-- assertions-passing requireParamType -->

--- a/.README/rules/require-param.md
+++ b/.README/rules/require-param.md
@@ -1,6 +1,6 @@
 ### `require-param`
 
-{"gitdown": "contents", "rootId": "require-param"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-require-param"}
 
 Requires that all function parameters are documented.
 
@@ -11,6 +11,12 @@ An options object accepts one optional property:
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
     block avoids the need for a `@param`. Defaults to an empty array.
 
+#### Fixer
+
+(Todo)
+
+#### Context and settings
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
@@ -19,4 +25,10 @@ An options object accepts one optional property:
 |Options|`exemptedBy`|
 |Settings|`overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`|
 
-<!-- assertions requireParam -->
+#### Failing examples
+
+<!-- assertions-failing requireParam -->
+
+#### Passing examples
+
+<!-- assertions-passing requireParam -->

--- a/.README/rules/require-param.md
+++ b/.README/rules/require-param.md
@@ -1,5 +1,7 @@
 ### `require-param`
 
+{"gitdown": "contents", "rootId": "require-param"}
+
 Requires that all function parameters are documented.
 
 #### Options

--- a/.README/rules/require-property-description.md
+++ b/.README/rules/require-property-description.md
@@ -1,5 +1,7 @@
 ### `require-property-description`
 
+{"gitdown": "contents", "rootId": "require-property-description"}
+
 Requires that each `@property` tag has a `description` value.
 
 |||

--- a/.README/rules/require-property-description.md
+++ b/.README/rules/require-property-description.md
@@ -1,12 +1,21 @@
 ### `require-property-description`
 
-{"gitdown": "contents", "rootId": "require-property-description"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-require-property-description"}
 
 Requires that each `@property` tag has a `description` value.
+
+#### Context and settings
 
 |||
 |---|---|
 |Context|everywhere|
-|Tags|N/A|
+|Tags|`property`|
+|Aliases|`prop`|
 
-<!-- assertions requirePropertyDescription -->
+#### Failing examples
+
+<!-- assertions-failing requirePropertyDescription -->
+
+#### Passing examples
+
+<!-- assertions-passing requirePropertyDescription -->

--- a/.README/rules/require-property-name.md
+++ b/.README/rules/require-property-name.md
@@ -1,5 +1,7 @@
 ### `require-property-name`
 
+{"gitdown": "contents", "rootId": "require-property-name"}
+
 Requires that all function `@property` tags have names.
 
 |||

--- a/.README/rules/require-property-name.md
+++ b/.README/rules/require-property-name.md
@@ -1,12 +1,21 @@
 ### `require-property-name`
 
-{"gitdown": "contents", "rootId": "require-property-name"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-require-property-name"}
 
-Requires that all function `@property` tags have names.
+Requires that all `@property` tags have names.
+
+#### Context and settings
 
 |||
 |---|---|
 |Context|everywhere|
-|Tags|N/A|
+|Tags|`property`|
+|Aliases|`prop`|
 
-<!-- assertions requirePropertyName -->
+#### Failing examples
+
+<!-- assertions-failing requirePropertyName -->
+
+#### Passing examples
+
+<!-- assertions-passing requirePropertyName -->

--- a/.README/rules/require-property-type.md
+++ b/.README/rules/require-property-type.md
@@ -1,5 +1,7 @@
 ### `require-property-type`
 
+{"gitdown": "contents", "rootId": "require-property-type"}
+
 Requires that each `@property` tag has a `type` value.
 
 |||

--- a/.README/rules/require-property-type.md
+++ b/.README/rules/require-property-type.md
@@ -1,12 +1,21 @@
 ### `require-property-type`
 
-{"gitdown": "contents", "rootId": "require-property-type"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-require-property-type"}
 
-Requires that each `@property` tag has a `type` value.
+Requires that each `@property` tag has a type value (within curly brackets).
+
+#### Context and settings
 
 |||
 |---|---|
 |Context|everywhere|
-|Tags|N/A|
+|Tags|`property`|
+|Aliases|`prop`|
 
-<!-- assertions requirePropertyType -->
+#### Failing examples
+
+<!-- assertions-failing requirePropertyType -->
+
+#### Passing examples
+
+<!-- assertions-passing requirePropertyType -->

--- a/.README/rules/require-property.md
+++ b/.README/rules/require-property.md
@@ -1,5 +1,7 @@
 ### `require-property`
 
+{"gitdown": "contents", "rootId": "require-property"}
+
 Requires that all `@typedef` and `@namespace` tags have `@property`
 when their type is a plain `object`, `Object`, or `PlainObject`.
 

--- a/.README/rules/require-property.md
+++ b/.README/rules/require-property.md
@@ -1,9 +1,9 @@
 ### `require-property`
 
-{"gitdown": "contents", "rootId": "require-property"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-require-property"}
 
 Requires that all `@typedef` and `@namespace` tags have `@property`
-when their type is a plain `object`, `Object`, or `PlainObject`.
+tags when their type is a plain `object`, `Object`, or `PlainObject`.
 
 Note that if any other type, including a subtype of object such as
 `object<string, string>`, will not be reported.
@@ -12,9 +12,18 @@ Note that if any other type, including a subtype of object such as
 
 The fixer for `require-example` will add an empty `@property`.
 
+#### Context and settings
+
 |||
 |---|---|
 |Context|Everywhere|
-|Tags|`typedef`, `namespace`|
+|Tags|`property` (relates to presence of `typedef` or `namespace`)|
+|Aliases|`prop`|
 
-<!-- assertions requireProperty -->
+#### Failing examples
+
+<!-- assertions-failing requireProperty -->
+
+#### Passing examples
+
+<!-- assertions-passing requireProperty -->

--- a/.README/rules/require-returns-check.md
+++ b/.README/rules/require-returns-check.md
@@ -1,5 +1,7 @@
 ### `require-returns-check`
 
+{"gitdown": "contents", "rootId": "require-returns-check"}
+
 Requires a return statement in function body if a `@returns` tag is specified in jsdoc comment.
 
 Will also report if multiple `@returns` tags are present.

--- a/.README/rules/require-returns-check.md
+++ b/.README/rules/require-returns-check.md
@@ -1,10 +1,13 @@
 ### `require-returns-check`
 
-{"gitdown": "contents", "rootId": "require-returns-check"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-require-returns-check"}
 
-Requires a return statement in function body if a `@returns` tag is specified in jsdoc comment.
+Requires a return statement be present in a function body if a `@returns`
+tag is specified in the jsdoc comment block.
 
 Will also report if multiple `@returns` tags are present.
+
+#### Context and settings
 
 |||
 |---|---|
@@ -12,4 +15,10 @@ Will also report if multiple `@returns` tags are present.
 |Tags|`returns`|
 |Aliases|`return`|
 
-<!-- assertions requireReturnsCheck -->
+#### Failing examples
+
+<!-- assertions-failing requireReturnsCheck -->
+
+#### Passing examples
+
+<!-- assertions-passing requireReturnsCheck -->

--- a/.README/rules/require-returns-description.md
+++ b/.README/rules/require-returns-description.md
@@ -1,6 +1,6 @@
 ### `require-returns-description`
 
-{"gitdown": "contents", "rootId": "require-returns-description"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-require-returns-description"}
 
 Requires that the `@returns` tag has a `description` value. The error
 will not be reported if the return value is `void` or `undefined`.
@@ -17,6 +17,8 @@ for finding function blocks not attached to a function declaration or
 expression, i.e., `@callback` or `@function` (or its aliases `@func` or
 `@method`) (including those associated with an `@interface`).
 
+#### Context and settings
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
@@ -24,4 +26,10 @@ expression, i.e., `@callback` or `@function` (or its aliases `@func` or
 |Aliases|`return`|
 |Options|`contexts`|
 
-<!-- assertions requireReturnsDescription -->
+#### Failing examples
+
+<!-- assertions-failing requireReturnsDescription -->
+
+#### Passing examples
+
+<!-- assertions-passing requireReturnsDescription -->

--- a/.README/rules/require-returns-description.md
+++ b/.README/rules/require-returns-description.md
@@ -1,5 +1,7 @@
 ### `require-returns-description`
 
+{"gitdown": "contents", "rootId": "require-returns-description"}
+
 Requires that the `@returns` tag has a `description` value. The error
 will not be reported if the return value is `void` or `undefined`.
 

--- a/.README/rules/require-returns-type.md
+++ b/.README/rules/require-returns-type.md
@@ -1,5 +1,7 @@
 ### `require-returns-type`
 
+{"gitdown": "contents", "rootId": "require-returns-type"}
+
 Requires that `@returns` tag has `type` value.
 
 #### Options

--- a/.README/rules/require-returns-type.md
+++ b/.README/rules/require-returns-type.md
@@ -1,8 +1,8 @@
 ### `require-returns-type`
 
-{"gitdown": "contents", "rootId": "require-returns-type"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-require-returns-type"}
 
-Requires that `@returns` tag has `type` value.
+Requires that `@returns` tag has a type value (in curly brackets).
 
 #### Options
 
@@ -16,6 +16,8 @@ for finding function blocks not attached to a function declaration or
 expression, i.e., `@callback` or `@function` (or its aliases `@func` or
 `@method`) (including those associated with an `@interface`).
 
+#### Context and settings
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
@@ -23,4 +25,10 @@ expression, i.e., `@callback` or `@function` (or its aliases `@func` or
 |Aliases|`return`|
 |Options|`contexts`|
 
-<!-- assertions requireReturnsType -->
+#### Failing examples
+
+<!-- assertions-failing requireReturnsType -->
+
+#### Passing examples
+
+<!-- assertions-passing requireReturnsType -->

--- a/.README/rules/require-returns.md
+++ b/.README/rules/require-returns.md
@@ -1,5 +1,7 @@
 ### `require-returns`
 
+{"gitdown": "contents", "rootId": "require-returns"}
+
 Requires returns are documented.
 
 Will also report if multiple `@returns` tags are present.

--- a/.README/rules/require-returns.md
+++ b/.README/rules/require-returns.md
@@ -1,8 +1,8 @@
 ### `require-returns`
 
-{"gitdown": "contents", "rootId": "require-returns"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-require-returns"}
 
-Requires returns are documented.
+Requires that return statements are documented.
 
 Will also report if multiple `@returns` tags are present.
 
@@ -37,6 +37,8 @@ Will also report if multiple `@returns` tags are present.
 'jsdoc/require-returns': ['error', {forceReturnsWithAsync: true}]
 ```
 
+#### Context and settings
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
@@ -45,4 +47,10 @@ Will also report if multiple `@returns` tags are present.
 |Options|`contexts`, `exemptedBy`, `forceRequireReturn`, `forceReturnsWithAsync`|
 |Settings|`overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`|
 
-<!-- assertions requireReturns -->
+#### Failing examples
+
+<!-- assertions-failing requireReturns -->
+
+#### Passing examples
+
+<!-- assertions-passing requireReturns -->

--- a/.README/rules/valid-types.md
+++ b/.README/rules/valid-types.md
@@ -1,5 +1,7 @@
 ### `valid-types`
 
+{"gitdown": "contents", "rootId": "valid-types"}
+
 Requires all types to be valid JSDoc or Closure compiler types without syntax errors.
 
 Also impacts behaviors on namepath (or event)-defining and pointing tags:

--- a/.README/rules/valid-types.md
+++ b/.README/rules/valid-types.md
@@ -1,8 +1,9 @@
 ### `valid-types`
 
-{"gitdown": "contents", "rootId": "valid-types"}
+{"gitdown": "contents", "rootId": "eslint-plugin-jsdoc-rules-valid-types"}
 
-Requires all types to be valid JSDoc or Closure compiler types without syntax errors.
+Requires all types/namepaths to be valid JSDoc, Closure compiler, or TypeScript types
+(configured by `settings.jsdoc.mode`).
 
 Also impacts behaviors on namepath (or event)-defining and pointing tags:
 
@@ -48,6 +49,7 @@ Also impacts behaviors on namepath (or event)-defining and pointing tags:
   that `@see` only use name paths (the tag is normally permitted to
   allow other text)
 
+#### Context and settings
 
 |||
 |---|---|
@@ -58,4 +60,10 @@ Also impacts behaviors on namepath (or event)-defining and pointing tags:
 |Options|`allowEmptyNamepaths`, `checkSeesForNamepaths`|
 |Settings|`mode`|
 
-<!-- assertions validTypes -->
+#### Failing examples
+
+<!-- assertions-failing validTypes -->
+
+#### Passing examples
+
+<!-- assertions-passing validTypes -->

--- a/src/bin/generateReadme.js
+++ b/src/bin/generateReadme.js
@@ -86,17 +86,22 @@ const generateReadme = async () => {
   });
   let documentBody = await gitdown.get();
 
-  documentBody = documentBody.replace(/<!-- assertions ([a-z]+?) -->/gui, (assertionsBlock) => {
-    const ruleName = assertionsBlock.match(/assertions ([a-z]+)/ui)[1];
-    const ruleAssertions = assertions[ruleName];
+  documentBody = documentBody.replace(
+    /<!-- assertions-(passing|failing) ([a-z]+?) -->/gui,
+    (assertionsBlock, passFail, ruleName) => {
+      const ruleAssertions = assertions[ruleName];
 
-    if (!ruleAssertions) {
-      throw new Error(`No assertions available for rule "${ruleName}".`);
-    }
+      if (!ruleAssertions) {
+        throw new Error(`No assertions available for rule "${ruleName}".`);
+      }
 
-    return 'The following patterns are considered problems:\n\n````js\n' + ruleAssertions.invalid.join('\n\n') +
-      '\n````\n\nThe following patterns are not considered problems:\n\n````js\n' + ruleAssertions.valid.join('\n\n') + '\n````\n';
-  });
+      return passFail === 'failing' ?
+        'The following patterns are considered problems:\n\n````js\n' +
+            ruleAssertions.invalid.join('\n\n') + '\n````\n' :
+        'The following patterns are not considered problems:\n\n````js\n' +
+            ruleAssertions.valid.join('\n\n') + '\n````\n';
+    },
+  );
 
   return documentBody;
 };


### PR DESCRIPTION
This is meant as a replacement for #475 (fixing #365 ), bringing the improvements of a Table view of the rules, as well as expanding headings and doc text (without breaking up into separate files).

The build is not currently working though as I'd need figure out the Gitdown usage and why it is not recognizing the `rootId`'s I have used (assuming you like each rule having its own mini Table of Contents as I thought could be convenient). But I thought I'd put it out here before spending more time, to see if this is the kind of approach you'd like, @gajus .

Thanks!

Btw, I guess #472 can be closed then if we are going with this approach. We could point out that the source is still available in individual files, so users could at least look at source separately if they felt overwhelmed.