### PR TITLE
fix(check-tag-names): Workaround for 'constructor' key in tagNamePreference

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -156,7 +156,7 @@ Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a
 }
 ```
 
-Note: ESLint does not allow settings to have keys which conflict with Object.prototype e.g. `'constructor'`. To work around this use can use the key `'tag constructor'`.
+Note: ESLint does not allow settings to have keys which conflict with `Object.prototype` e.g. `'constructor'`. To work around this, you can use the key `'tag constructor'`.
 
 One may also use an object with a `message` and `replacement`.
 

--- a/.README/README.md
+++ b/.README/README.md
@@ -156,6 +156,8 @@ Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a
 }
 ```
 
+Note: ESLint does not allow settings to have keys which conflict with Object.prototype e.g. `'constructor'`. To work around this use can use the key `'tag constructor'`.
+
 One may also use an object with a `message` and `replacement`.
 
 The following will report the message `@extends is to be used over @augments as it is more evocative of classes than @augments` upon encountering `@augments`.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a
 }
 ```
 
-Note: ESLint does not allow settings to have keys which conflict with Object.prototype e.g. `'constructor'`. To work around this use can use the key `'tag constructor'`.
+Note: ESLint does not allow settings to have keys which conflict with `Object.prototype` e.g. `'constructor'`. To work around this, you can use the key `'tag constructor'`.
 
 One may also use an object with a `message` and `replacement`.
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ Use `settings.jsdoc.tagNamePreference` to configure a preferred alias name for a
 }
 ```
 
+Note: ESLint does not allow settings to have keys which conflict with Object.prototype e.g. `'constructor'`. To work around this use can use the key `'tag constructor'`.
+
 One may also use an object with a `message` and `replacement`.
 
 The following will report the message `@extends is to be used over @augments as it is more evocative of classes than @augments` upon encountering `@augments`.
@@ -2613,6 +2615,15 @@ function quux (foo) {
 }
 // Settings: {"jsdoc":{"tagNamePreference":{"param":"arg"}}}
 // Message: Invalid JSDoc tag (preference). Replace "param" JSDoc tag with "arg".
+
+/**
+ * @constructor foo
+ */
+function quux (foo) {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"tag constructor":"cons"}}}
+// Message: Invalid JSDoc tag (preference). Replace "constructor" JSDoc tag with "cons".
 
 /**
  * @arg foo

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -223,8 +223,15 @@ const getPreferredTagName = (
     return name;
   }
 
-  if (_.has(tagPreference, name)) {
-    return tagPreference[name];
+  // Allow keys to have a 'tag ' prefix to avoid upstream bug in ESLint
+  // that disallows keys that conflict with Object.prototype,
+  // e.g. 'tag constructor' for 'constructor' (#537)
+  const tagPreferenceFixed = _.mapKeys(tagPreference, (value, key) => {
+    return key.replace('tag ', '');
+  });
+
+  if (_.has(tagPreferenceFixed, name)) {
+    return tagPreferenceFixed[name];
   }
 
   const tagNames = getTagNamesForMode(mode, context);

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -216,7 +216,7 @@ const getPreferredTagName = (
   name : string,
   tagPreference : Object = {},
 ) : string|Object => {
-  const prefValues = _.values(tagPreference);
+  const prefValues = Object.values(tagPreference);
   if (prefValues.includes(name) || prefValues.some((prefVal) => {
     return prefVal && typeof prefVal === 'object' && prefVal.replacement === name;
   })) {
@@ -236,9 +236,9 @@ const getPreferredTagName = (
 
   const tagNames = getTagNamesForMode(mode, context);
 
-  const preferredTagName = _.findKey(tagNames, (aliases) => {
+  const preferredTagName = Object.entries(tagNames).find(([, aliases]) => {
     return aliases.includes(name);
-  });
+  })?.[0];
   if (preferredTagName) {
     return preferredTagName;
   }
@@ -253,7 +253,7 @@ const isValidTag = (
   definedTags : Array,
 ) : boolean => {
   const tagNames = getTagNamesForMode(mode, context);
-  const validTagNames = _.keys(tagNames).concat(_.flatten(_.values(tagNames)));
+  const validTagNames = Object.keys(tagNames).concat(_.flatten(Object.values(tagNames)));
   const additionalTags = definedTags;
   const allTags = validTagNames.concat(additionalTags);
 

--- a/test/rules/assertions/checkTagNames.js
+++ b/test/rules/assertions/checkTagNames.js
@@ -115,6 +115,37 @@ export default {
     {
       code: `
           /**
+           * @constructor foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc tag (preference). Replace "constructor" JSDoc tag with "cons".',
+        },
+      ],
+      output: `
+          /**
+           * @cons foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            'tag constructor': 'cons',
+          },
+        },
+      },
+    },
+    {
+      code: `
+          /**
            * @arg foo
            */
           function quux (foo) {


### PR DESCRIPTION
Fixes #537