### PR TITLE
feat: `structuredTags` setting to control type/name portions of existing or custom tags

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -380,6 +380,49 @@ key nor the value will be reported. Thus in `check-types`, this fact can
 be used to allow both `object` and `Object` if one has a `preferredTypes`
 key `object: 'Object'` and `Object: 'object'`.
 
+### `structuredTags`
+
+An object indicating tags whose types and names/namepaths (whether defining or
+referencing namepaths) will be checked, subject to configuration. If the tags
+have predefined behavior or `allowEmptyNamepaths` behavior, this option will
+override that behavior for any specified tags, though this option can also be
+used for tags without predefined behavior. Its keys are tag names and its
+values are objects with the following optional properties:
+  - `name` - String set to one of the following:
+    - `"text"` - When a name is present, plain text will be allowed in the
+      name position (non-whitespace immediately after the tag and whitespace),
+      e.g., in `@throws This is an error`, "This" would normally be the name,
+      but "text" allows non-name text here also. This is the default.
+    - `"namepath-defining"` - As with `namepath-referencing`, but also
+      indicates the tag adds a namepath to definitions, e.g., to prevent
+      `no-undefined-types` from reporting references to that namepath.
+    - `"namepath-referencing"` - This will cause any name position to be
+      checked to ensure it is a valid namepath. You might use this to ensure
+      that tags which normally allow free text, e.g., `@see` will instead
+      require a namepath.
+    - `false` - This will disallow any text in the name position.
+  - `type`:
+      - `true` - Allows valid types within brackets. This is the default.
+      - `false` - Explicitly disallows any brackets or bracketed type. You
+        might use this with `@throws` to suggest that only free form text
+        is being input or with `@augments` (for jsdoc mode) to disallow
+        Closure-style bracketed usage along with a required namepath.
+  - `required` - Array of one of the following (defaults to an empty array,
+      meaning none are required):
+    - One or both of the following strings (if both are included, then both
+      are required):
+      - `"name"` - Indicates that a name position is required (not just that
+        if present, it is a valid namepath). You might use this with `see`
+        to insist that a value (or namepath, depending on the `name` value)
+        is always present.
+      - `"type"` - Indicates that the type position (within curly brackets)
+        is required (not just that if present, it is a valid type). You
+        might use this with `@throws` or `@typedef` which might otherwise
+        normally have their types optional. See the type groups 3-5 above.
+    - `"typeOrName"` - Must have either type (e.g., `@throws {aType}`) or
+        name (`@throws Some text`); does not require that both exist but
+        disallows just an empty tag.
+
 ## Advanced
 
 ### AST and Selectors

--- a/.README/rules/check-types.md
+++ b/.README/rules/check-types.md
@@ -120,6 +120,10 @@ Boolean | **boolean** | **boolean** | `(true) instanceof Boolean` -> **`false`**
 Number | **number** | **number** | `(41) instanceof Number` -> **`false`**
 String | **string** | **string** | `("test") instanceof String` -> **`false`**
 
+If you define your own tags and don't wish their bracketed portions checked
+for types, you can use `settings.jsdoc.structuredTags` with a tag `type` of
+`false`.
+
 |||
 |---|---|
 |Context|everywhere|
@@ -127,6 +131,6 @@ String | **string** | **string** | `("test") instanceof String` -> **`false`**
 |Aliases|`constructor`, `const`, `extends`, `var`, `arg`, `argument`, `prop`, `return`, `exception`, `yield`|
 |Closure-only|`package`, `private`, `protected`, `public`, `static`|
 |Options|`noDefaults`, `exemptTagContexts`, `unifyParentAndChildTypeChecks`|
-|Settings|`preferredTypes`, `mode`|
+|Settings|`preferredTypes`, `mode`, `structuredTags`|
 
 <!-- assertions checkTypes -->

--- a/.README/rules/no-undefined-types.md
+++ b/.README/rules/no-undefined-types.md
@@ -36,6 +36,11 @@ Also note that if there is an error [parsing](https://github.com/jsdoctypeparser
 types for a tag, the function will silently ignore that tag, leaving it to
 the `valid-types` rule to report parsing errors.
 
+If you define your own tags, you can use `settings.jsdoc.structuredTags`
+to indicate that a tag's `name` is "namepath-defining" (and should prevent
+reporting on use of that namepath elsewhere) and/or that a tag's `type` is
+`false` (and should not be checked for types).
+
 #### Options
 
 An option object may have the following key:
