### PR TITLE
Jsdoctypeparser update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3469,7 +3469,7 @@ function quux () {
 // Message: Invalid JSDoc @returns type "Number"; prefer: "number".
 
 /**
- * @param {(Number|string|Boolean)=} foo
+ * @param {(Number | string | Boolean)=} foo
  */
 function quux (foo, bar, baz) {
 
@@ -3477,7 +3477,7 @@ function quux (foo, bar, baz) {
 // Message: Invalid JSDoc @param "foo" type "Number"; prefer: "number".
 
 /**
- * @param {Array.<Number|String>} foo
+ * @param {Array.<Number | String>} foo
  */
 function quux (foo, bar, baz) {
 
@@ -3485,7 +3485,7 @@ function quux (foo, bar, baz) {
 // Message: Invalid JSDoc @param "foo" type "Number"; prefer: "number".
 
 /**
- * @param {(Number|String)[]} foo
+ * @param {(Number | String)[]} foo
  */
 function quux (foo, bar, baz) {
 
@@ -3984,7 +3984,7 @@ function quux () {}
 // Message: Invalid JSDoc @typedef "foo" type "object"; prefer: "Object<>".
 
 /**
- * @param {Array<number|undefined>} foo
+ * @param {Array<number | undefined>} foo
  */
 function quux (foo) {
 
@@ -4015,7 +4015,7 @@ function quux (foo, bar, baz) {
 }
 
 /**
- * @param {(number|string|boolean)=} foo
+ * @param {(number | string | boolean)=} foo
  */
 function quux (foo, bar, baz) {
 
@@ -13475,10 +13475,10 @@ function quux() {
 // Message: Tag @type must have a type
 
 /**
- * @modifies {bar|foo<}
+ * @modifies {bar | foo<}
  */
 function quux (foo, bar, baz) {}
-// Message: Syntax error in type: bar|foo<
+// Message: Syntax error in type: bar | foo<
 
 /**
  * @private {BadTypeChecked<}
@@ -13688,17 +13688,17 @@ function quux() {
 // Settings: {"jsdoc":{"mode":"closure"}}
 
 /**
- * @typedef {number|string} UserDefinedType
+ * @typedef {number | string} UserDefinedType
  */
 
 /**
- * @typedef {number|string}
+ * @typedef {number | string}
  */
 let UserDefinedGCCType;
 // Settings: {"jsdoc":{"mode":"closure"}}
 
 /**
- * @modifies {foo|bar}
+ * @modifies {foo | bar}
  */
 function quux (foo, bar, baz) {}
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "comment-parser": "^0.7.5",
     "debug": "^4.1.1",
-    "jsdoctypeparser": "^7.0.0",
+    "jsdoctypeparser": "^8.0.0",
     "lodash": "^4.17.15",
     "regextras": "^0.7.1",
     "semver": "^7.3.2",

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -104,7 +104,7 @@ export default {
     {
       code: `
           /**
-           * @param {(Number|string|Boolean)=} foo
+           * @param {(Number | string | Boolean)=} foo
            */
           function quux (foo, bar, baz) {
 
@@ -122,7 +122,7 @@ export default {
       ],
       output: `
           /**
-           * @param {(number|string|boolean)=} foo
+           * @param {(number | string | boolean)=} foo
            */
           function quux (foo, bar, baz) {
 
@@ -132,7 +132,7 @@ export default {
     {
       code: `
           /**
-           * @param {Array.<Number|String>} foo
+           * @param {Array.<Number | String>} foo
            */
           function quux (foo, bar, baz) {
 
@@ -150,7 +150,7 @@ export default {
       ],
       output: `
           /**
-           * @param {Array.<number|string>} foo
+           * @param {Array.<number | string>} foo
            */
           function quux (foo, bar, baz) {
 
@@ -160,7 +160,7 @@ export default {
     {
       code: `
           /**
-           * @param {(Number|String)[]} foo
+           * @param {(Number | String)[]} foo
            */
           function quux (foo, bar, baz) {
 
@@ -178,7 +178,7 @@ export default {
       ],
       output: `
           /**
-           * @param {(number|string)[]} foo
+           * @param {(number | string)[]} foo
            */
           function quux (foo, bar, baz) {
 
@@ -1896,7 +1896,7 @@ export default {
     {
       code: `
       /**
-       * @param {Array<number|undefined>} foo
+       * @param {Array<number | undefined>} foo
        */
       function quux (foo) {
 
@@ -1909,7 +1909,7 @@ export default {
       ],
       output: `
       /**
-       * @param {(number|undefined)[]} foo
+       * @param {(number | undefined)[]} foo
        */
       function quux (foo) {
 
@@ -1953,7 +1953,7 @@ export default {
     {
       code: `
           /**
-           * @param {(number|string|boolean)=} foo
+           * @param {(number | string | boolean)=} foo
            */
           function quux (foo, bar, baz) {
 

--- a/test/rules/assertions/validTypes.js
+++ b/test/rules/assertions/validTypes.js
@@ -253,13 +253,13 @@ export default {
     {
       code: `
           /**
-           * @modifies {bar|foo<}
+           * @modifies {bar | foo<}
            */
           function quux (foo, bar, baz) {}
       `,
       errors: [
         {
-          message: 'Syntax error in type: bar|foo<',
+          message: 'Syntax error in type: bar | foo<',
         },
       ],
     },
@@ -655,14 +655,14 @@ export default {
     {
       code: `
           /**
-           * @typedef {number|string} UserDefinedType
+           * @typedef {number | string} UserDefinedType
            */
       `,
     },
     {
       code: `
           /**
-           * @typedef {number|string}
+           * @typedef {number | string}
            */
           let UserDefinedGCCType;
       `,
@@ -675,7 +675,7 @@ export default {
     {
       code: `
           /**
-           * @modifies {foo|bar}
+           * @modifies {foo | bar}
            */
           function quux (foo, bar, baz) {}
       `,


### PR DESCRIPTION
chore: update `jsdoctypeparser`

BREAKING CHANGE:

1. Adds spaces between union items per jsdoctypeparser update.
2. Removes JSDuck support (unions with "/" instead of "|")

Also adds support in typescript mode for `readonly` and intersections (`X & Y`)

(If someone was against the whitespace change, jsdoctypeparser could perhaps preserve whitespace and/or add an `eslint-plugin-jsdoc` fixer option to configure desired whitespace.)