### PR TITLE
Add rule `require-throws`

### DIFF
--- a/.README/rules/require-returns.md
+++ b/.README/rules/require-returns.md
@@ -1,53 +1,54 @@
 ### `require-returns`
 
-Requires returns are documented.
+Requires that returns are documented.
 
 Will also report if multiple `@returns` tags are present.
 
 #### Options
 
 - `checkConstructors` - A value indicating whether `constructor`s should
-  be checked for `@returns` tags. Defaults to `false`.
+    be checked for `@returns` tags. Defaults to `false`.
 - `checkGetters` - Boolean to determine whether getter methods should
-  be checked for `@returns` tags. Defaults to `true`.
-- `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
-    block avoids the need for a `@returns`. Defaults to an array with
-    `inheritdoc`. If you set this array, it will overwrite the default,
+    be checked for `@returns` tags. Defaults to `true`.
+- `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the
+    document block avoids the need for a `@returns`. Defaults to an array
+    with `inheritdoc`. If you set this array, it will overwrite the default,
     so be sure to add back `inheritdoc` if you wish its presence to cause
     exemption of the rule.
 - `forceRequireReturn` - Set to `true` to always insist on
-  `@returns` documentation regardless of implicit or explicit `return`'s
-  in the function. May be desired to flag that a project is aware of an
-  `undefined`/`void` return. Defaults to `false`.
+    `@returns` documentation regardless of implicit or explicit `return`'s
+    in the function. May be desired to flag that a project is aware of an
+    `undefined`/`void` return. Defaults to `false`.
 - `forceReturnsWithAsync` - By default `async` functions that do not explicitly
-  return a value pass this rule as an `async` function will always return a
-  `Promise`, even if the `Promise` resolves to void. You can force all `async`
-  functions to require return statements by setting `forceReturnsWithAsync`
-  to `true` on the options object. This may be useful for flagging that there
-  has been consideration of return type. Defaults to `false`.
+    return a value pass this rule as an `async` function will always return a
+    `Promise`, even if the `Promise` resolves to void. You can force all
+    `async` functions to require return statements by setting
+    `forceReturnsWithAsync` to `true` on the options object. This may be useful
+    for flagging that there has been consideration of return type. Defaults
+    to `false`.
 - `contexts` - Set this to an array of strings representing the AST context