@@ -51,6 +56,6 @@ An option object may have the following key:
 |Aliases|`constructor`, `const`, `extends`, `var`, `arg`, `argument`, `prop`, `return`, `exception`, `yield`|
 |Closure-only|`package`, `private`, `protected`, `public`, `static`|
 |Options|`definedTypes`|
-|Settings|`preferredTypes`, `mode`|
+|Settings|`preferredTypes`, `mode`, `structuredTags`|
 
 <!-- assertions noUndefinedTypes -->

--- a/.README/rules/valid-types.md
+++ b/.README/rules/valid-types.md
@@ -31,15 +31,15 @@ e.g., `@modifies`):
 The following tags have their name/namepath portion (the non-whitespace
 text after the tag name) checked:
 
-1. Name(path)-defining tags requiring namepath: `@external`, `@host`,
-    `@name`, `@typedef`, and `@template` (TypeScript/Closure only);
-    `@param` (`@arg`, `@argument`) and `@property`
+1. Name(path)-defining tags requiring namepath: `@event`, `@callback`,
+    `@external`, `@host`, `@name`, `@typedef`, and `@template`
+    (TypeScript/Closure only); `@param` (`@arg`, `@argument`) and `@property`
     (`@prop`) also fall into this category, but while this rule will check
     their namepath validity, we leave the requiring of the name portion
     to the rules `require-param-name` and `require-property-name`,
     respectively.
 1. Name(path)-defining tags (which may have value without namepath or their
-    namepath can be expressed elsewhere on the block): `@event`, `@callback`,
+    namepath can be expressed elsewhere on the block):
     `@class`, `@constructor`, `@constant`, `@const`, `@function`, `@func`,
     `@method`, `@interface` (TypeScript tag only), `@member`, `@var`,
     `@mixin`, `@namespace`, `@module` (module paths are not planned for
@@ -70,16 +70,22 @@ text after the tag name) checked:
    allow `#`, `.`, or `~` at the end (which is not allowed at the end of
    normal paths).
 
+If you define your own tags, `settings.jsdoc.structuredTags` will allow
+these custom tags to be checked, with the name portion of tags checked for
+valid namepaths (based on the tag's `name` value), their type portions checked
+for valid types (based on the tag's `type` value), and either portion checked
+for presence (based on `false` `name` or `type` values or their `required`
+value). See the setting for more details.
+
 #### Options
 
 - `allowEmptyNamepaths` (default: true) - Set to `false` to bulk disallow
   empty name paths with namepath groups 2 and 4 (these might often be
   expected to have an accompanying name path, though they have some
   indicative value without one; these may also allow names to be defined
-  in another manner elsewhere in the block)
-- `checkSeesForNamepaths` (default: false) - Set this to `true` to insist
-  that `@see` only use name paths (the tag is normally permitted to
-  allow other text)
+  in another manner elsewhere in the block); you can use
+  `settings.jsdoc.structuredTags` with the `required` key set to "name" if you
+  wish to require name paths on a tag-by-tag basis.
 
 |||
 |---|---|
@@ -87,7 +93,7 @@ text after the tag name) checked:
 |Tags|For name only unless otherwise stated: `alias`, `augments`, `borrows`, `callback`, `class` (for name and type), `constant` (for name and type), `enum` (for type), `event`, `external`, `fires`, `function`, `implements` (for type), `interface`, `lends`, `listens`, `member` (for name and type),  `memberof`, `memberof!`, `mixes`, `mixin`, `modifies`, `module` (for name and type), `name`, `namespace` (for name and type), `param` (for name and type), `property` (for name and type), `returns` (for type), `see` (optionally for name), `this`, `throws` (for type), `type` (for type), `typedef` (for name and type), `yields` (for type)|
 |Aliases|`extends`, `constructor`, `const`, `host`, `emits`, `func`, `method`, `var`, `arg`, `argument`, `prop`, `return`, `exception`, `yield`|
 |Closure-only|For type only: `package`, `private`, `protected`, `public`, `static`|
-|Options|`allowEmptyNamepaths`, `checkSeesForNamepaths`|
-|Settings|`mode`|
+|Options|`allowEmptyNamepaths`|
+|Settings|`mode`, `structuredTags`|
 
 <!-- assertions validTypes -->

