### PR TITLE
exempt descriptions for `Promise<void>` and `Promise<undefined>`

### DIFF
--- a/.README/rules/require-returns-description.md
+++ b/.README/rules/require-returns-description.md
@@ -1,7 +1,8 @@
 ### `require-returns-description`
 
 Requires that the `@returns` tag has a `description` value. The error
-will not be reported if the return value is `void` or `undefined`.
+will not be reported if the return value is `void` or `undefined`
+or if it is `Promise<void>` or `Promise<undefined>`.
 
 #### Options
 

--- a/README.md
+++ b/README.md
@@ -11424,7 +11424,8 @@ function quux () {
 ### <code>require-returns-description</code>
 
 Requires that the `@returns` tag has a `description` value. The error
-will not be reported if the return value is `void` or `undefined`.
+will not be reported if the return value is `void` or `undefined`
+or if it is `Promise<void>` or `Promise<undefined>`.
 
 <a name="eslint-plugin-jsdoc-rules-require-returns-description-options-24"></a>
 #### Options
@@ -11542,6 +11543,20 @@ function quux () {
 
 /**
  * @returns {void}
+ */
+function quux () {
+
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+function quux () {
+
+}
+
+/**
+ * @returns {Promise<undefined>}
  */
 function quux () {
 

--- a/src/rules/requireReturnsDescription.js
+++ b/src/rules/requireReturnsDescription.js
@@ -7,7 +7,7 @@ export default iterateJsdoc(({
   utils.forEachPreferredTag('returns', (jsdocTag, targetTagName) => {
     const type = jsdocTag.type && jsdocTag.type.trim();
 
-    if (type === 'void' || type === 'undefined') {
+    if (['void', 'undefined', 'Promise<void>', 'Promise<undefined>'].includes(type)) {
       return;
     }
 

--- a/test/rules/assertions/requireReturnsDescription.js
+++ b/test/rules/assertions/requireReturnsDescription.js
@@ -196,6 +196,26 @@ export default {
     {
       code: `
           /**
+           * @returns {Promise<void>}
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @returns {Promise<undefined>}
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
            * @function
            * @returns
            */


### PR DESCRIPTION
feat(require-returns-description): avoid reporting missing descriptions for `Promise<void>` and `Promise<undefined>`. Fixes #525.