### PR TITLE
feat(require-returns): add checkGetter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10512,6 +10512,15 @@ async function foo(a) {
 }
 // Options: [{"forceReturnsWithAsync":true}]
 // Message: Missing JSDoc @returns declaration.
+
+class foo {
+  /** gets bar */
+  get bar() {
+    return 0;
+  }
+}
+// Options: [{"checkGetters":true}]
+// Message: Missing JSDoc @returns declaration.
 ````
 
 The following patterns are not considered problems:
@@ -10845,6 +10854,21 @@ async function foo(a) {
  * @callback
  */
 // Options: [{"contexts":["any"],"forceReturnsWithAsync":true}]
+
+class foo {
+  get bar() {
+    return 0;
+  }
+}
+// Options: [{"checkGetters":false}]
+
+class foo {
+  /** @returns zero */
+  get bar() {
+    return 0;
+  }
+}
+// Options: [{"checkGetters":true}]
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -10869,6 +10869,14 @@ class foo {
   }
 }
 // Options: [{"checkGetters":true}]
+
+class foo {
+  /** @returns zero */
+  get bar() {
+    return 0;
+  }
+}
+// Options: [{"checkGetters":false}]
 ````
 
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -174,6 +174,10 @@ const getUtils = (
     return node && node.parent && node.parent.kind === 'constructor';
   };
 
+  utils.isGetter = () => {
+    return node && node.parent.kind === 'get';
+  };
+
   utils.isSetter = () => {
     return node && node.parent.kind === 'set';
   };

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -34,7 +34,7 @@ const canSkip = (utils, checkGetters) => {
     'interface',
   ]) ||
     utils.isConstructor() ||
-    utils.isGetter() && !checkGetters ||
+    !checkGetters && utils.isGetter() ||
     utils.isSetter() ||
     utils.avoidDocs();
 };

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -440,6 +440,28 @@ export default {
         ecmaVersion: 8,
       },
     },
+    {
+      code: `
+      class foo {
+        /** gets bar */
+        get bar() {
+          return 0;
+        }
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      options: [{
+        checkGetters: true,
+      }],
+      parserOptions: {
+        ecmaVersion: 8,
+      },
+    },
   ],
   valid: [
     {
@@ -987,6 +1009,37 @@ export default {
         contexts: ['any'],
         forceReturnsWithAsync: true,
       }],
+    },
+    {
+      code: `
+          class foo {
+            get bar() {
+              return 0;
+            }
+          }
+      `,
+      options: [{
+        checkGetters: false,
+      }],
+      parserOptions: {
+        ecmaVersion: 8,
+      },
+    },
+    {
+      code: `
+          class foo {
+            /** @returns zero */
+            get bar() {
+              return 0;
+            }
+          }
+      `,
+      options: [{
+        checkGetters: true,
+      }],
+      parserOptions: {
+        ecmaVersion: 8,
+      },
     },
   ],
 };

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -1041,5 +1041,21 @@ export default {
         ecmaVersion: 8,
       },
     },
+    {
+      code: `
+          class foo {
+            /** @returns zero */
+            get bar() {
+              return 0;
+            }
+          }
+      `,
+      options: [{
+        checkGetters: false,
+      }],
+      parserOptions: {
+        ecmaVersion: 8,
+      },
+    },
   ],
 };


### PR DESCRIPTION
Implimentation for https://github.com/gajus/eslint-plugin-jsdoc/issues/503

This PR adds for the rule `jsdoc/require-returns` a new boolean option `checkGetters`, which defaults to `true`, as is the rule current behavior of the rule without the option.

When `checkGetters = false`, it allows developers to omit the `@returns` tag for `get` functions, e.g.:

```js
// jsdoc/require-returns: ["error", { checkGetters: false }]

class Foo {
    /** gets bar value of zero */
    get bar() {
        return 0;
    }
}
```

The motivation behind this option is because in regular `eslint`, the `valid-jsdoc` rule automatically ignores `get` functions, so direct porting to this plugin is now possible. This also allows for a greater flexibility as developers can choose if they do or do not want to require the `@returns` tag for these `get` functions.