--- a/src/getDefaultTagStructureForMode.js
+++ b/src/getDefaultTagStructureForMode.js
@@ -1,0 +1,464 @@
+const getDefaultTagStructureForMode = (mode) => {
+  const isJsdoc = mode === 'jsdoc';
+  const isClosure = mode === 'closure';
+  const isTypescript = mode === 'typescript';
+  const isPermissive = mode === 'permissive';
+
+  const isJsdocOrTypescript = isJsdoc || isTypescript;
+  const isTypescriptOrClosure = isTypescript || isClosure;
+  const isClosureOrPermissive = isClosure || isPermissive;
+  const isJsdocTypescriptOrPermissive = isJsdocOrTypescript || isPermissive;
+
+  // Properties:
+  // `nameContents` - 'namepath-referencing'|'namepath-defining'|'text'|false
+  // `typeAllowed` - boolean
+  // `nameRequired` - boolean
+  // `typeRequired` - boolean
+  // `typeOrNameRequired` - boolean
+
+  // All of `typeAllowed` have a signature with "type" except for
+  //  `augments`/`extends` ("namepath")
+  //  `param`/`arg`/`argument` (no signature)
+  //  `property`/`prop` (no signature)
+  //  `modifies` (undocumented)
+
+  // None of the `nameContents: 'namepath-defining'` show as having curly
+  //  brackets for their name/namepath
+
+  // Among `namepath-defining` and `namepath-referencing`, these do not seem
+  //  to allow curly brackets in their doc signature or examples (`modifies`
+  //  references namepaths within its type brackets and `param` is
+  //  name-defining but not namepath-defining, so not part of these groups)
+
+  // Todo: Should support special processing for "name" as distinct from
+  //   "namepath" (e.g., param can't define a namepath)
+
+  // Once checking inline tags:
+  // Todo: Re: `typeOrNameRequired`, `@link` (or @linkcode/@linkplain) seems
+  //  to require a namepath OR URL and might be checked as such.
+  // Todo: Should support a `tutorialID` type (for `@tutorial` block and
+  //  inline)
+
+  return new Map([
+    ['alias', new Map([
+      // Signature seems to require a "namepath" (and no counter-examples)
+      ['nameContents', 'namepath-referencing'],
+
+      // "namepath"
+      ['typeOrNameRequired', true],
+    ])],
+
+    ['arg', new Map([
+      ['nameContents', 'namepath-defining'],
+
+      // See `param`
+      ['nameRequired', true],
+
+      // Has no formal signature in the docs but shows curly brackets
+      //   in the examples
+      ['typeAllowed', true],
+    ])],
+
+    ['argument', new Map([
+      ['nameContents', 'namepath-defining'],
+
+      // See `param`
+      ['nameRequired', true],
+
+      // Has no formal signature in the docs but shows curly brackets
+      //   in the examples
+      ['typeAllowed', true],
+    ])],
+
+    ['augments', new Map([
+      // Signature seems to require a "namepath" (and no counter-examples)
+      ['nameContents', 'namepath-referencing'],
+
+      // Does not show curly brackets in either the signature or examples
+      ['typeAllowed', true],
+
+      // "namepath"
+      ['typeOrNameRequired', true],
+    ])],
+
+    ['borrows', new Map([
+      // `borrows` has a different format, however, so needs special parsing;
+      //   seems to require both, and as "namepath"'s
+      ['nameContents', 'namepath-referencing'],
+
+      // "namepath"
+      ['typeOrNameRequired', true],
+    ])],
+
+    ['callback', new Map([
+      // Seems to require a "namepath" in the signature (with no
+      //   counter-examples)
+      ['nameContents', 'namepath-defining'],
+
+      // "namepath"
+      ['nameRequired', true],
+    ])],
+
+    ['class', new Map([
+      // Allows for "name"'s in signature, but indicated as optional
+      ['nameContents', 'namepath-defining'],
+
+      ['typeAllowed', true],
+    ])],
+
+    ['const', new Map([
+      // Allows for "name"'s in signature, but indicated as optional
+      ['nameContents', 'namepath-defining'],
+
+      ['typeAllowed', true],
+    ])],
+    ['constant', new Map([
+      // Allows for "name"'s in signature, but indicated as optional
+      ['nameContents', 'namepath-defining'],
+
+      ['typeAllowed', true],
+    ])],
+    ['constructor', new Map([
+      // Allows for "name"'s in signature, but indicated as optional
+      ['nameContents', 'namepath-defining'],
+
+      ['typeAllowed', true],
+    ])],
+
+    ['define', new Map([
+      ['typeRequired', isClosure],
+    ])],
+
+    ['emits', new Map([
+      // Signature seems to require a "name" (of an event) and no counter-examples
+      ['nameContents', 'namepath-referencing'],
+    ])],
+
+    ['enum', new Map([
+      // Has example showing curly brackets but not in doc signature
+      ['typeAllowed', true],
+    ])],
+
+    ['event', new Map([
+      // The doc signature of `event` seems to require a "name"
+      ['nameRequired', true],
+
+      // Appears to require a "name" in its signature, albeit somewhat
+      //  different from other "name"'s (including as described
+      //  at https://jsdoc.app/about-namepaths.html )
+      ['nameContents', 'namepath-defining'],
+    ])],
+
+    ['exception', new Map([
+      // Shows curly brackets in the signature and in the examples
+      ['typeAllowed', true],
+    ])],
+
+    ['export', new Map([
+      ['typeAllowed', isClosureOrPermissive],
+    ])],
+
+    ['extends', new Map([
+      // Signature seems to require a "namepath" (and no counter-examples)
+      ['nameContents', 'namepath-referencing'],
+
+      // Does not show curly brackets in either the signature or examples
+      ['typeAllowed', isClosureOrPermissive],
+
+      ['nameRequired', isJsdocOrTypescript],
+
+      // "namepath"
+      ['typeOrNameRequired', isClosureOrPermissive],
+    ])],
+
+    ['external', new Map([
+      // Appears to require a "name" in its signature, albeit somewhat
+      //  different from other "name"'s (including as described
+      //  at https://jsdoc.app/about-namepaths.html )
+      ['nameContents', 'namepath-defining'],
+
+      // "name" (and a special syntax for the `external` name)
+      ['nameRequired', true],
+    ])],
+
+    ['fires', new Map([
+      // Signature seems to require a "name" (of an event) and no
+      //  counter-examples
+      ['nameContents', 'namepath-referencing'],
+    ])],
+
+    ['function', new Map([
+      // Allows for "name"'s in signature, but indicated as optional
+      ['nameContents', 'namepath-defining'],
+    ])],
+    ['func', new Map([
+      // Allows for "name"'s in signature, but indicated as optional
+      ['nameContents', 'namepath-defining'],
+    ])],
+
+    ['host', new Map([
+      // Appears to require a "name" in its signature, albeit somewhat
+      //  different from other "name"'s (including as described
+      //  at https://jsdoc.app/about-namepaths.html )
+      ['nameContents', 'namepath-defining'],
+
+      // See `external`
+      ['nameRequired', true],
+
+      // "namepath"
+      ['typeOrNameRequired', true],
+    ])],
+
+    ['interface', new Map([
+      // Allows for "name" in signature, but indicates as optional
+      [
+        'nameContents',
+        isJsdocTypescriptOrPermissive ? 'namepath-defining' : false,
+      ],
+    ])],
+
+    ['implements', new Map([
+      // Shows curly brackets in the doc signature and examples
+      // "typeExpression"
+      ['typeRequired', true],
+    ])],
+
+    ['lends', new Map([
+      // Signature seems to require a "namepath" (and no counter-examples)
+      ['nameContents', 'namepath-referencing'],
+
+      // "namepath"
+      ['typeOrNameRequired', true],
+    ])],
+
+    ['listens', new Map([
+      // Signature seems to require a "name" (of an event) and no
+      //  counter-examples
+      ['nameContents', 'namepath-referencing'],
+    ])],
+
+    ['member', new Map([
+      // Allows for "name"'s in signature, but indicated as optional
+      ['nameContents', 'namepath-defining'],
+
+      // Has example showing curly brackets but not in doc signature
+      ['typeAllowed', true],
+    ])],
+
+    ['memberof', new Map([
+      // Signature seems to require a "namepath" (and no counter-examples),
+      //  though it allows an incomplete namepath ending with connecting symbol
+      ['nameContents', 'namepath-referencing'],
+
+      // "namepath"
+      ['typeOrNameRequired', true],
+    ])],
+    ['memberof!', new Map([
+      // Signature seems to require a "namepath" (and no counter-examples),
+      //  though it allows an incomplete namepath ending with connecting symbol
+      ['nameContents', 'namepath-referencing'],
+
+      // "namepath"
+      ['typeOrNameRequired', true],
+    ])],
+
+    ['method', new Map([
+      // Allows for "name"'s in signature, but indicated as optional
+      ['nameContents', 'namepath-defining'],
+    ])],
+    ['mixes', new Map([
+      // Signature seems to require a "OtherObjectPath" with no
+      //   counter-examples
+      ['nameContents', 'namepath-referencing'],
+
+      // "OtherObjectPath"
+      ['typeOrNameRequired', true],
+    ])],
+
+    ['mixin', new Map([
+      // Allows for "name"'s in signature, but indicated as optional
+      ['nameContents', 'namepath-defining'],
+    ])],
+
+    ['modifies', new Map([
+      // Has no documentation, but test example has curly brackets, and
+      //  "name" would be suggested rather than "namepath" based on example;
+      //  not sure if name is required
+      ['typeAllowed', true],
+    ])],
+
+    ['module', new Map([
+      // Optional "name" and no curly brackets
+      //  this block impacts `no-undefined-types` and `valid-types` (search for
+      //  "isNamepathDefiningTag|tagMightHaveNamepath|tagMightHaveEitherTypeOrNamePosition")
+      ['nameContents', isJsdoc ? 'namepath-defining' : 'text'],
+
+      // Shows the signature with curly brackets but not in the example
+      ['typeAllowed', true],
+    ])],
+
+    ['name', new Map([
+      // Seems to require a "namepath" in the signature (with no
+      //   counter-examples)
+      ['nameContents', 'namepath-defining'],
+
+      // "namepath"
+      ['nameRequired', true],
+
+      // "namepath"
+      ['typeOrNameRequired', true],
+    ])],
+
+    ['namespace', new Map([
+      // Allows for "name"'s in signature, but indicated as optional
+      ['nameContents', 'namepath-defining'],
+
+      // Shows the signature with curly brackets but not in the example
+      ['typeAllowed', true],
+    ])],
+    ['package', new Map([
+      // Shows the signature with curly brackets but not in the example
+      // "typeExpression"
+      ['typeAllowed', isClosureOrPermissive],
+    ])],
+
+    ['param', new Map([
+      ['nameContents', 'namepath-defining'],
+
+      // Though no signature provided requiring, per
+      //  https://jsdoc.app/tags-param.html:
+      // "The @param tag requires you to specify the name of the parameter you
+      //  are documenting."
+      ['nameRequired', true],
+
+      // Has no formal signature in the docs but shows curly brackets
+      //   in the examples
+      ['typeAllowed', true],
+    ])],
+
+    ['private', new Map([
+      // Shows the signature with curly brackets but not in the example
+      // "typeExpression"
+      ['typeAllowed', isClosureOrPermissive],
+    ])],
+
+    ['prop', new Map([
+      ['nameContents', 'namepath-defining'],
+
+      // See `property`
+      ['nameRequired', true],
+
+      // Has no formal signature in the docs but shows curly brackets
+      //   in the examples
+      ['typeAllowed', true],
+    ])],
+
+    ['property', new Map([
+      ['nameContents', 'namepath-defining'],
+
+      // No docs indicate required, but since parallel to `param`, we treat as
+      //   such:
+      ['nameRequired', true],
+
+      // Has no formal signature in the docs but shows curly brackets
+      //   in the examples
+      ['typeAllowed', true],
+    ])],
+
+    ['protected', new Map([
+      // Shows the signature with curly brackets but not in the example
+      // "typeExpression"
+      ['typeAllowed', isClosureOrPermissive],
+    ])],
+
+    ['public', new Map([
+      // Does not show a signature nor show curly brackets in the example
+      ['typeAllowed', isClosureOrPermissive],
+    ])],
+
+    ['returns', new Map([
+      // Shows curly brackets in the signature and in the examples
+      ['typeAllowed', true],
+    ])],
+    ['return', new Map([
+      // Shows curly brackets in the signature and in the examples
+      ['typeAllowed', true],
+    ])],
+
+    ['see', new Map([
+      // Signature allows for "namepath" or text, so user must configure to
+      //  'namepath-referencing' to enforce checks
+      ['nameContents', 'text'],
+    ])],
+
+    ['static', new Map([
+      // Does not show a signature nor show curly brackets in the example
+      ['typeAllowed', isClosureOrPermissive],
+    ])],
+
+    ['template', new Map([
+      ['nameContents', isJsdoc ? 'text' : 'namepath-referencing'],
+
+      // Though defines `nameContents: 'namepath-defining'` in a sense, it is
+      //   not parseable in the same way for template (e.g., allowing commas),
+      //   so not adding
+      ['typeAllowed', isTypescriptOrClosure || isPermissive],
+    ])],
+
+    ['this', new Map([
+      // Signature seems to require a "namepath" (and no counter-examples)
+      // Not used with namepath in Closure/TypeScript, however
+      ['nameContents', isJsdoc ? 'namepath-referencing' : false],
+
+      ['typeRequired', isTypescriptOrClosure],
+
+      // namepath
+      ['typeOrNameRequired', isJsdoc],
+    ])],
+
+    ['throws', new Map([
+      // Shows curly brackets in the signature and in the examples
+      ['typeAllowed', true],
+    ])],
+
+    ['type', new Map([
+      // Shows curly brackets in the doc signature and examples
+      // "typeName"
+      ['typeRequired', true],
+    ])],
+
+    ['typedef', new Map([
+      // Seems to require a "namepath" in the signature (with no
+      //  counter-examples)
+      ['nameContents', 'namepath-defining'],
+
+      // "namepath"
+      ['nameRequired', isJsdocTypescriptOrPermissive],
+
+      // Has example showing curly brackets but not in doc signature
+      ['typeAllowed', true],
+
+      // "namepath"
+      ['typeOrNameRequired', true],
+    ])],
+
+    ['var', new Map([
+      // Allows for "name"'s in signature, but indicated as optional
+      ['nameContents', 'namepath-defining'],
+
+      // Has example showing curly brackets but not in doc signature
+      ['typeAllowed', true],
+    ])],
+
+    ['yields', new Map([
+      // Shows curly brackets in the signature and in the examples
+      ['typeAllowed', true],
+    ])],
+    ['yield', new Map([
+      // Shows curly brackets in the signature and in the examples
+      ['typeAllowed', true],
+    ])],
+  ]);
+};
+
+export default getDefaultTagStructureForMode;

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -166,6 +166,9 @@ export default {
   create (context) {
     const sourceCode = context.getSourceCode();
     const settings = getSettings(context);
+    if (!settings) {
+      return {};
+    }
 
     const {
       require: requireOption,

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -11,7 +11,7 @@ export default iterateJsdoc(({
   settings,
 }) => {
   const {
-    allowEmptyNamepaths = true,
+    allowEmptyNamepaths = false,
   } = context.options[0] || {};
   const {mode} = settings;
   if (!jsdoc.tags) {
@@ -122,7 +122,9 @@ export default iterateJsdoc(({
     if (tagMustHaveNamePosition !== false && !tag.name && !allowEmptyNamepaths && ![
       'param', 'arg', 'argument',
       'property', 'prop',
-    ].includes(tag.tag)) {
+    ].includes(tag.tag) &&
+      (tag.tag !== 'see' || !tag.description.includes('{@link'))
+    ) {
       const modeInfo = tagMustHaveNamePosition === true ? '' : ` in "${mode}" mode`;
       report(`Tag @${tag.tag} must have a name/namepath${modeInfo}.`, null, tag);
 
@@ -174,7 +176,7 @@ export default iterateJsdoc(({
         additionalProperies: false,
         properties: {
           allowEmptyNamepaths: {
-            default: true,
+            default: false,
             type: 'boolean',
           },
         },

--- a/test/eslint/getJSDocComment.js
+++ b/test/eslint/getJSDocComment.js
@@ -8,6 +8,9 @@ const rule = {
   create (context) {
     const sourceCode = context.getSourceCode();
     const settings = getSettings(context);
+    if (!settings) {
+      return {};
+    }
 
     return {
       ObjectExpression (node) {

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -852,6 +852,30 @@ export default {
       ],
       parser: require.resolve('@typescript-eslint/parser'),
     },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux() {
+
+          }
+      `,
+      errors: [{
+        line: 1,
+        message: 'Cannot add "name" to `require` with the tag\'s `name` set to `false`',
+      }],
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            see: {
+              name: false,
+              required: ['name'],
+            },
+          },
+        },
+      },
+    },
   ],
   valid: [
     {

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -1962,6 +1962,33 @@ export default {
         },
       },
     },
+    {
+      code: `
+          /**
+           * @aCustomTag {Number} foo
+           */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @aCustomTag "foo" type "Number"; prefer: "number".',
+        },
+      ],
+      output: `
+          /**
+           * @aCustomTag {number} foo
+           */
+      `,
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            aCustomTag: {
+              type: true,
+            },
+          },
+        },
+      },
+    },
   ],
   valid: [
     {
@@ -2480,6 +2507,22 @@ export default {
       settings: {
         jsdoc: {
           mode: 'typescript',
+        },
+      },
+    },
+    {
+      code: `
+          /**
+           * @aCustomTag {Number} foo
+           */
+      `,
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            aCustomTag: {
+              type: false,
+            },
+          },
         },
       },
     },

--- a/test/rules/assertions/noBadBlocks.js
+++ b/test/rules/assertions/noBadBlocks.js
@@ -42,6 +42,27 @@ export default {
            */
       `,
     },
+    {
+      code: `
+          function quux() {
+
+          }
+      `,
+      errors: [{
+        line: 1,
+        message: 'Cannot add "name" to `require` with the tag\'s `name` set to `false`',
+      }],
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            see: {
+              name: false,
+              required: ['name'],
+            },
+          },
+        },
+      },
+    },
   ],
   valid: [
     {

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -314,6 +314,70 @@ export default {
         },
       },
     },
+    {
+      code: `
+      /**
+       * @aCustomTag {SomeType}
+       */
+      function quux () {}
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'The type \'SomeType\' is undefined.',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            aCustomTag: {
+              type: true,
+            },
+          },
+        },
+      },
+    },
+    {
+      code: `
+      /**
+       * @namepathDefiner SomeType
+       */
+      /**
+       * @type {SomeType}
+       */
+      `,
+      errors: [
+        {
+          line: 6,
+          message: 'The type \'SomeType\' is undefined.',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            namepathDefiner: {
+              name: 'namepath-referencing',
+            },
+          },
+        },
+      },
+    },
+    {
+      code: `
+      /**
+       * @namepathDefiner SomeType
+       */
+      /**
+       * @type {SomeType}
+       */
+      `,
+      errors: [
+        {
+          line: 6,
+          message: 'The type \'SomeType\' is undefined.',
+        },
+      ],
+    },
   ],
   valid: [
     {
@@ -779,6 +843,42 @@ export default {
       settings: {
         jsdoc: {
           mode: 'typescript',
+        },
+      },
+    },
+    {
+      code: `
+      /**
+       * @aCustomTag {SomeType}
+       */
+      function quux () {}
+      `,
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            aCustomTag: {
+              type: false,
+            },
+          },
+        },
+      },
+    },
+    {
+      code: `
+      /**
+       * @namepathDefiner SomeType
+       */
+      /**
+       * @type {SomeType}
+       */
+      `,
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            namepathDefiner: {
+              name: 'namepath-defining',
+            },
+          },
         },
       },
     },

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -2404,6 +2404,30 @@ export default {
         }
       `,
     },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux() {
+
+          }
+      `,
+      errors: [{
+        line: 1,
+        message: 'Cannot add "name" to `require` with the tag\'s `name` set to `false`',
+      }],
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            see: {
+              name: false,
+              required: ['name'],
+            },
+          },
+        },
+      },
+    },
   ],
   valid: [{
     code: `

--- a/test/rules/assertions/validTypes.js
+++ b/test/rules/assertions/validTypes.js
@@ -133,9 +133,16 @@ export default {
         line: 3,
         message: 'Syntax error in namepath: foo%',
       }],
-      options: [{
-        checkSeesForNamepaths: true,
-      }],
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            see: {
+              name: 'namepath-referencing',
+              required: ['name'],
+            },
+          },
+        },
+      },
     },
     {
       code: `
@@ -176,7 +183,7 @@ export default {
       `,
       errors: [{
         line: 3,
-        message: 'Tag @callback must have a name/namepath',
+        message: 'Tag @callback must have a name/namepath.',
       }],
       options: [{
         allowEmptyNamepaths: false,
@@ -225,16 +232,48 @@ export default {
     {
       code: `
           /**
-           * @extends
+           * @this
            */
            class Bar {};
       `,
       errors: [
         {
           line: 3,
-          message: 'Tag @extends must have either a type or namepath',
+          message: 'Tag @this must have either a type or namepath in "jsdoc" mode.',
         },
       ],
+      options: [
+        {
+          allowEmptyNamepaths: false,
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @aCustomTag
+           */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Tag @aCustomTag must have either a type or namepath.',
+        },
+      ],
+      options: [
+        {
+          allowEmptyNamepaths: false,
+        },
+      ],
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            aCustomTag: {
+              required: ['typeOrNameRequired'],
+            },
+          },
+        },
+      },
     },
     {
       code: `
@@ -246,7 +285,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Tag @type must have a type',
+          message: 'Tag @type must have a type.',
         },
       ],
     },
