### PR TITLE
`require-jsdoc`: add `enableFixer` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8367,6 +8367,12 @@ function myFunction() {
 // Settings: {"jsdoc":{"minLines":1}}
 // Message: Missing JSDoc comment.
 
+function myFunction() {
+
+}
+// Options: [{"enableFixer":false}]
+// Message: Missing JSDoc comment.
+
 export var test = function () {
 
 };

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -29,6 +29,10 @@ const OPTIONS_SCHEMA = {
       },
       type: 'array',
     },
+    enableFixer: {
+      default: true,
+      type: 'boolean',
+    },
     exemptEmptyFunctions: {
       default: false,
       type: 'boolean',
@@ -108,10 +112,12 @@ const getOptions = (context) => {
     publicOnly,
     contexts = [],
     exemptEmptyFunctions = false,
+    enableFixer = true,
   } = context.options[0] || {};
 
   return {
     contexts,
+    enableFixer,
     exemptEmptyFunctions,
     publicOnly: ((baseObj) => {
       if (!publicOnly) {
@@ -146,7 +152,7 @@ export default {
     const {
       require: requireOption,
       contexts,
-      publicOnly, exemptEmptyFunctions,
+      publicOnly, exemptEmptyFunctions, enableFixer,
     } = getOptions(context);
 
     const checkJsDoc = (node, isFunctionContext) => {
@@ -200,7 +206,7 @@ export default {
           start: node.loc.start,
         };
         context.report({
-          fix,
+          fix: enableFixer ? fix : null,
           loc,
           messageId: 'missingJsDoc',
           node,

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -99,6 +99,28 @@ export default {
     },
     {
       code: `
+       function myFunction() {
+
+       }
+       `,
+      errors: [
+        {
+          message: 'Missing JSDoc comment.',
+        },
+      ],
+      options: [
+        {
+          enableFixer: false,
+        },
+      ],
+      output: `
+       function myFunction() {
+
+       }
+       `,
+    },
+    {
+      code: `
           export var test = function () {
 
           };


### PR DESCRIPTION
feat(`require-jsdoc`): add `enableFixer` option; if set to `false`, will avoid fixer; fixes #372

As per discussion in #372, let me know if you want me to change this to make a break from previous behavior by instead making `enableFixer` off by default. (If so, I think `enableFixer` should be added as `true` on most existing tests so that the docs continue to make clear how/where the fix will appear.)

Also, @gajus, @golopot seems to favor [ESLint's approach](https://github.com/eslint/eslint#semantic-versioning-policy) of only treating something as breaking if it is likely to increase the number of errors. I personally favor an approach which I think is more in line with the spirit of semver by requiring a breaking change if there will be fewer errors (and there was legitimate reason to see them previously as errors and those errors were not the result of a mere bug). If you want to weigh in on this, I think it will save us from some future back-and-forth.