### PR TITLE
Check syntax closure

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -144,6 +144,7 @@ how many line breaks to add when a block is missing.
   - For type-checking rules, impacts parsing of types (through
     [jsdoctypeparser](https://github.com/jsdoctypeparser/jsdoctypeparser) dependency)
   - Check preferred tag names
+  - For `check-syntax`, determines aspects that may be enforced
   - Disallows namepath on `@interface` for "closure" mode in `valid-types` (and
       avoids checking in other rules)
 

--- a/.README/rules/check-syntax.md
+++ b/.README/rules/check-syntax.md
@@ -1,6 +1,16 @@
 ### `check-syntax`
 
-Reports against Google Closure Compiler syntax.
+Reports against syntax not encouraged for the mode (e.g., Google Closure Compiler
+in "jsdoc" or "typescript" mode). Note that this rule will not chekc for types
+that are wholly invalid for a given mode, as that is covered by `valid-types`.
+
+Currently checks against:
+
+- Use of `=` in "jsdoc" or "typescript" mode
+
+Note that "jsdoc" actually allows Closure syntax, but with another
+option available for optional parameters (enclosing the name in brackets), the
+rule is enforced (except under "permissive" and "closure" modes).
 
 |||
 |---|---|

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ how many line breaks to add when a block is missing.
   - For type-checking rules, impacts parsing of types (through
     [jsdoctypeparser](https://github.com/jsdoctypeparser/jsdoctypeparser) dependency)
   - Check preferred tag names
+  - For `check-syntax`, determines aspects that may be enforced
   - Disallows namepath on `@interface` for "closure" mode in `valid-types` (and
       avoids checking in other rules)
 
@@ -2464,7 +2465,17 @@ function quux (code = 1) {
 <a name="eslint-plugin-jsdoc-rules-check-syntax"></a>
 ### <code>check-syntax</code>
 
-Reports against Google Closure Compiler syntax.
+Reports against syntax not encouraged for the mode (e.g., Google Closure Compiler
+in "jsdoc" or "typescript" mode). Note that this rule will not chekc for types
+that are wholly invalid for a given mode, as that is covered by `valid-types`.
+
+Currently checks against:
+
+- Use of `=` in "jsdoc" or "typescript" mode
+
+Note that "jsdoc" actually allows Closure syntax, but with another
+option available for optional parameters (enclosing the name in brackets), the
+rule is enforced (except under "permissive" and "closure" modes).
 
 |||
 |---|---|
@@ -2486,6 +2497,14 @@ function quux (foo) {
 The following patterns are not considered problems:
 
 ````js
+/**
+ * @param {string=} foo
+ */
+function quux (foo) {
+
+}
+// Settings: {"jsdoc":{"mode":"closure"}}
+
 /**
  * @param {string} [foo]
  */

--- a/src/rules/checkSyntax.js
+++ b/src/rules/checkSyntax.js
@@ -3,22 +3,28 @@ import iterateJsdoc from '../iterateJsdoc';
 export default iterateJsdoc(({
   jsdoc,
   report,
+  settings,
 }) => {
   if (!jsdoc.tags) {
     return;
   }
 
-  for (const tag of jsdoc.tags) {
-    if (tag.type.slice(-1) === '=') {
-      report('Syntax should not be Google Closure Compiler style.', null, tag);
-      break;
+  const {mode} = settings;
+
+  // Don't check for "permissive" and "closure"
+  if (mode === 'jsdoc' || mode === 'typescript') {
+    for (const tag of jsdoc.tags) {
+      if (tag.type.slice(-1) === '=') {
+        report('Syntax should not be Google Closure Compiler style.', null, tag);
+        break;
+      }
     }
   }
 }, {
   iterateAllJsdocs: true,
   meta: {
     docs: {
-      description: 'Reports against Google Closure Compiler syntax.',
+      description: 'Reports against syntax not valid for the mode (e.g., Google Closure Compiler in non-Closure mode).',
     },
     type: 'suggestion',
   },

--- a/test/rules/assertions/checkSyntax.js
+++ b/test/rules/assertions/checkSyntax.js
@@ -21,6 +21,21 @@ export default {
     {
       code: `
           /**
+           * @param {string=} foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'closure',
+        },
+      },
+    },
+    {
+      code: `
+          /**
            * @param {string} [foo]
            */
           function quux (foo) {


### PR DESCRIPTION
Builds on #587 and #588.

feat(`check-syntax`): only check against Closure syntax in "jsdoc" and "typescript" mode; fixes part of #356

"jsdoc" mode or new "permissive" mode will not complain (in preparation for the rule potentially preventing other syntaxes by mode (where jsdoctypeparser does not forbid)).