### PR TITLE
feat(check-param-names, check-property-names): add `enableFixer` option

### DIFF
--- a/.README/rules/check-param-names.md
+++ b/.README/rules/check-param-names.md
@@ -39,10 +39,10 @@ See `require-param` under the option of the same name.
 
 ##### `enableFixer`
 
-Set to `false` to avoid auto-removing `@param`'s duplicates (based on
-identical names).
+Set to `true` to auto-remove `@param` duplicates (based on identical
+names).
 
-Note that, by default, duplicates of the same name are removed even if
+Note that this option will remove duplicates of the same name even if
 the definitions do not match in other ways (e.g., the second param will
 be removed even if it has a different type or description).
 

--- a/.README/rules/check-param-names.md
+++ b/.README/rules/check-param-names.md
@@ -37,6 +37,15 @@ See the "Destructuring" section. Defaults to `false`.
 
 See `require-param` under the option of the same name.
 
+##### `enableFixer`
+
+Set to `false` to avoid auto-removing `@param`'s duplicates (based on
+identical names).
+
+Note that, by default, duplicates of the same name are removed even if
+the definitions do not match in other ways (e.g., the second param will
+be removed even if it has a different type or description).
+
 ##### `allowExtraTrailingParamDocs`
 
 If set to `true`, this option will allow extra `@param` definitions (e.g.,

--- a/.README/rules/check-property-names.md
+++ b/.README/rules/check-property-names.md
@@ -7,10 +7,10 @@ and that nested properties have defined roots.
 
 ##### `enableFixer`
 
-Set to `false` to avoid auto-removing `@property`'s duplicates (based on
+Set to `true` to auto-remove `@property` duplicates (based on
 identical names).
 
-Note that, by default, duplicates of the same name are removed even if
+Note that this option will remove duplicates of the same name even if
 the definitions do not match in other ways (e.g., the second property will
 be removed even if it has a different type or description).
 

--- a/.README/rules/check-property-names.md
+++ b/.README/rules/check-property-names.md
@@ -5,9 +5,19 @@ and that nested properties have defined roots.
 
 #### Options
 
+##### `enableFixer`
+
+Set to `false` to avoid auto-removing `@property`'s duplicates (based on
+identical names).
+
+Note that, by default, duplicates of the same name are removed even if
+the definitions do not match in other ways (e.g., the second property will
+be removed even if it has a different type or description).
+
 |||
 |---|---|
 |Context|Everywhere|
+|Options|`enableFixer`|
 |Tags|`property`|
 
 <!-- assertions checkPropertyNames -->

--- a/README.md
+++ b/README.md
@@ -1584,6 +1584,16 @@ See the "Destructuring" section. Defaults to `false`.
 
 See `require-param` under the option of the same name.
 
+<a name="eslint-plugin-jsdoc-rules-check-param-names-options-3-enablefixer"></a>
+##### <code>enableFixer</code>
+
+Set to `false` to avoid auto-removing `@param`'s duplicates (based on
+identical names).
+
+Note that, by default, duplicates of the same name are removed even if
+the definitions do not match in other ways (e.g., the second param will
+be removed even if it has a different type or description).
+
 <a name="eslint-plugin-jsdoc-rules-check-param-names-options-3-allowextratrailingparamdocs"></a>
 ##### <code>allowExtraTrailingParamDocs</code>
 
