### PR TITLE
fix: Object destructuring in function parameters if key is string

### DIFF
--- a/README.md
+++ b/README.md
@@ -2103,7 +2103,16 @@ function quux ({"a": A, b}) {
 
 /**
  * @param foo
- * @param foo.a-b
+ * @param foo."a"
+ * @param foo.b
+ */
+function quux ({a: A, b}) {
+
+}
+
+/**
+ * @param foo
+ * @param foo."a-b"
  * @param foo.b
  */
 function quux ({"a-b": A, b}) {

--- a/README.md
+++ b/README.md
@@ -2094,6 +2094,24 @@ function quux ({a, b}) {
 
 /**
  * @param foo
+ * @param foo.a
+ * @param foo.b
+ */
+function quux ({"a": A, b}) {
+
+}
+
+/**
+ * @param foo
+ * @param foo.a-b
+ * @param foo.b
+ */
+function quux ({"a-b": A, b}) {
+
+}
+
+/**
+ * @param foo
  * @param foo.bar
  * @param foo.baz
  * @param bar

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -133,6 +133,11 @@ const getFunctionParameterNames = (functionNode : Object) : Array<T> => {
       if (param.key.type === 'Identifier') {
         return param.key.name;
       }
+        
+      // The key of an object could also be a string or number
+      if (param.key.type === 'Literal') {
+        return param.key.value;
+      }
     }
 
     if (param.type === 'ArrayPattern' || param.left?.type === 'ArrayPattern') {

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -133,8 +133,9 @@ const getFunctionParameterNames = (functionNode : Object) : Array<T> => {
       if (param.key.type === 'Identifier') {
         return param.key.name;
       }
-        
+
       // The key of an object could also be a string or number
+      /* istanbul ignore else */
       if (param.key.type === 'Literal') {
         return param.key.value;
       }

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -137,7 +137,9 @@ const getFunctionParameterNames = (functionNode : Object) : Array<T> => {
       // The key of an object could also be a string or number
       /* istanbul ignore else */
       if (param.key.type === 'Literal') {
-        return param.key.value;
+        return param.key.raw ||
+          // istanbul ignore next -- `raw` may not be present in all parsers
+          param.key.value;
       }
     }
 

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -1,5 +1,25 @@
 import iterateJsdoc from '../iterateJsdoc';
 
+/**
+ * Since path segments may be unquoted (if matching a reserved word,
+ * identifier or numeric literal) or single or double quoted, in either
+ * the `@param` or in source, we need to strip the quotes to give a fair
+ * comparison.
+ *
+ * @param {string} str
+ * @returns {string}
+ */
+const dropPathSegmentQuotes = (str) => {
+  return str.replace(/\.(['"])(.*)\1/gu, '.$2');
+};
+
+const comparePaths = (name) => {
+  return (otherPathName) => {
+    return otherPathName === name ||
+      dropPathSegmentQuotes(otherPathName) === dropPathSegmentQuotes(name);
+  };
+};
+
 const validateParameterNames = (
   targetTagName : string,
   allowExtraTrailingParamDocs: boolean,
@@ -76,8 +96,9 @@ const validateParameterNames = (
       });
 
       const missingProperties = [];
+
       expectedNames.forEach((name, idx) => {
-        if (!actualNames.includes(name)) {
+        if (!actualNames.some(comparePaths(name))) {
           if (!checkRestProperty && rests[idx]) {
             return;
           }
@@ -89,7 +110,7 @@ const validateParameterNames = (
       if (!hasPropertyRest || checkRestProperty) {
         actualNames.forEach((name, idx) => {
           const match = name.startsWith(tag.name.trim() + '.');
-          if (match && !expectedNames.includes(name) && name !== tag.name) {
+          if (match && !expectedNames.some(comparePaths(name)) && name !== tag.name) {
             extraProperties.push([name, paramTags[idx][1]]);
           }
         });

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -40,7 +40,7 @@ export default {
       settings: {
         jsdoc: {
           tagNamePreference: {
-            param: 'arg',
+            param: "arg",
           },
         },
       },
@@ -73,7 +73,8 @@ export default {
       errors: [
         {
           line: 3,
-          message: '@param path declaration ("Foo.Bar") appears before any real parameter.',
+          message:
+            '@param path declaration ("Foo.Bar") appears before any real parameter.',
         },
       ],
     },
@@ -90,7 +91,8 @@ export default {
       errors: [
         {
           line: 4,
-          message: '@param path declaration ("Foo.Bar") root node name ("Foo") does not match previous real parameter name ("foo").',
+          message:
+            '@param path declaration ("Foo.Bar") root node name ("Foo") does not match previous real parameter name ("foo").',
         },
       ],
     },
@@ -108,7 +110,8 @@ export default {
       errors: [
         {
           line: 4,
-          message: '@param path declaration ("employees[].name") appears before any real parameter.',
+          message:
+            '@param path declaration ("employees[].name") appears before any real parameter.',
         },
       ],
     },
@@ -175,7 +178,8 @@ export default {
       errors: [
         {
           line: 4,
-          message: '@param "bar" does not match an existing function parameter.',
+          message:
+            '@param "bar" does not match an existing function parameter.',
         },
       ],
     },
@@ -540,9 +544,9 @@ export default {
           message: 'Expected @param names to be "property". Got "prop".',
         },
       ],
-      parser: require.resolve('@typescript-eslint/parser'),
+      parser: require.resolve("@typescript-eslint/parser"),
       parserOptions: {
-        sourceType: 'module',
+        sourceType: "module",
       },
     },
     {
@@ -561,9 +565,9 @@ export default {
           message: 'Missing @param "prop.bar"',
         },
       ],
-      parser: require.resolve('@typescript-eslint/parser'),
+      parser: require.resolve("@typescript-eslint/parser"),
       parserOptions: {
-        sourceType: 'module',
+        sourceType: "module",
       },
     },
     {
@@ -599,9 +603,9 @@ export default {
           message: '@param "prop.bar" does not exist on prop',
         },
       ],
-      parser: require.resolve('@typescript-eslint/parser'),
+      parser: require.resolve("@typescript-eslint/parser"),
       parserOptions: {
-        sourceType: 'module',
+        sourceType: "module",
       },
     },
     {
@@ -621,9 +625,9 @@ export default {
           message: '@param "options.bar" does not exist on options',
         },
       ],
-      parser: require.resolve('@typescript-eslint/parser'),
+      parser: require.resolve("@typescript-eslint/parser"),
       parserOptions: {
-        sourceType: 'module',
+        sourceType: "module",
       },
     },
     {
@@ -638,7 +642,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Unexpected tag `@param`',
+          message: "Unexpected tag `@param`",
         },
       ],
       settings: {
@@ -661,7 +665,8 @@ export default {
       errors: [
         {
           line: 4,
-          message: 'Expected @param names to be "error, cde". Got "error, code".',
+          message:
+            'Expected @param names to be "error, cde". Got "error, code".',
         },
       ],
     },
@@ -762,7 +767,7 @@ export default {
       ],
       options: [
         {
-          checkTypesPattern: 'SVGRect',
+          checkTypesPattern: "SVGRect",
         },
       ],
     },
@@ -815,7 +820,7 @@ export default {
           checkRestProperty: true,
         },
       ],
-      parser: require.resolve('babel-eslint'),
+      parser: require.resolve("babel-eslint"),
     },
     {
       code: `
@@ -845,7 +850,7 @@ export default {
           message: '@param "options.four" does not exist on options',
         },
       ],
-      parser: require.resolve('@typescript-eslint/parser'),
+      parser: require.resolve("@typescript-eslint/parser"),
     },
   ],
   valid: [
@@ -941,6 +946,18 @@ export default {
       code: `
           /**
            * @param foo
+           * @param foo.a-b
+           * @param foo.b
+           */
+          function quux ({"a-b": A, b}) {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @param foo
            * @param foo.bar
            * @param foo.baz
            * @param bar
@@ -972,9 +989,9 @@ export default {
           constructor(private property: string) {}
         }
       `,
-      parser: require.resolve('@typescript-eslint/parser'),
+      parser: require.resolve("@typescript-eslint/parser"),
       parserOptions: {
-        sourceType: 'module',
+        sourceType: "module",
       },
     },
     {
@@ -988,9 +1005,9 @@ export default {
           constructor(options: { foo: string, bar: string }) {}
         }
       `,
-      parser: require.resolve('@typescript-eslint/parser'),
+      parser: require.resolve("@typescript-eslint/parser"),
       parserOptions: {
-        sourceType: 'module',
+        sourceType: "module",
       },
     },
     {
@@ -1004,9 +1021,9 @@ export default {
           constructor({ foo, bar }: { foo: string, bar: string }) {}
         }
       `,
-      parser: require.resolve('@typescript-eslint/parser'),
+      parser: require.resolve("@typescript-eslint/parser"),
       parserOptions: {
-        sourceType: 'module',
+        sourceType: "module",
       },
     },
     {
@@ -1020,9 +1037,9 @@ export default {
           constructor({ foo, bar }: { foo: string, bar: string }) {}
         }
       `,
-      parser: require.resolve('@typescript-eslint/parser'),
+      parser: require.resolve("@typescript-eslint/parser"),
       parserOptions: {
-        sourceType: 'module',
+        sourceType: "module",
       },
     },
     {
@@ -1146,7 +1163,7 @@ export default {
       `,
       options: [
         {
-          checkTypesPattern: 'SVGRect',
+          checkTypesPattern: "SVGRect",
         },
       ],
     },
@@ -1162,7 +1179,7 @@ export default {
         }
       }
       `,
-      parser: require.resolve('@typescript-eslint/parser'),
+      parser: require.resolve("@typescript-eslint/parser"),
     },
     {
       code: `
@@ -1177,7 +1194,7 @@ export default {
         input;
       }
       `,
-      parser: require.resolve('@typescript-eslint/parser'),
+      parser: require.resolve("@typescript-eslint/parser"),
     },
     {
       code: `
@@ -1192,7 +1209,7 @@ export default {
         }
       }
       `,
-      parser: require.resolve('@typescript-eslint/parser'),
+      parser: require.resolve("@typescript-eslint/parser"),
     },
   ],
 };

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -929,6 +929,18 @@ export default {
       code: `
           /**
            * @param foo
+           * @param foo.a
+           * @param foo.b
+           */
+          function quux ({"a": A, b}) {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @param foo
            * @param foo.bar
            * @param foo.baz
            * @param bar

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -946,7 +946,19 @@ export default {
       code: `
           /**
            * @param foo
-           * @param foo.a-b
+           * @param foo."a"
+           * @param foo.b
+           */
+          function quux ({a: A, b}) {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @param foo
+           * @param foo."a-b"
            * @param foo.b
            */
           function quux ({"a-b": A, b}) {

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -40,7 +40,7 @@ export default {
       settings: {
         jsdoc: {
           tagNamePreference: {
-            param: "arg",
+            param: 'arg',
           },
         },
       },
@@ -544,9 +544,9 @@ export default {
           message: 'Expected @param names to be "property". Got "prop".',
         },
       ],
-      parser: require.resolve("@typescript-eslint/parser"),
+      parser: require.resolve('@typescript-eslint/parser'),
       parserOptions: {
-        sourceType: "module",
+        sourceType: 'module',
       },
     },
     {
@@ -565,9 +565,9 @@ export default {
           message: 'Missing @param "prop.bar"',
         },
       ],
-      parser: require.resolve("@typescript-eslint/parser"),
+      parser: require.resolve('@typescript-eslint/parser'),
       parserOptions: {
-        sourceType: "module",
+        sourceType: 'module',
       },
     },
     {
@@ -603,9 +603,9 @@ export default {
           message: '@param "prop.bar" does not exist on prop',
         },
       ],
-      parser: require.resolve("@typescript-eslint/parser"),
+      parser: require.resolve('@typescript-eslint/parser'),
       parserOptions: {
-        sourceType: "module",
+        sourceType: 'module',
       },
     },
     {
@@ -625,9 +625,9 @@ export default {
           message: '@param "options.bar" does not exist on options',
         },
       ],
-      parser: require.resolve("@typescript-eslint/parser"),
+      parser: require.resolve('@typescript-eslint/parser'),
       parserOptions: {
-        sourceType: "module",
+        sourceType: 'module',
       },
     },
     {
@@ -642,7 +642,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: "Unexpected tag `@param`",
+          message: 'Unexpected tag `@param`',
         },
       ],
       settings: {
@@ -767,7 +767,7 @@ export default {
       ],
       options: [
         {
-          checkTypesPattern: "SVGRect",
+          checkTypesPattern: 'SVGRect',
         },
       ],
     },
@@ -820,7 +820,7 @@ export default {
           checkRestProperty: true,
         },
       ],
-      parser: require.resolve("babel-eslint"),
+      parser: require.resolve('babel-eslint'),
     },
     {
       code: `
@@ -850,7 +850,7 @@ export default {
           message: '@param "options.four" does not exist on options',
         },
       ],
-      parser: require.resolve("@typescript-eslint/parser"),
+      parser: require.resolve('@typescript-eslint/parser'),
     },
   ],
   valid: [
@@ -989,9 +989,9 @@ export default {
           constructor(private property: string) {}
         }
       `,
-      parser: require.resolve("@typescript-eslint/parser"),
+      parser: require.resolve('@typescript-eslint/parser'),
       parserOptions: {
-        sourceType: "module",
+        sourceType: 'module',
       },
     },
     {
@@ -1005,9 +1005,9 @@ export default {
           constructor(options: { foo: string, bar: string }) {}
         }
       `,
-      parser: require.resolve("@typescript-eslint/parser"),
+      parser: require.resolve('@typescript-eslint/parser'),
       parserOptions: {
-        sourceType: "module",
+        sourceType: 'module',
       },
     },
     {
@@ -1021,9 +1021,9 @@ export default {
           constructor({ foo, bar }: { foo: string, bar: string }) {}
         }
       `,
-      parser: require.resolve("@typescript-eslint/parser"),
+      parser: require.resolve('@typescript-eslint/parser'),
       parserOptions: {
-        sourceType: "module",
+        sourceType: 'module',
       },
     },
     {
@@ -1037,9 +1037,9 @@ export default {
           constructor({ foo, bar }: { foo: string, bar: string }) {}
         }
       `,
-      parser: require.resolve("@typescript-eslint/parser"),
+      parser: require.resolve('@typescript-eslint/parser'),
       parserOptions: {
-        sourceType: "module",
+        sourceType: 'module',
       },
     },
     {
@@ -1163,7 +1163,7 @@ export default {
       `,
       options: [
         {
-          checkTypesPattern: "SVGRect",
+          checkTypesPattern: 'SVGRect',
         },
       ],
     },
@@ -1179,7 +1179,7 @@ export default {
         }
       }
       `,
-      parser: require.resolve("@typescript-eslint/parser"),
+      parser: require.resolve('@typescript-eslint/parser'),
     },
     {
       code: `
@@ -1194,7 +1194,7 @@ export default {
         input;
       }
       `,
-      parser: require.resolve("@typescript-eslint/parser"),
+      parser: require.resolve('@typescript-eslint/parser'),
     },
     {
       code: `
@@ -1209,7 +1209,7 @@ export default {
         }
       }
       `,
-      parser: require.resolve("@typescript-eslint/parser"),
+      parser: require.resolve('@typescript-eslint/parser'),
     },
   ],
 };


### PR DESCRIPTION
Fixes: #598 

A key in a destructured object that is passed as a function parameter could be a string or a number. This case was previously not handled by `getParamName()`.

Example that failed before and succeeds now:
```js
const someFunction = ({ 
  "value": renamedValue,  // eslint throws Unsupported function signature format.
  otherArg,
}) => {
  console.log("not important");
}
```

