### PR TITLE
`require-description-complete-sentence`: `newlineBeforeCapsAssumesBadSentenceEnd` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6348,6 +6348,7 @@ function quux () {
 function quux () {
 
 }
+// Options: [{"newlineBeforeCapsAssumesBadSentenceEnd":true}]
 // Message: A line of text is started with an uppercase character, but preceding line does not end the sentence.
 
 /**
@@ -6565,6 +6566,15 @@ function quux () {
 
  }
 // Message: Sentence should start with an uppercase character.
+
+/**
+ * Implements support for the
+ * Swahili voice synthesizer.
+ */
+function speak() {
+}
+// Options: [{"newlineBeforeCapsAssumesBadSentenceEnd":true}]
+// Message: A line of text is started with an uppercase character, but preceding line does not end the sentence.
 ````
 
 The following patterns are not considered problems:
@@ -6877,6 +6887,13 @@ function quux () {
 
 }
 // Options: [{"abbreviations":["etc","e.g.","i.e."]}]
+
+/**
+ * Implements support for the
+ * Swahili voice synthesizer.
+ */
+function speak() {
+}
 ````
 
 

--- a/test/rules/assertions/requireDescriptionCompleteSentence.js
+++ b/test/rules/assertions/requireDescriptionCompleteSentence.js
@@ -210,6 +210,9 @@ export default {
           message: 'A line of text is started with an uppercase character, but preceding line does not end the sentence.',
         },
       ],
+      options: [{
+        newlineBeforeCapsAssumesBadSentenceEnd: true,
+      }],
     },
     {
       code: `
@@ -822,6 +825,25 @@ export default {
        }
        `,
     },
+    {
+      code: `
+      /**
+       * Implements support for the
+       * Swahili voice synthesizer.
+       */
+      function speak() {
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'A line of text is started with an uppercase character, but preceding line does not end the sentence.',
+        },
+      ],
+      options: [{
+        newlineBeforeCapsAssumesBadSentenceEnd: true,
+      }],
+    },
   ],
   valid: [
     {
@@ -1279,6 +1301,16 @@ export default {
       options: [{
         abbreviations: ['etc', 'e.g.', 'i.e.'],
       }],
+    },
+    {
+      code: `
+      /**
+       * Implements support for the
+       * Swahili voice synthesizer.
+       */
+      function speak() {
+      }
+      `,
     },
   ],
 };


### PR DESCRIPTION
Fixes #427.

- feat(`require-description-complete-sentence`): add `newlineBeforeCapsAssumesBadSentenceEnd` option to disable heuristic for caps after newlines being assumed to be a bad sentence end.

I might suggest further changing this to be `false` by default but it would be breaking in the sense of changing behavior for those expecting it to continue reporting.