@@ -310,7 +349,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Tag @define must have a type',
+          message: 'Tag @define must have a type in "closure" mode.',
         },
       ],
       settings: {
@@ -329,7 +368,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Tag @this must have a type',
+          message: 'Tag @this must have a type in "closure" mode.',
         },
       ],
       settings: {
@@ -413,6 +452,27 @@ export default {
     {
       code: `
       /**
+       * @aCustomTag name
+       */
+      `,
+      errors: [
+        {
+          message: '@aCustomTag should not have a name.',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            aCustomTag: {
+              name: false,
+            },
+          },
+        },
+      },
+    },
+    {
+      code: `
+      /**
        * @typedef {SomeType}
        */
       function quux () {}
@@ -420,7 +480,12 @@ export default {
       `,
       errors: [
         {
-          message: '@typedef must have a name in "jsdoc" mode.',
+          message: 'Tag @typedef must have a name/namepath in "jsdoc" mode.',
+        },
+      ],
+      options: [
+        {
+          allowEmptyNamepaths: false,
         },
       ],
       settings: {
@@ -445,6 +510,125 @@ export default {
       settings: {
         jsdoc: {
           mode: 'jsdoc',
+        },
+      },
+    },
+    {
+      code: `
+      /**
+       * @aCustomTag {SomeType}
+       */
+      function quux () {}
+
+      `,
+      errors: [
+        {
+          message: '@aCustomTag should not have a bracketed type.',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            aCustomTag: {
+              type: false,
+            },
+          },
+        },
+      },
+    },
+    {
+      code: `
+          /**
+           * @see foo%
+           */
+          function quux() {
+
+          }
+      `,
+      errors: [{
+        line: 1,
+        message: 'Cannot add "name" to `require` with the tag\'s `name` set to `false`',
+      }],
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            see: {
+              name: false,
+              required: ['name'],
+            },
+          },
+        },
+      },
+    },
+    {
+      code: `
+          /**
+           * @see foo%
+           */
+          function quux() {
+
+          }
+      `,
+      errors: [{
+        line: 1,
+        message: 'Cannot add "type" to `require` with the tag\'s `type` set to `false`',
+      }],
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            see: {
+              required: ['type'],
+              type: false,
+            },
+          },
+        },
+      },
+    },
+    {
+      code: `
+          /**
+           * @see foo%
+           */
+          function quux() {
+
+          }
+      `,
+      errors: [{
+        line: 1,
+        message: 'Cannot add "typeOrNameRequired" to `require` with the tag\'s `name` set to `false`',
+      }],
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            see: {
+              name: false,
+              required: ['typeOrNameRequired'],
+            },
+          },
+        },
+      },
+    },
+    {
+      code: `
+          /**
+           * @see foo%
+           */
+          function quux() {
+
+          }
+      `,
+      errors: [{
+        line: 1,
+        message: 'Cannot add "typeOrNameRequired" to `require` with the tag\'s `type` set to `false`',
+      }],
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            see: {
+              required: ['typeOrNameRequired'],
+              type: false,
+            },
+          },
         },
       },
     },