@@ -1717,6 +1727,17 @@ function quux (foo, foo) {
 function quux ({foo}) {
 
 }
+// Message: Duplicate @param "cfg.foo"
+
+/**
+ * @param cfg
+ * @param cfg.foo
+ * @param cfg.foo
+ */
+function quux ({foo}) {
+
+}
+// Options: [{"enableFixer":false}]
 // Message: Duplicate @param "cfg.foo"
 
 /**
@@ -2088,9 +2109,20 @@ and that nested properties have defined roots.
 <a name="eslint-plugin-jsdoc-rules-check-property-names-options-4"></a>
 #### Options
 
+<a name="eslint-plugin-jsdoc-rules-check-property-names-options-4-enablefixer-1"></a>
+##### <code>enableFixer</code>
+
+Set to `false` to avoid auto-removing `@property`'s duplicates (based on
+identical names).
+
+Note that, by default, duplicates of the same name are removed even if
+the definitions do not match in other ways (e.g., the second property will
+be removed even if it has a different type or description).
+
 |||
 |---|---|
 |Context|Everywhere|
+|Options|`enableFixer`|
 |Tags|`property`|
 
 The following patterns are considered problems:
@@ -2130,6 +2162,14 @@ The following patterns are considered problems:
  * @property foo
  * @property foo
  */
+// Message: Duplicate @property "foo"
+
+/**
+ * @typedef (SomeType) SomeTypedef
+ * @property foo
+ * @property foo
+ */
+// Options: [{"enableFixer":false}]
 // Message: Duplicate @property "foo"
 
 /**
@@ -9485,7 +9525,7 @@ function signature, it may appear that there is an actual property named
 
 An options object accepts the following optional properties:
 
-<a name="eslint-plugin-jsdoc-rules-require-param-options-23-enablefixer"></a>
+<a name="eslint-plugin-jsdoc-rules-require-param-options-23-enablefixer-2"></a>
 ##### <code>enableFixer</code>
 
 Whether to enable the fixer. Defaults to `true`.

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -188,7 +188,7 @@ export default iterateJsdoc(({
     allowExtraTrailingParamDocs,
     checkRestProperty = false,
     checkTypesPattern = '/^(?:[oO]bject|[aA]rray|PlainObject|Generic(?:Object|Array))$/',
-    enableFixer = true,
+    enableFixer = false,
   } = context.options[0] || {};
 
   const lastSlashPos = checkTypesPattern.lastIndexOf('/');

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -5,6 +5,7 @@ const validateParameterNames = (
   allowExtraTrailingParamDocs: boolean,
   checkRestProperty : boolean,
   checkTypesRegex : RegExp,
+  enableFixer: boolean,
   functionParameterNames : Array<string>, jsdoc, jsdocNode, utils, report,
 ) => {
   const paramTags = Object.entries(jsdoc.tags).filter(([, tag]) => {
@@ -24,9 +25,9 @@ const validateParameterNames = (
       return tg.name === tag.name && idx !== index;
     });
     if (dupeTagInfo) {
-      utils.reportJSDoc(`Duplicate @${targetTagName} "${tag.name}"`, dupeTagInfo[1], () => {
+      utils.reportJSDoc(`Duplicate @${targetTagName} "${tag.name}"`, dupeTagInfo[1], enableFixer ? () => {
         jsdoc.tags.splice(tagsIndex, 1);
-      });
+      } : null);
 
       return true;
     }
@@ -187,6 +188,7 @@ export default iterateJsdoc(({
     allowExtraTrailingParamDocs,
     checkRestProperty = false,
     checkTypesPattern = '/^(?:[oO]bject|[aA]rray|PlainObject|Generic(?:Object|Array))$/',
+    enableFixer = true,
   } = context.options[0] || {};
 
   const lastSlashPos = checkTypesPattern.lastIndexOf('/');
@@ -202,8 +204,10 @@ export default iterateJsdoc(({
   const targetTagName = utils.getPreferredTagName({tagName: 'param'});
   const isError = validateParameterNames(
     targetTagName,
-    allowExtraTrailingParamDocs, checkRestProperty,
+    allowExtraTrailingParamDocs,
+    checkRestProperty,
     checkTypesRegex,
+    enableFixer,
     functionParameterNames,
     jsdoc, jsdocNode, utils, report,
   );
@@ -231,6 +235,9 @@ export default iterateJsdoc(({
           },
           checkTypesPattern: {
             type: 'string',
+          },
+          enableFixer: {
+            type: 'boolean',
           },
         },
         type: 'object',

--- a/src/rules/checkPropertyNames.js
+++ b/src/rules/checkPropertyNames.js
@@ -76,7 +76,7 @@ export default iterateJsdoc(({
   utils,
 }) => {
   const {
-    enableFixer = true,
+    enableFixer = false,
   } = context.options[0] || {};
   const jsdocPropertyNamesDeep = utils.getJsdocTagsDeep('property');
   if (!jsdocPropertyNamesDeep.length) {

--- a/src/rules/checkPropertyNames.js
+++ b/src/rules/checkPropertyNames.js
@@ -2,6 +2,7 @@ import iterateJsdoc from '../iterateJsdoc';
 
 const validatePropertyNames = (
   targetTagName : string,
+  enableFixer : boolean,
   jsdoc, jsdocNode, utils,
 ) => {
   const propertyTags = Object.entries(jsdoc.tags).filter(([, tag]) => {
@@ -16,9 +17,9 @@ const validatePropertyNames = (
       return tg.name === tag.name && idx !== index;
     });
     if (dupeTagInfo) {
-      utils.reportJSDoc(`Duplicate @${targetTagName} "${tag.name}"`, dupeTagInfo[1], () => {
+      utils.reportJSDoc(`Duplicate @${targetTagName} "${tag.name}"`, dupeTagInfo[1], enableFixer ? () => {
         jsdoc.tags.splice(tagsIndex, 1);
-      });
+      } : null);
 
       return true;
     }
@@ -68,11 +69,15 @@ const validatePropertyNamesDeep = (
 };
 
 export default iterateJsdoc(({
+  context,
   jsdoc,
   jsdocNode,
   report,
   utils,
 }) => {
+  const {
+    enableFixer = true,
+  } = context.options[0] || {};
   const jsdocPropertyNamesDeep = utils.getJsdocTagsDeep('property');
   if (!jsdocPropertyNamesDeep.length) {
     return;
@@ -80,6 +85,7 @@ export default iterateJsdoc(({
   const targetTagName = utils.getPreferredTagName({tagName: 'property'});
   const isError = validatePropertyNames(
     targetTagName,
+    enableFixer,
     jsdoc, jsdocNode, utils,
   );
 
@@ -95,6 +101,17 @@ export default iterateJsdoc(({
   iterateAllJsdocs: true,
   meta: {
     fixable: 'code',
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          enableFixer: {
+            type: 'boolean',
+          },
+        },
+        type: 'object',
+      },
+    ],
     type: 'suggestion',
   },
 });

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -281,6 +281,39 @@ export default {
           /**
            * @param cfg
            * @param cfg.foo
+           * @param cfg.foo
+           */
+          function quux ({foo}) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 5,
+          message: 'Duplicate @param "cfg.foo"',
+        },
+      ],
+      options: [
+        {
+          enableFixer: false,
+        },
+      ],
+      output: `
+          /**
+           * @param cfg
+           * @param cfg.foo
+           * @param cfg.foo
+           */
+          function quux ({foo}) {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @param cfg
+           * @param cfg.foo
            */
           function quux ({foo, bar}) {
 

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -129,6 +129,11 @@ export default {
           message: 'Duplicate @param "employees[].name"',
         },
       ],
+      options: [
+        {
+          enableFixer: true,
+        },
+      ],
       output: `
           /**
            * Assign the project to a list of employees.
@@ -190,6 +195,11 @@ export default {
           message: 'Duplicate @param "foo"',
         },
       ],
+      options: [
+        {
+          enableFixer: true,
+        },
+      ],
       output: `
           /**
            * @param foo
@@ -215,6 +225,11 @@ export default {
           message: 'Duplicate @param "foo"',
         },
       ],
+      options: [
+        {
+          enableFixer: true,
+        },
+      ],
       output: `
           /**
            * @param foo
@@ -240,6 +255,11 @@ export default {
           message: 'Duplicate @param "foo"',
         },
       ],
+      options: [
+        {
+          enableFixer: true,
+        },
+      ],
       output: `
           /**
            * @param foo
@@ -266,6 +286,11 @@ export default {
           message: 'Duplicate @param "cfg.foo"',
         },
       ],
+      options: [
+        {
+          enableFixer: true,
+        },
+      ],
       output: `
           /**
            * @param cfg
@@ -291,11 +316,6 @@ export default {
         {
           line: 5,
           message: 'Duplicate @param "cfg.foo"',
-        },
-      ],
-      options: [
-        {
-          enableFixer: false,
         },
       ],
       output: `
@@ -344,6 +364,11 @@ export default {
           message: 'Duplicate @param "cfg.foo"',
         },
       ],
+      options: [
+        {
+          enableFixer: true,
+        },
+      ],
       output: `
           /**
            * @param cfg
@@ -390,6 +415,11 @@ export default {
         {
           line: 5,
           message: 'Duplicate @param "cfg.foo"',
+        },
+      ],
+      options: [
+        {
+          enableFixer: true,
         },
       ],
       output: `

--- a/test/rules/assertions/checkPropertyNames.js
+++ b/test/rules/assertions/checkPropertyNames.js
@@ -99,6 +99,33 @@ export default {
       code: `
           /**
            * @typedef (SomeType) SomeTypedef
+           * @property foo
+           * @property foo
+           */
+      `,
+      errors: [
+        {
+          line: 5,
+          message: 'Duplicate @property "foo"',
+        },
+      ],
+      options: [
+        {
+          enableFixer: false,
+        },
+      ],
+      output: `
+          /**
+           * @typedef (SomeType) SomeTypedef
+           * @property foo
+           * @property foo
+           */
+      `,
+    },
+    {
+      code: `
+          /**
+           * @typedef (SomeType) SomeTypedef
            * @property cfg
            * @property cfg.foo
            * @property cfg.foo

--- a/test/rules/assertions/checkPropertyNames.js
+++ b/test/rules/assertions/checkPropertyNames.js
@@ -66,6 +66,11 @@ export default {
           message: 'Duplicate @property "employees[].name"',
         },
       ],
+      options: [
+        {
+          enableFixer: true,
+        },
+      ],
       output: `
           /**
            * Assign the project to a list of employees.
@@ -88,6 +93,11 @@ export default {
           message: 'Duplicate @property "foo"',
         },
       ],
+      options: [
+        {
+          enableFixer: true,
+        },
+      ],
       output: `
           /**
            * @typedef (SomeType) SomeTypedef
@@ -107,11 +117,6 @@ export default {
         {
           line: 5,
           message: 'Duplicate @property "foo"',
-        },
-      ],
-      options: [
-        {
-          enableFixer: false,
         },
       ],
       output: `
@@ -138,6 +143,11 @@ export default {
         {
           line: 6,
           message: 'Duplicate @property "cfg.foo"',
+        },
+      ],
+      options: [
+        {
+          enableFixer: true,
         },
       ],
       output: `
@@ -168,6 +178,11 @@ export default {
         {
           line: 6,
           message: 'Duplicate @property "cfg.foo"',
+        },
+      ],
+      options: [
+        {
+          enableFixer: true,
         },
       ],
       output: `
@@ -201,6 +216,11 @@ export default {
           message: 'Duplicate @property "cfg.foo"',
         },
       ],
+      options: [
+        {
+          enableFixer: true,
+        },
+      ],
       output: `
           /**
            * @typedef (SomeType) SomeTypedef
@@ -225,6 +245,11 @@ export default {
         {
           line: 5,
           message: 'Duplicate @prop "foo"',
+        },
+      ],
+      options: [
+        {
+          enableFixer: true,
         },
       ],
       output: `


### PR DESCRIPTION
Allows disabling duplicate fixing.