### PR TITLE
Module namepath

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -135,16 +135,16 @@ how many line breaks to add when a block is missing.
   containing both JavaScript and TypeScript, you can also use [`overrides`](https://eslint.org/docs/user-guide/configuring). You may also set to `"permissive"` to
   try to be as accommodating to any of the styles, but this is not recommended.
   Currently is used for the following:
-  - Determine valid tags and aliases for `check-tag-names`
-  - Only check `@template` in `no-undefined-types` for types in "closure" and
+  - `check-tag-names`: Determine valid tags and aliases
+  - `no-undefined-types`: Only check `@template` for types in "closure" and
     "typescript" modes
-  - For type-checking rules, determine which tags will be checked for types
-    (Closure allows types on some tags which the others do not,
+  - `check-syntax`: determines aspects that may be enforced
+  - For type/namepath-checking rules, determine which tags will be checked for
+    types/namepaths (Closure allows types on some tags which the others do not,
     so these tags will additionally be checked in "closure" mode)
   - For type-checking rules, impacts parsing of types (through
     [jsdoctypeparser](https://github.com/jsdoctypeparser/jsdoctypeparser) dependency)
   - Check preferred tag names
-  - For `check-syntax`, determines aspects that may be enforced
   - Disallows namepath on `@interface` for "closure" mode in `valid-types` (and
       avoids checking in other rules)
 

--- a/README.md
+++ b/README.md
@@ -193,16 +193,16 @@ how many line breaks to add when a block is missing.
   containing both JavaScript and TypeScript, you can also use [`overrides`](https://eslint.org/docs/user-guide/configuring). You may also set to `"permissive"` to
   try to be as accommodating to any of the styles, but this is not recommended.
   Currently is used for the following:
-  - Determine valid tags and aliases for `check-tag-names`
-  - Only check `@template` in `no-undefined-types` for types in "closure" and
+  - `check-tag-names`: Determine valid tags and aliases
+  - `no-undefined-types`: Only check `@template` for types in "closure" and
     "typescript" modes
-  - For type-checking rules, determine which tags will be checked for types
-    (Closure allows types on some tags which the others do not,
+  - `check-syntax`: determines aspects that may be enforced
+  - For type/namepath-checking rules, determine which tags will be checked for
+    types/namepaths (Closure allows types on some tags which the others do not,
     so these tags will additionally be checked in "closure" mode)
   - For type-checking rules, impacts parsing of types (through
     [jsdoctypeparser](https://github.com/jsdoctypeparser/jsdoctypeparser) dependency)
   - Check preferred tag names
-  - For `check-syntax`, determines aspects that may be enforced
   - Disallows namepath on `@interface` for "closure" mode in `valid-types` (and
       avoids checking in other rules)
 
@@ -13474,6 +13474,12 @@ function foo(bar) {}
 
 /**
  * @interface name<
+ */
+// Settings: {"jsdoc":{"mode":"jsdoc"}}
+// Message: Syntax error in namepath: name<
+
+/**
+ * @module name<
  */
 // Settings: {"jsdoc":{"mode":"jsdoc"}}
 // Message: Syntax error in namepath: name<

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -392,20 +392,26 @@ const closureNamepathDefiningTags = new Set([
   'mixin',
   'namespace',
 
-  // Todo: Should add `module` here (with optional "name" and no curly brackets);
-  //  this block impacts `no-undefined-types` and `valid-types` (search for
-  //  "isNamepathDefiningTag|tagMightHaveNamePosition|tagMightHaveEitherTypeOrNamePosition")
-
   // These seem to all require a "namepath" in their signatures (with no counter-examples)
   'name',
   'typedef',
   'callback',
 ]);
-const namepathDefiningTags = new Set([
+
+const typescriptNamepathDefiningTags = new Set([
   ...closureNamepathDefiningTags,
 
   // Allows for "name" in signature, but indicates as optional
   'interface',
+]);
+
+const namepathDefiningTags = new Set([
+  ...typescriptNamepathDefiningTags,
+
+  // Optional "name" and no curly brackets
+  //  this block impacts `no-undefined-types` and `valid-types` (search for
+  //  "isNamepathDefiningTag|tagMightHaveNamePosition|tagMightHaveEitherTypeOrNamePosition")
+  'module',
 ]);
 
 const tagsWithOptionalNamePositionBase = new Set([
@@ -440,6 +446,11 @@ const tagsWithOptionalNamePositionBase = new Set([
 //  signature or examples (besides `modifies` and `param`)
 const tagsWithOptionalNamePosition = new Set([
   ...namepathDefiningTags,
+  ...tagsWithOptionalNamePositionBase,
+]);
+
+const typescriptTagsWithOptionalNamePosition = new Set([
+  ...typescriptNamepathDefiningTags,
   ...tagsWithOptionalNamePositionBase,
 ]);
 
@@ -480,9 +491,14 @@ const tagsWithMandatoryTypeOrNamePosition = new Set([
 ]);
 
 const isNamepathDefiningTag = (mode, tagName) => {
-  return mode === 'closure' ?
-    closureNamepathDefiningTags.has(tagName) :
-    namepathDefiningTags.has(tagName);
+  if (mode === 'closure') {
+    return closureNamepathDefiningTags.has(tagName);
+  }
+  if (mode === 'typescript') {
+    return typescriptNamepathDefiningTags.has(tagName);
+  }
+
+  return namepathDefiningTags.has(tagName);
 };
 
 const tagMightHaveTypePosition = (mode, tag) => {
@@ -504,9 +520,14 @@ const tagMustHaveTypePosition = (mode, tag) => {
 };
 
 const tagMightHaveNamePosition = (mode, tag) => {
-  return mode === 'closure' ?
-    closureTagsWithOptionalNamePosition.has(tag) :
-    tagsWithOptionalNamePosition.has(tag);
+  if (mode === 'closure') {
+    return closureTagsWithOptionalNamePosition.has(tag);
+  }
+  if (mode === 'typescript') {
+    return typescriptTagsWithOptionalNamePosition.has(tag);
+  }
+
+  return tagsWithOptionalNamePosition.has(tag);
 };
 
 const tagMustHaveNamePosition = (tag) => {

--- a/test/rules/assertions/validTypes.js
+++ b/test/rules/assertions/validTypes.js
@@ -379,6 +379,23 @@ export default {
     {
       code: `
       /**
+       * @module name<
+       */
+      `,
+      errors: [
+        {
+          message: 'Syntax error in namepath: name<',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          mode: 'jsdoc',
+        },
+      },
+    },
+    {
+      code: `
+      /**
        * @interface name
        */
       `,


### PR DESCRIPTION
Builds on #587, #588, and #589.

feat(`valid-types`, `no-undefined-types`): check `module` for namepath in non-"typescript" mode; fixes part of #356