-  where you wish the rule to be applied.
-  Overrides the default contexts (see below). Set to `"any"` if you want
-  the rule to apply to any jsdoc block throughout your files (as is necessary
-  for finding function blocks not attached to a function declaration or
-  expression, i.e., `@callback` or `@function` (or its aliases `@func` or
-  `@method`) (including those associated with an `@interface`). This
-  rule will only apply on non-default contexts when there is such a tag
-  present and the `forceRequireReturn` option is set or if the
-  `forceReturnsWithAsync` option is set with a present `@async` tag
-  (since we are not checking against the actual `return` values in these
-  cases).
+    where you wish the rule to be applied.
+    Overrides the default contexts (see below). Set to `"any"` if you want
+    the rule to apply to any jsdoc block throughout your files (as is necessary
+    for finding function blocks not attached to a function declaration or
+    expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+    `@method`) (including those associated with an `@interface`). This
+    rule will only apply on non-default contexts when there is such a tag
+    present and the `forceRequireReturn` option is set or if the
+    `forceReturnsWithAsync` option is set with a present `@async` tag
+    (since we are not checking against the actual `return` values in these
+    cases).
 
 ```js
 'jsdoc/require-returns': ['error', {forceReturnsWithAsync: true}]
 ```
 
-|          |                                                                                                               |
-| -------- | ------------------------------------------------------------------------------------------------------------- |
+|          |         |
+| -------- | ------- |
 | Context  | `ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled |
-| Tags     | `returns`                                                                                                     |
-| Aliases  | `return`                                                                                                      |
-| Options  | `checkConstructors`, `checkGetters`, `contexts`, `exemptedBy`, `forceRequireReturn`, `forceReturnsWithAsync`  |
-| Settings | `overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`                               |
+| Tags     | `returns` |
+| Aliases  | `return` |
+| Options  | `checkConstructors`, `checkGetters`, `contexts`, `exemptedBy`, `forceRequireReturn`, `forceReturnsWithAsync` |
+| Settings | `overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs` |
 
 <!-- assertions requireReturns -->

--- a/.README/rules/require-throws.md
+++ b/.README/rules/require-throws.md
@@ -1,32 +1,32 @@
 ### `require-throws`
 
-Requires throw statements are documented.
+Requires that throw statements are documented.
 
 #### Options
 
-- `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
-    block avoids the need for a `@throws`. Defaults to an array with
-    `inheritdoc`. If you set this array, it will overwrite the default,
+- `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the
+    document block avoids the need for a `@throws`. Defaults to an array
+    with `inheritdoc`. If you set this array, it will overwrite the default,
     so be sure to add back `inheritdoc` if you wish its presence to cause
     exemption of the rule.
 - `contexts` - Set this to an array of strings representing the AST context
-  where you wish the rule to be applied.
-  Overrides the default contexts (see below). Set to `"any"` if you want
-  the rule to apply to any jsdoc block throughout your files (as is necessary
-  for finding function blocks not attached to a function declaration or
-  expression, i.e., `@callback` or `@function` (or its aliases `@func` or
-  `@method`) (including those associated with an `@interface`).
+    where you wish the rule to be applied.
+    Overrides the default contexts (see below). Set to `"any"` if you want
+    the rule to apply to any jsdoc block throughout your files (as is necessary
+    for finding function blocks not attached to a function declaration or
+    expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+    `@method`) (including those associated with an `@interface`).
 
 ```js
 'jsdoc/require-throws': 'error',
 ```
 
-|          |                                                                                                               |
-| -------- | ------------------------------------------------------------------------------------------------------------- |
+| | |
+| -------- | --- |
 | Context  | `ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled |
-| Tags     | `throws`                                                                                                      |
-| Aliases  | `exception`                                                                                                   |
-| Options  | `contexts`, `exemptedBy`                                                                                      |
-| Settings | `overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`                               |
+| Tags     | `throws` |
+| Aliases  | `exception` |
+| Options  | `contexts`, `exemptedBy` |
+| Settings | `overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs` |
 
 <!-- assertions requireThrows -->

--- a/.README/rules/require-throws.md
+++ b/.README/rules/require-throws.md
@@ -1,0 +1,32 @@
+### `require-throws`
+
+Requires throw statements are documented.
+
+#### Options
+
+- `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
+    block avoids the need for a `@throws`. Defaults to an array with
+    `inheritdoc`. If you set this array, it will overwrite the default,
+    so be sure to add back `inheritdoc` if you wish its presence to cause
+    exemption of the rule.
+- `contexts` - Set this to an array of strings representing the AST context
+  where you wish the rule to be applied.
+  Overrides the default contexts (see below). Set to `"any"` if you want
+  the rule to apply to any jsdoc block throughout your files (as is necessary
+  for finding function blocks not attached to a function declaration or
+  expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+  `@method`) (including those associated with an `@interface`).
+
+```js
+'jsdoc/require-throws': 'error',
+```
+
+|          |                                                                                                               |
+| -------- | ------------------------------------------------------------------------------------------------------------- |
+| Context  | `ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled |
+| Tags     | `throws`                                                                                                      |
+| Aliases  | `exception`                                                                                                   |
+| Options  | `contexts`, `exemptedBy`                                                                                      |
+| Settings | `overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`                               |
+
+<!-- assertions requireThrows -->

--- a/README.md
+++ b/README.md
@@ -12226,7 +12226,7 @@ function quux () {
 <a name="eslint-plugin-jsdoc-rules-require-returns"></a>
 ### <code>require-returns</code>
 
-Requires returns are documented.
+Requires that returns are documented.
 
 Will also report if multiple `@returns` tags are present.
 
@@ -12234,48 +12234,49 @@ Will also report if multiple `@returns` tags are present.
 #### Options
 
 - `checkConstructors` - A value indicating whether `constructor`s should
-  be checked for `@returns` tags. Defaults to `false`.
+    be checked for `@returns` tags. Defaults to `false`.
 - `checkGetters` - Boolean to determine whether getter methods should
-  be checked for `@returns` tags. Defaults to `true`.
-- `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the document
-    block avoids the need for a `@returns`. Defaults to an array with
-    `inheritdoc`. If you set this array, it will overwrite the default,
+    be checked for `@returns` tags. Defaults to `true`.
+- `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the
+    document block avoids the need for a `@returns`. Defaults to an array
+    with `inheritdoc`. If you set this array, it will overwrite the default,
     so be sure to add back `inheritdoc` if you wish its presence to cause
     exemption of the rule.
 - `forceRequireReturn` - Set to `true` to always insist on
-  `@returns` documentation regardless of implicit or explicit `return`'s
-  in the function. May be desired to flag that a project is aware of an
-  `undefined`/`void` return. Defaults to `false`.
+    `@returns` documentation regardless of implicit or explicit `return`'s
+    in the function. May be desired to flag that a project is aware of an
+    `undefined`/`void` return. Defaults to `false`.
 - `forceReturnsWithAsync` - By default `async` functions that do not explicitly
-  return a value pass this rule as an `async` function will always return a
-  `Promise`, even if the `Promise` resolves to void. You can force all `async`
-  functions to require return statements by setting `forceReturnsWithAsync`
-  to `true` on the options object. This may be useful for flagging that there
-  has been consideration of return type. Defaults to `false`.
+    return a value pass this rule as an `async` function will always return a
+    `Promise`, even if the `Promise` resolves to void. You can force all
+    `async` functions to require return statements by setting
+    `forceReturnsWithAsync` to `true` on the options object. This may be useful
+    for flagging that there has been consideration of return type. Defaults
+    to `false`.
 - `contexts` - Set this to an array of strings representing the AST context
-  where you wish the rule to be applied.
-  Overrides the default contexts (see below). Set to `"any"` if you want
-  the rule to apply to any jsdoc block throughout your files (as is necessary
-  for finding function blocks not attached to a function declaration or
-  expression, i.e., `@callback` or `@function` (or its aliases `@func` or
-  `@method`) (including those associated with an `@interface`). This
-  rule will only apply on non-default contexts when there is such a tag
-  present and the `forceRequireReturn` option is set or if the
-  `forceReturnsWithAsync` option is set with a present `@async` tag
-  (since we are not checking against the actual `return` values in these
-  cases).
+    where you wish the rule to be applied.
+    Overrides the default contexts (see below). Set to `"any"` if you want
+    the rule to apply to any jsdoc block throughout your files (as is necessary
+    for finding function blocks not attached to a function declaration or
+    expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+    `@method`) (including those associated with an `@interface`). This
+    rule will only apply on non-default contexts when there is such a tag
+    present and the `forceRequireReturn` option is set or if the
+    `forceReturnsWithAsync` option is set with a present `@async` tag
+    (since we are not checking against the actual `return` values in these
+    cases).
 
 ```js
 'jsdoc/require-returns': ['error', {forceReturnsWithAsync: true}]
 ```
 
-|          |                                                                                                               |
-| -------- | ------------------------------------------------------------------------------------------------------------- |
+|          |         |
+| -------- | ------- |
 | Context  | `ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled |
-| Tags     | `returns`                                                                                                     |
-| Aliases  | `return`                                                                                                      |
-| Options  | `checkConstructors`, `checkGetters`, `contexts`, `exemptedBy`, `forceRequireReturn`, `forceReturnsWithAsync`  |
-| Settings | `overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`                               |
+| Tags     | `returns` |
+| Aliases  | `return` |
+| Options  | `checkConstructors`, `checkGetters`, `contexts`, `exemptedBy`, `forceRequireReturn`, `forceReturnsWithAsync` |
+| Settings | `overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs` |
 
 The following patterns are considered problems:
 

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ import requireReturns from './rules/requireReturns';
 import requireReturnsCheck from './rules/requireReturnsCheck';
 import requireReturnsDescription from './rules/requireReturnsDescription';
 import requireReturnsType from './rules/requireReturnsType';
+import requireThrows from './rules/requireThrows';
 import validTypes from './rules/validTypes';
 import requireJsdoc from './rules/requireJsdoc';
 
@@ -119,6 +120,7 @@ export default {
     'require-returns-check': requireReturnsCheck,
     'require-returns-description': requireReturnsDescription,
     'require-returns-type': requireReturnsType,
+    'require-throws': requireThrows,
     'valid-types': validTypes,
   },
 };

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -325,6 +325,10 @@ const getUtils = (
     return jsdocUtils.hasReturnValue(node);
   };
 
+  utils.hasThrowValue = () => {
+    return jsdocUtils.hasThrowValue(node);
+  };
+
   utils.isAsync = () => {
     return node.async;
   };

--- a/src/rules/requireThrows.js
+++ b/src/rules/requireThrows.js
@@ -1,0 +1,82 @@
+import iterateJsdoc from '../iterateJsdoc';
+
+/**
+ * We can skip checking for a throws value, in case the documentation is inherited
+ * or the method is either a constructor or an abstract method.
+ *
+ * @param {*} utils
+ *   a reference to the utils which are used to probe if a tag is present or not.
+ * @returns {boolean}
+ *   true in case deep checking can be skipped; otherwise false.
+ */
+const canSkip = (utils) => {
+  return utils.hasATag([
+    // inheritdoc implies that all documentation is inherited
+    // see https://jsdoc.app/tags-inheritdoc.html
+    //
+    // Abstract methods are by definition incomplete,
+    // so it is not necessary to document that they throw an error.
+    'abstract',
+    'virtual',
+  ]) ||
+    utils.avoidDocs();
+};
+
+export default iterateJsdoc(({
+  report,
+  utils,
+}) => {
+  // A preflight check. We do not need to run a deep check for abstract functions.
+  if (canSkip(utils)) {
+    return;
+  }
+
+  const tagName = utils.getPreferredTagName({tagName: 'throws'});
+  if (!tagName) {
+    return;
+  }
+
+  const tags = utils.getTags(tagName);
+  const iteratingFunction = utils.isIteratingFunction();
+
+  // In case the code returns something, we expect a return value in JSDoc.
+  const [tag] = tags;
+  const missingThrowsTag = typeof tag === 'undefined' || tag === null;
+
+  const shouldReport = () => {
+    if (!missingThrowsTag) {
+      return false;
+    }
+
+    return iteratingFunction && utils.hasThrowValue();
+  };
+
+  if (shouldReport()) {
+    report(`Missing JSDoc @${tagName} declaration.`);
+  }
+}, {
+  contextDefaults: true,
+  meta: {
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          contexts: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+          exemptedBy: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
+    type: 'suggestion',
+  },
+});

--- a/src/rules/requireThrows.js
+++ b/src/rules/requireThrows.js
@@ -18,6 +18,9 @@ const canSkip = (utils) => {
     // so it is not necessary to document that they throw an error.
     'abstract',
     'virtual',
+
+    // The designated type can itself document `@throws`
+    'type',
   ]) ||
     utils.avoidDocs();
 };
@@ -26,7 +29,8 @@ export default iterateJsdoc(({
   report,
   utils,
 }) => {
-  // A preflight check. We do not need to run a deep check for abstract functions.
+  // A preflight check. We do not need to run a deep check for abstract
+  //  functions.
   if (canSkip(utils)) {
     return;
   }

--- a/test/rules/assertions/requireThrows.js
+++ b/test/rules/assertions/requireThrows.js
@@ -21,8 +21,148 @@ export default {
           /**
            *
            */
+          const quux = function (foo) {
+            throw new Error('err')
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @throws declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          const quux = (foo) => {
+            throw new Error('err')
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @throws declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
           function quux (foo) {
             while(true) {
+              throw new Error('err')
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @throws declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+            do {
+              throw new Error('err')
+            } while(true)
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @throws declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+            for(var i = 0; i <= 10; i++) {
+              throw new Error('err')
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @throws declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+            for(num in [1,2,3]) {
+              throw new Error('err')
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @throws declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+            for(const num of [1,2,3]) {
+              throw new Error('err')
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @throws declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+            for(const index in [1,2,3]) {
+              throw new Error('err')
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @throws declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+            with(foo) {
               throw new Error('err')
             }
           }

--- a/test/rules/assertions/requireThrows.js
+++ b/test/rules/assertions/requireThrows.js
@@ -1,0 +1,204 @@
+export default {
+  invalid: [
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+            throw new Error('err')
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @throws declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+            while(true) {
+              throw new Error('err')
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @throws declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+            if (true) {
+              throw new Error('err')
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @throws declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+            if (false) {
+              // do nothing
+            } else {
+              throw new Error('err')
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @throws declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+            try {
+              throw new Error('err')
+            } catch(e) {
+              throw new Error(e.message)
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @throws declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+            try {
+              // do nothing
+            } finally {
+              throw new Error(e.message)
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @throws declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+            const a = 'b'
+            switch(a) {
+              case 'b':
+                throw new Error('err')
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @throws declaration.',
+        },
+      ],
+    },
+  ],
+  valid: [
+    {
+      code: `
+          /**
+           * @throws An error.
+           */
+          function quux () {
+            throw new Error('err')
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+            try {
+              throw new Error('err')
+            } catch(e) {}
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @inheritdoc
+           */
+          function quux (foo) {
+            throw new Error('err')
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @abstract
+           */
+          function quux (foo) {
+            throw new Error('err')
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @type {MyCallback}
+           */
+          function quux () {
+            throw new Error('err')
+          }
+      `,
+      options: [
+        {
+          exemptedBy: ['type'],
+        },
+      ],
+    },
+  ],
+};

--- a/test/rules/assertions/requireThrows.js
+++ b/test/rules/assertions/requireThrows.js
@@ -272,6 +272,28 @@ export default {
         },
       ],
     },
+    {
+      code: `
+          /**
+           * @throws
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Unexpected tag `@throws`',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            throws: false,
+          },
+        },
+      },
+    },
   ],
   valid: [
     {

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -44,6 +44,7 @@ const ruleTester = new RuleTester();
   'require-returns-check',
   'require-returns-description',
   'require-returns-type',
+  'require-throws',
   'valid-types',
 ]).forEach((ruleName) => {
   const rule = config.rules[ruleName];


### PR DESCRIPTION
This adds a new rule `require-throws`, that requires a `@throws` statement in the JSDoc if the function body contains the `throw` keyword.

I based this off of `require-returns`, as suggested in https://github.com/gajus/eslint-plugin-jsdoc/issues/566