### PR TITLE
Report more precisely when `descriptionStyle: 'body'` and only `@desc`/`@description` present

### DIFF
--- a/README.md
+++ b/README.md
@@ -7276,6 +7276,24 @@ function quux () {
 // Message: Missing JSDoc block description.
 
 /**
+ * @desc Not a blank description
+ */
+function quux () {
+
+}
+// Options: [{"descriptionStyle":"body"}]
+// Message: Remove the @desc tag to leave a plain block description or add additional description text above the @desc line.
+
+/**
+ * @description Not a blank description
+ */
+function quux () {
+
+}
+// Options: [{"descriptionStyle":"body"}]
+// Message: Remove the @description tag to leave a plain block description or add additional description text above the @description line.
+
+/**
  *
  */
 class quux {

--- a/src/rules/requireDescription.js
+++ b/src/rules/requireDescription.js
@@ -40,7 +40,13 @@ export default iterateJsdoc(({
     }
 
     if (descriptionStyle === 'body') {
-      report('Missing JSDoc block description.');
+      const descTags = utils.getPresentTags(['desc', 'description']);
+      if (descTags.length) {
+        const [{tag: tagName}] = descTags;
+        report(`Remove the @${tagName} tag to leave a plain block description or add additional description text above the @${tagName} line.`);
+      } else {
+        report('Missing JSDoc block description.');
+      }
 
       return;
     }

--- a/test/rules/assertions/requireDescription.js
+++ b/test/rules/assertions/requireDescription.js
@@ -63,6 +63,46 @@ export default {
     {
       code: `
           /**
+           * @desc Not a blank description
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Remove the @desc tag to leave a plain block description or add additional description text above the @desc line.',
+        },
+      ],
+      options: [
+        {
+          descriptionStyle: 'body',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @description Not a blank description
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Remove the @description tag to leave a plain block description or add additional description text above the @description line.',
+        },
+      ],
+      options: [
+        {
+          descriptionStyle: 'body',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
            *
            */
           class quux {


### PR DESCRIPTION
feat(`require-description`): report more precisely the action to take when "body" `descriptionStyle` is set and where user (only) has a desc/description tag; fixes #608