### PR TITLE
chore: update dep. spdx-expression-parse and devDeps.; apply new linting

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -8,7 +8,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": 6
+          "node": 8
         }
       }
     ]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.15",
     "regextras": "^0.7.1",
     "semver": "^6.3.0",
-    "spdx-expression-parse": "^3.0.0"
+    "spdx-expression-parse": "^3.0.1"
   },
   "description": "JSDoc linting rules for ESLint.",
   "devDependencies": {
@@ -21,14 +21,14 @@
     "@babel/plugin-transform-flow-strip-types": "^7.9.0",
     "@babel/preset-env": "^7.9.6",
     "@babel/register": "^7.9.0",
-    "@typescript-eslint/parser": "^2.32.0",
+    "@typescript-eslint/parser": "^2.33.0",
     "babel-eslint": "^10.1.0",
     "babel-plugin-add-module-exports": "^1.0.2",
     "babel-plugin-istanbul": "^6.0.0",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "eslint": "7.0.0",
-    "eslint-config-canonical": "^19.0.4",
+    "eslint-config-canonical": "^20.0.4",
     "gitdown": "^3.1.3",
     "glob": "^7.1.6",
     "husky": "^4.2.5",
@@ -36,7 +36,7 @@
     "nyc": "^15.0.1",
     "rimraf": "^3.0.2",
     "semantic-release": "^17.0.7",
-    "typescript": "^3.8.3"
+    "typescript": "^3.9.2"
   },
   "engines": {
     "node": ">=8"

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -8,7 +8,7 @@ const globalState = new Map();
 
 const skipSeeLink = (parser) => {
   return (str, data) => {
-    if (data.tag === 'see' && str.match(/\{@link.+?\}/u)) {
+    if (data.tag === 'see' && (/\{@link.+?\}/u).test(str)) {
       return null;
     }
 

--- a/src/rules/checkTypes.js
+++ b/src/rules/checkTypes.js
@@ -121,7 +121,7 @@ export default iterateJsdoc(({
 
     try {
       typeAst = parse(jsdocTag.type);
-    } catch (error) {
+    } catch {
       return;
     }
 

--- a/src/rules/checkValues.js
+++ b/src/rules/checkValues.js
@@ -67,7 +67,7 @@ export default iterateJsdoc(({
     } else {
       try {
         spdxExpressionParse(license);
-      } catch (error) {
+      } catch {
         report(
           `Invalid JSDoc @${targetTagName}: "${license}"; expected SPDX expression: https://spdx.org/licenses/.`,
           null,

--- a/src/rules/emptyTags.js
+++ b/src/rules/emptyTags.js
@@ -1,20 +1,20 @@
 import iterateJsdoc from '../iterateJsdoc';
 
-const defaultEmptyTags = [
+const defaultEmptyTags = new Set([
   'abstract', 'async', 'generator', 'global', 'hideconstructor',
   'ignore', 'inner', 'instance', 'override', 'readonly',
 
   // jsdoc doesn't use this form in its docs, but allow for compatibility with
   //  TypeScript which allows and Closure which requires
   'inheritDoc',
-];
+]);
 
-const emptyIfNotClosure = [
+const emptyIfNotClosure = new Set([
   'package', 'private', 'protected', 'public', 'static',
 
   // Closure doesn't allow with this casing
   'inheritdoc',
-];
+]);
 
 export default iterateJsdoc(({
   settings,
@@ -25,11 +25,11 @@ export default iterateJsdoc(({
     return;
   }
   const emptyTags = utils.filterTags(({tag: tagName}) => {
-    return defaultEmptyTags.includes(tagName) ||
+    return defaultEmptyTags.has(tagName) ||
       utils.hasOptionTag(tagName) && jsdoc.tags.some(({tag}) => {
         return tag === tagName;
       }) ||
-      settings.mode !== 'closure' && emptyIfNotClosure.includes(tagName);
+      settings.mode !== 'closure' && emptyIfNotClosure.has(tagName);
   });
   emptyTags.forEach((tag) => {
     const fix = () => {

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -80,8 +80,8 @@ export default iterateJsdoc(({
     return jsdocUtils.parseClosureTemplateTag(tag);
   });
 
-  const allDefinedTypes = new Set(globalScope.variables.map((variable) => {
-    return variable.name;
+  const allDefinedTypes = new Set(globalScope.variables.map(({name}) => {
+    return name;
   })
 
     // If the file is a module, concat the variables from the module scope.

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -90,12 +90,9 @@ export default iterateJsdoc(({
       // This covers `commonjs` as well as `node`
       scopeManager.__options.nodejsScope ||
       scopeManager.isModule() ?
-        // eslint-disable-next-line unicorn/no-reduce
-        globalScope.childScopes.reduce((arr, {variables}) => {
+        _.flatMap(globalScope.childScopes, ({variables}) => {
           // Flatten
-          arr.push(...variables);
-
-          return arr;
+          return variables;
         }, []).map(({name}) => {
           return name;
         }) : [],

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -67,11 +67,11 @@ export default iterateJsdoc(({
 
   let templateTags = utils.getPresentTags('template');
   const classJsdoc = utils.getClassJsdoc();
-  if (classJsdoc && classJsdoc.tags) {
+  if (classJsdoc?.tags) {
     templateTags = templateTags.concat(
       classJsdoc.tags
-        .filter((tag) => {
-          return tag.tag === 'template';
+        .filter(({tag}) => {
+          return tag === 'template';
         }),
     );
   }
@@ -102,8 +102,8 @@ export default iterateJsdoc(({
     .concat(definedPreferredTypes)
     .concat(settings.mode === 'jsdoc' ? [] : closureGenericTypes));
 
-  const jsdocTagsWithPossibleType = utils.filterTags((tag) => {
-    return utils.tagMightHaveTypePosition(tag.tag);
+  const jsdocTagsWithPossibleType = utils.filterTags(({tag}) => {
+    return utils.tagMightHaveTypePosition(tag);
   });
 
   jsdocTagsWithPossibleType.forEach((tag) => {

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -91,7 +91,6 @@ export default iterateJsdoc(({
       scopeManager.__options.nodejsScope ||
       scopeManager.isModule() ?
         _.flatMap(globalScope.childScopes, ({variables}) => {
-          // Flatten
           return variables;
         }, []).map(({name}) => {
           return name;

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -2,13 +2,13 @@ import _ from 'lodash';
 import {RegExtras} from 'regextras/dist/main-umd';
 import iterateJsdoc from '../iterateJsdoc';
 
-const otherDescriptiveTags = [
+const otherDescriptiveTags = new Set([
   // 'copyright' and 'see' might be good addition, but as the former may be
   //   sensitive text, and the latter may have just a link, they are not
   //   included by default
   'summary', 'file', 'fileoverview', 'overview', 'classdesc', 'todo',
   'deprecated', 'throws', 'exception', 'yields', 'yield',
-];
+]);
 
 const extractParagraphs = (text) => {
   // Todo [engine:node@>8.11.0]: Uncomment following line with neg. lookbehind instead
@@ -175,7 +175,7 @@ export default iterateJsdoc(({
 
   const {tagsWithNames} = utils.getTagsByType(jsdoc.tags);
   const tagsWithoutNames = utils.filterTags(({tag: tagName}) => {
-    return otherDescriptiveTags.includes(tagName) ||
+    return otherDescriptiveTags.has(tagName) ||
       utils.hasOptionTag(tagName) && !tagsWithNames.some(({tag}) => {
         // If user accidentally adds tags with names (or like `returns`
         //  get parsed as having names), do not add to this list

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -119,20 +119,22 @@ const getOptions = (context) => {
         return false;
       }
 
-      return Object.keys(baseObj.properties).reduce((obj, prop) => {
+      const properties = {};
+      Object.keys(baseObj.properties).forEach((prop) => {
         const opt = getOption(context, baseObj, 'publicOnly', prop);
-        obj[prop] = opt;
+        properties[prop] = opt;
+      });
 
-        return obj;
-      }, {});
+      return properties;
     })(OPTIONS_SCHEMA.properties.publicOnly.oneOf[1]),
     require: ((baseObj) => {
-      return Object.keys(baseObj.properties).reduce((obj, prop) => {
+      const properties = {};
+      Object.keys(baseObj.properties).forEach((prop) => {
         const opt = getOption(context, baseObj, 'require', prop);
-        obj[prop] = opt;
+        properties[prop] = opt;
+      });
 
-        return obj;
-      }, {});
+      return properties;
     })(OPTIONS_SCHEMA.properties.require),
   };
 };

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -65,11 +65,11 @@ export default iterateJsdoc(({
 
   const missingTags = [];
   const flattenedRoots = utils.flattenRoots(functionParameterNames).names;
-  const paramIndex = flattenedRoots.reduce((acc, cur, idx) => {
-    acc[cur] = idx;
 
-    return acc;
-  }, {});
+  const paramIndex = {};
+  flattenedRoots.forEach((cur, idx) => {
+    paramIndex[cur] = idx;
+  });
 
   const findExpectedIndex = (jsdocTags, indexAtFunctionParams) => {
     const remainingRoots = functionParameterNames.slice(indexAtFunctionParams || 0);

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -24,7 +24,7 @@ export default iterateJsdoc(({
     const validNamepathParsing = function (namepath, tagName) {
       try {
         parse(namepath);
-      } catch (error) {
+      } catch {
         let handled = false;
 
         if (tagName) {
@@ -34,7 +34,7 @@ export default iterateJsdoc(({
               try {
                 parse(namepath.slice(0, -1));
                 handled = true;
-              } catch (memberofError) {
+              } catch {
                 // Use the original error for including the whole type
               }
             }
@@ -44,7 +44,7 @@ export default iterateJsdoc(({
               try {
                 parse(namepath.slice(1));
                 handled = true;
-              } catch (memberofError) {
+              } catch {
                 // Use the original error for including the whole type
               }
             }
@@ -64,7 +64,7 @@ export default iterateJsdoc(({
     const validTypeParsing = function (type) {
       try {
         parse(type);
-      } catch (error) {
+      } catch {
         report(`Syntax error in type: ${type}`, null, tag);
 
         return false;

--- a/test/rules/assertions/checkTagNames.js
+++ b/test/rules/assertions/checkTagNames.js
@@ -1,9 +1,9 @@
 import {jsdocTags, typeScriptTags, closureTags} from '../../../src/tagNames';
 
 const buildTagBlock = (tags) => {
-  return '/** \n * @' + Object.keys(tags).reduce((string, tagName, idx) => {
-    return string + (idx === 0 ? '' : '\n * @') + tagName;
-  }, '') + '\n */';
+  return '/** \n * @' + Object.keys(tags).map((tagName, idx) => {
+    return (idx === 0 ? '' : '\n * @') + tagName;
+  }).join('') + '\n */';
 };
 
 // We avoid testing all closure tags as too many


### PR DESCRIPTION
@gajus, here's how the linting changes may look...  (Related to https://github.com/gajus/eslint-config-canonical/issues/23 )

Though I re-enabled `reduce` in a couple cases, I think it is mostly more readable. (I conceptually like `reduce` better as it is just one action (e.g., not a `map` and `join`, or a variable declaration and `forEach`), but I'll admit it can *look* less intuitive, so except in the two cases, I think it has indeed become more readable after dropping `reduce`).