### PR TITLE
`valid-types`: disallow namepath on `interface` tag for Closure

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -144,6 +144,8 @@ how many line breaks to add when a block is missing.
   - For type-checking rules, impacts parsing of types (through
     [jsdoctypeparser](https://github.com/jsdoctypeparser/jsdoctypeparser) dependency)
   - Check preferred tag names
+  - Disallows namepath on `@interface` for "closure" mode in `valid-types` (and
+      avoids checking in other rules)
 
 ### Alias Preference
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ how many line breaks to add when a block is missing.
   - For type-checking rules, impacts parsing of types (through
     [jsdoctypeparser](https://github.com/jsdoctypeparser/jsdoctypeparser) dependency)
   - Check preferred tag names
+  - Disallows namepath on `@interface` for "closure" mode in `valid-types` (and
+      avoids checking in other rules)
 
 <a name="eslint-plugin-jsdoc-settings-alias-preference"></a>
 ### Alias Preference
@@ -13430,6 +13432,18 @@ function quux () {}
 function foo(bar) {}
 // Settings: {"jsdoc":{"mode":"jsdoc"}}
 // Message: Syntax error in type: [number, string]
+
+/**
+ * @interface name<
+ */
+// Settings: {"jsdoc":{"mode":"jsdoc"}}
+// Message: Syntax error in namepath: name<
+
+/**
+ * @interface name
+ */
+// Settings: {"jsdoc":{"mode":"closure"}}
+// Message: @interface should not have a name in "closure" mode.
 ````
 
 The following patterns are not considered problems:

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -280,7 +280,7 @@ const getUtils = (
 
     const exemptedBy = context.options[0]?.exemptedBy ?? [
       'inheritDoc',
-      ...settings.mode === 'closure' ? [] : ['inheritdoc'],
+      ...mode === 'closure' ? [] : ['inheritdoc'],
     ];
     if (exemptedBy.length && utils.getPresentTags(exemptedBy).length) {
       return true;
@@ -302,7 +302,7 @@ const getUtils = (
   };
 
   utils.tagMightHaveNamePosition = (tagName) => {
-    return jsdocUtils.tagMightHaveNamePosition(tagName);
+    return jsdocUtils.tagMightHaveNamePosition(mode, tagName);
   };
 
   utils.tagMustHaveTypePosition = (tagName) => {
@@ -314,7 +314,7 @@ const getUtils = (
   };
 
   utils.isNamepathDefiningTag = (tagName) => {
-    return jsdocUtils.isNamepathDefiningTag(tagName);
+    return jsdocUtils.isNamepathDefiningTag(mode, tagName);
   };
 
   utils.hasDefinedTypeReturnTag = (tag) => {

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -375,7 +375,7 @@ const tagsWithOptionalTypePositionClosure = new Set([
 ]);
 
 // None of these show as having curly brackets for their name/namepath
-const namepathDefiningTags = new Set([
+const closureNamepathDefiningTags = new Set([
   // These appear to require a "name" in their signature, albeit these
   //  are somewhat different from other "name"'s (including as described
   // at https://jsdoc.app/about-namepaths.html )
@@ -386,7 +386,6 @@ const namepathDefiningTags = new Set([
   'class', 'constructor',
   'constant', 'const',
   'function', 'func', 'method',
-  'interface',
   'member', 'var',
   'mixin',
   'namespace',
@@ -400,11 +399,14 @@ const namepathDefiningTags = new Set([
   'typedef',
   'callback',
 ]);
+const namepathDefiningTags = new Set([
+  ...closureNamepathDefiningTags,
 
-// The following do not seem to allow curly brackets in their doc
-//  signature or examples (besides `modifies` and `param`)
-const tagsWithOptionalNamePosition = new Set([
-  ...namepathDefiningTags,
+  // Allows for "name" in signature, but indicates as optional
+  'interface',
+]);
+
+const tagsWithOptionalNamePositionBase = new Set([
   'param',
 
   // `borrows` has a different format, however, so needs special parsing;
@@ -430,6 +432,18 @@ const tagsWithOptionalNamePosition = new Set([
 
   // Signature allows for "namepath" or text
   'see',
+]);
+
+// The following do not seem to allow curly brackets in their doc
+//  signature or examples (besides `modifies` and `param`)
+const tagsWithOptionalNamePosition = new Set([
+  ...namepathDefiningTags,
+  ...tagsWithOptionalNamePositionBase,
+]);
+
+const closureTagsWithOptionalNamePosition = new Set([
+  ...closureNamepathDefiningTags,
+  ...tagsWithOptionalNamePositionBase,
 ]);
 
 // Todo: `@link` seems to require a namepath OR URL and might be checked as such.
@@ -463,8 +477,10 @@ const tagsWithMandatoryTypeOrNamePosition = new Set([
   'mixes',
 ]);
 
-const isNamepathDefiningTag = (tagName) => {
-  return namepathDefiningTags.has(tagName);
+const isNamepathDefiningTag = (mode, tagName) => {
+  return mode === 'closure' ?
+    closureNamepathDefiningTags.has(tagName) :
+    namepathDefiningTags.has(tagName);
 };
 
 const tagMightHaveTypePosition = (mode, tag) => {
@@ -485,8 +501,10 @@ const tagMustHaveTypePosition = (mode, tag) => {
   return tagsWithMandatoryTypePosition.has(tag);
 };
 
-const tagMightHaveNamePosition = (tag) => {
-  return tagsWithOptionalNamePosition.has(tag);
+const tagMightHaveNamePosition = (mode, tag) => {
+  return mode === 'closure' ?
+    closureTagsWithOptionalNamePosition.has(tag) :
+    tagsWithOptionalNamePosition.has(tag);
 };
 
 const tagMustHaveNamePosition = (tag) => {
@@ -494,7 +512,7 @@ const tagMustHaveNamePosition = (tag) => {
 };
 
 const tagMightHaveEitherTypeOrNamePosition = (mode, tag) => {
-  return tagMightHaveTypePosition(mode, tag) || tagMightHaveNamePosition(tag);
+  return tagMightHaveTypePosition(mode, tag) || tagMightHaveNamePosition(mode, tag);
 };
 
 const tagMustHaveEitherTypeOrNamePosition = (tag) => {

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -18,6 +18,7 @@ export default iterateJsdoc(({
   if (!jsdoc.tags) {
     return;
   }
+  // eslint-disable-next-line complexity
   jsdoc.tags.forEach((tag) => {
     const validNamepathParsing = function (namepath, tagName) {
       try {
@@ -80,7 +81,8 @@ export default iterateJsdoc(({
     const hasEither = utils.tagMightHaveEitherTypeOrNamePosition(tag.tag) && (hasTypePosition || hasNameOrNamepathPosition);
     const mustHaveEither = utils.tagMustHaveEitherTypeOrNamePosition(tag.tag);
 
-    if (tag.tag === 'borrows') {
+    switch (tag.tag) {
+    case 'borrows': {
       const thisNamepath = tag.description.replace(asExpression, '');
 
       if (!asExpression.test(tag.description) || !thisNamepath) {
@@ -94,7 +96,17 @@ export default iterateJsdoc(({
 
         validNamepathParsing(thatNamepath);
       }
-    } else {
+      break;
+    }
+    case 'interface': {
+      if (mode === 'closure' && tag.name) {
+        report('@interface should not have a name in "closure" mode.', null, tag);
+        break;
+      }
+    }
+
+    // Fallthrough
+    default: {
       if (mustHaveEither && !hasEither && !mustHaveTypePosition) {
         report(`Tag @${tag.tag} must have either a type or namepath`, null, tag);
 
@@ -112,6 +124,7 @@ export default iterateJsdoc(({
       } else if (mustHaveNameOrNamepathPosition) {
         report(`Tag @${tag.tag} must have a name/namepath`, null, tag);
       }
+    }
     }
   });
 }, {

--- a/test/rules/assertions/validTypes.js
+++ b/test/rules/assertions/validTypes.js
@@ -359,6 +359,40 @@ export default {
         },
       },
     },
+    {
+      code: `
+      /**
+       * @interface name<
+       */
+      `,
+      errors: [
+        {
+          message: 'Syntax error in namepath: name<',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          mode: 'jsdoc',
+        },
+      },
+    },
+    {
+      code: `
+      /**
+       * @interface name
+       */
+      `,
+      errors: [
+        {
+          message: '@interface should not have a name in "closure" mode.',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          mode: 'closure',
+        },
+      },
+    },
   ],
   valid: [
     {


### PR DESCRIPTION
feat(`valid-types`): disallow namepath on `interface` tag for Closure mode; continue checking on jsdoc; fixes part of #356

Also avoids checking namepath on `interface` tag for `no-undefined-types` and `check-types` when in closure mode.