### PR TITLE
annotation mismatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1906,7 +1906,7 @@ export class SomeClass {
    */
   constructor(options: { foo: string, bar: string }) {}
 }
-// Message: @param "prop" does not match annotation name "options"
+// Message: @param "prop" does not match parameter name "options"
 
 export class SomeClass {
   /**

--- a/README.md
+++ b/README.md
@@ -1906,7 +1906,7 @@ export class SomeClass {
    */
   constructor(options: { foo: string, bar: string }) {}
 }
-// Message: Missing @param "options.foo"
+// Message: @param "prop" does not match annotation name "options"
 
 export class SomeClass {
   /**
@@ -1993,6 +1993,23 @@ module.exports = class GraphQL {
 };
 // Options: [{"checkRestProperty":true}]
 // Message: Missing @param "fetchOptions.url"
+
+/**
+ * Testing
+ *
+ * @param options
+ * @param options.one One
+ * @param options.two Two
+ * @param options.four Four
+ */
+function testingEslint(options: {
+  one: string;
+  two: string;
+  three: string;
+}): string {
+  return one + two + three;
+}
+// Message: Missing @param "options.three"
 ````
 
 The following patterns are not considered problems:

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -92,7 +92,10 @@ const getFunctionParameterNames = (functionNode : Object) : Array<T> => {
         const propertyNames = typeAnnotation.typeAnnotation.members.map((member) => {
           return getPropertiesFromPropertySignature(member);
         });
-        const flattened = flattenRoots(propertyNames);
+        const flattened = {
+          ...flattenRoots(propertyNames),
+          annotationName: param.name,
+        };
         if (_.has(param, 'name') || _.has(param, 'left.name')) {
           return [_.has(param, 'left.name') ? param.left.name : param.name, flattened];
         }

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -94,7 +94,7 @@ const getFunctionParameterNames = (functionNode : Object) : Array<T> => {
         });
         const flattened = {
           ...flattenRoots(propertyNames),
-          annotationName: param.name,
+          annotationParamName: param.name,
         };
         if (_.has(param, 'name') || _.has(param, 'left.name')) {
           return [_.has(param, 'left.name') ? param.left.name : param.name, flattened];

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -59,12 +59,12 @@ const validateParameterNames = (
       }
 
       const [parameterName, {
-        names: properties, hasPropertyRest, rests, annotationName,
+        names: properties, hasPropertyRest, rests, annotationParamName,
       }] = functionParameterName;
-      if (annotationName !== undefined) {
+      if (annotationParamName !== undefined) {
         const name = tag.name.trim();
-        if (name !== annotationName) {
-          report(`@${targetTagName} "${name}" does not match annotation name "${annotationName}"`, null, tag);
+        if (name !== annotationParamName) {
+          report(`@${targetTagName} "${name}" does not match parameter name "${annotationParamName}"`, null, tag);
         }
       }
       const tagName = parameterName === undefined ? tag.name.trim() : parameterName;

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -59,9 +59,15 @@ const validateParameterNames = (
       }
 
       const [parameterName, {
-        names: properties, hasPropertyRest, rests,
+        names: properties, hasPropertyRest, rests, annotationName,
       }] = functionParameterName;
-      const tagName = parameterName ? parameterName : tag.name.trim();
+      if (annotationName !== undefined) {
+        const name = tag.name.trim();
+        if (name !== annotationName) {
+          report(`@${targetTagName} "${name}" does not match annotation name "${annotationName}"`, null, tag);
+        }
+      }
+      const tagName = parameterName === undefined ? tag.name.trim() : parameterName;
       const expectedNames = properties.map((name) => {
         return `${tagName}.${name}`;
       });
@@ -81,32 +87,30 @@ const validateParameterNames = (
 
       const extraProperties = [];
       if (!hasPropertyRest || checkRestProperty) {
-        actualNames.filter((name) => {
-          return name.startsWith(tag.name.trim() + '.');
-        }).forEach((name) => {
-          if (!expectedNames.includes(name) && name !== tag.name) {
-            extraProperties.push(name);
+        actualNames.forEach((name, idx) => {
+          const match = name.startsWith(tag.name.trim() + '.');
+          if (match && !expectedNames.includes(name) && name !== tag.name) {
+            extraProperties.push([name, paramTags[idx][1]]);
           }
         });
       }
 
-      if (missingProperties.length) {
+      const hasMissing = missingProperties.length;
+      if (hasMissing) {
         missingProperties.forEach((missingProperty) => {
           report(`Missing @${targetTagName} "${missingProperty}"`, null, tag);
         });
-
-        return true;
       }
 
       if (extraProperties.length) {
-        extraProperties.forEach((extraProperty) => {
-          report(`@${targetTagName} "${extraProperty}" does not exist on ${tag.name}`, null, tag);
+        extraProperties.forEach(([extraProperty, tg]) => {
+          report(`@${targetTagName} "${extraProperty}" does not exist on ${tag.name}`, null, tg);
         });
 
         return true;
       }
 
-      return false;
+      return hasMissing;
     }
 
     let funcParamName;

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -580,11 +580,23 @@ export default {
       errors: [
         {
           line: 4,
+          message: '@param "prop" does not match annotation name "options"',
+        },
+        {
+          line: 4,
           message: 'Missing @param "options.foo"',
         },
         {
           line: 4,
           message: 'Missing @param "options.bar"',
+        },
+        {
+          line: 5,
+          message: '@param "prop.foo" does not exist on prop',
+        },
+        {
+          line: 6,
+          message: '@param "prop.bar" does not exist on prop',
         },
       ],
       parser: require.resolve('@typescript-eslint/parser'),
@@ -605,7 +617,7 @@ export default {
       `,
       errors: [
         {
-          line: 4,
+          line: 6,
           message: '@param "options.bar" does not exist on options',
         },
       ],
@@ -711,7 +723,7 @@ export default {
       `,
       errors: [
         {
-          line: 3,
+          line: 5,
           message: '@param "cfg.bar" does not exist on cfg',
         },
       ],
@@ -804,6 +816,36 @@ export default {
         },
       ],
       parser: require.resolve('babel-eslint'),
+    },
+    {
+      code: `
+      /**
+       * Testing
+       *
+       * @param options
+       * @param options.one One
+       * @param options.two Two
+       * @param options.four Four
+       */
+      function testingEslint(options: {
+        one: string;
+        two: string;
+        three: string;
+      }): string {
+        return one + two + three;
+      }
+      `,
+      errors: [
+        {
+          line: 5,
+          message: 'Missing @param "options.three"',
+        },
+        {
+          line: 8,
+          message: '@param "options.four" does not exist on options',
+        },
+      ],
+      parser: require.resolve('@typescript-eslint/parser'),
     },
   ],
   valid: [

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -580,7 +580,7 @@ export default {
       errors: [
         {
           line: 4,
-          message: '@param "prop" does not match annotation name "options"',
+          message: '@param "prop" does not match parameter name "options"',
         },
         {
           line: 4,


### PR DESCRIPTION
feat(`check-param-names`): report missing/extraneous TypeScript annotation properties in both directions and report mismatches of parameter names which are parents to annotations; fixes #491

Also provides more precise line number reporting.

In some ways this is more of a fix, but I wanted a regular TS user to confirm that a case like:

```js
        export class SomeClass {
          /**
           * @param prop
           * @param prop.foo
           * @param prop.bar
           */
          constructor(options: { foo: string, bar: string }) {}
        }
```

...should report a mismatch between `prop` and `options` and not just the nested items--as seems to make sense to me.