@@ -562,9 +746,16 @@ export default {
 
           }
       `,
-      options: [{
-        checkSeesForNamepaths: true,
-      }],
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            see: {
+              name: 'namepath-referencing',
+              required: ['name'],
+            },
+          },
+        },
+      },
     },
     {
       code: `
@@ -601,6 +792,16 @@ export default {
       code: `
           /**
            *
+           */
+          function quux() {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @aCustomTag
            */
           function quux() {
 
@@ -791,6 +992,11 @@ export default {
       function quux () {}
 
       `,
+      options: [
+        {
+          allowEmptyNamepaths: false,
+        },
+      ],
       settings: {
         jsdoc: {
           mode: 'closure',
@@ -825,6 +1031,25 @@ export default {
           allowEmptyNamepaths: false,
         },
       ],
+    },
+    {
+      code: `
+          /**
+           * @see
+           */
+          function quux() {
+
+          }
+      `,
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            see: {
+              name: 'namepath-referencing',
+            },
+          },
+        },
+      },
     },
   ],
 };


### PR DESCRIPTION
feat(`check-types`, `no-undefined-types`, `valid-types`): Add `structuredTags` setting to control whether the type and namepath portions should be checked for validity and whether such portions are required, and to let user-defined "namepath-defining" tags be added to defined types. Closes #481

BREAKING CHANGE:

Drops `checkSeesForNamepaths` setting. Use `{settings: {jsdoc: {structuredTags: {name: 'namepath', type: false, required: ['name'],}}}}` instead.

Also:
1. Clarifies in more cases where a problem is specific to the mode or not
2. Reports simultaneous invalid name *and* type errors
3. `typdef` now requires `allowEmptyNamepaths: false,` to report empty names (as with other tags)
4. Requires a name for `event` and `external` (and `extends` in jsdoc mode); some tweaking of other tags per docs

(Also does some jsdocUtil refactoring along the way to pull tag meta-data all into one map for easier management and to minimize tag-specific handling blocks within `valid-types`.)

(Since settings can now throw, needed to add a test to a few other rules to cover such cases.)