### PR TITLE
Fix bug with destructured parameters in check-param-names

### DIFF
--- a/README.md
+++ b/README.md
@@ -2132,6 +2132,25 @@ function quux ({foo}, baz) {
 }
 
 /**
+ * @param cfg
+ * @param cfg.foo
+ * @param cfg2
+ */
+function quux ({foo}, cfg2) {
+
+}
+
+/**
+ * @param cfg
+ * @param cfg.foo
+ * @param baz
+ * @param baz.cfg
+ */
+function quux ({foo}, {cfg}) {
+
+}
+
+/**
  * @param options
  * @param options.foo
  */

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -82,7 +82,7 @@ const validateParameterNames = (
       const extraProperties = [];
       if (!hasPropertyRest || checkRestProperty) {
         actualNames.filter((name) => {
-          return name.includes(tag.name.trim());
+          return name.startsWith(tag.name.trim() + '.');
         }).forEach((name) => {
           if (!expectedNames.includes(name) && name !== tag.name) {
             extraProperties.push(name);

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -1011,6 +1011,31 @@ export default {
     },
     {
       code: `
+          /**
+           * @param cfg
+           * @param cfg.foo
+           * @param cfg2
+           */
+          function quux ({foo}, cfg2) {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @param cfg
+           * @param cfg.foo
+           * @param baz
+           * @param baz.cfg
+           */
+          function quux ({foo}, {cfg}) {
+
+          }
+      `,
+    },
+    {
+      code: `
       /**
        * @param options
        * @param options.foo


### PR DESCRIPTION

This PR fixes the false negatives in the check-param-names rule for the following cases:

```js
/**
 * @param cfg
 * @param cfg.foo
 * @param cfg2
 */
function quux ({foo}, cfg2) {

}
// Results in: @param "cfg2" does not exist on cfg

/**
 * @param cfg
 * @param cfg.foo
 * @param baz
 * @param baz.cfg
 */
function quux ({foo}, {cfg}) {

}
// Results in: @param "baz.cfg" does not exist on cfg
```
