### PR TITLE
`check-param-names`: add `checkDestructured` option

### DIFF
--- a/.README/rules/check-param-names.md
+++ b/.README/rules/check-param-names.md
@@ -53,10 +53,14 @@ representing future expected or virtual params) to be present without needing
 their presence within the function signature. Other inconsistencies between
 `@param`'s and present function parameters will still be reported.
 
+##### `checkDestructured`
+
+Whether to check destructured properties. Defaults to `true`.
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
-|Options|`allowExtraTrailingParamDocs`, `checkRestProperty`, `checkTypesPattern`|
+|Options|`allowExtraTrailingParamDocs`, `checkDestructured`, `checkRestProperty`, `checkTypesPattern`|
 |Tags|`param`|
 
 <!-- assertions checkParamNames -->

--- a/.README/rules/require-param.md
+++ b/.README/rules/require-param.md
@@ -343,12 +343,16 @@ A value indicating whether getters should be checked. Defaults to `false`.
 
 A value indicating whether getters should be checked. Defaults to `false`.
 
+##### `checkDestructured`
+
+Whether to require destructured properties. Defaults to `true`.
+
 |          |                                                                                                               |
 | -------- | ------------------------------------------------------------------------------------------------------------- |
 | Context  | `ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled |
 | Tags     | `param`                                                                                                       |
 | Aliases  | `arg`, `argument`                                                                                             |
-| Options  | `autoIncrementBase`, `contexts`, `enableFixer`, `enableRootFixer`, `enableRestElementFixer`, `checkRestProperty`, `exemptedBy`, `checkConstructors`, `checkGetters`, `checkSetters`, `checkTypesPattern`, `unnamedRootBase`                                 |
+| Options  | `autoIncrementBase`, `checkDestructured`, `contexts`, `enableFixer`, `enableRootFixer`, `enableRestElementFixer`, `checkRestProperty`, `exemptedBy`, `checkConstructors`, `checkGetters`, `checkSetters`, `checkTypesPattern`, `unnamedRootBase`                                 |
 | Settings | `overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`                               |
 
 <!-- assertions requireParam -->

--- a/README.md
+++ b/README.md
@@ -2103,6 +2103,16 @@ function quux() {
 }
 // Settings: {"jsdoc":{"structuredTags":{"see":{"name":false,"required":["name"]}}}}
 // Message: Cannot add "name" to `require` with the tag's `name` set to `false`
+
+/**
+ * @param root
+ * @param foo
+ */
+function quux ({foo, bar}, baz) {
+
+}
+// Options: [{"checkDestructured":false}]
+// Message: Expected @param names to be "root, baz". Got "root, foo".
 ````
 
 The following patterns are not considered problems:
@@ -2359,6 +2369,15 @@ export class Thing {
     this.foo = new C();
   }
 }
+
+/**
+ * @param foo
+ * @param root
+ */
+function quux (foo, {bar}) {
+
+}
+// Options: [{"checkDestructured":false}]
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -1741,10 +1741,15 @@ representing future expected or virtual params) to be present without needing
 their presence within the function signature. Other inconsistencies between
 `@param`'s and present function parameters will still be reported.
 
+<a name="eslint-plugin-jsdoc-rules-check-param-names-options-3-checkdestructured"></a>
+##### <code>checkDestructured</code>
+
+Whether to check destructured properties. Defaults to `true`.
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
-|Options|`allowExtraTrailingParamDocs`, `checkRestProperty`, `checkTypesPattern`|
+|Options|`allowExtraTrailingParamDocs`, `checkDestructured`, `checkRestProperty`, `checkTypesPattern`|
 |Tags|`param`|
 
 The following patterns are considered problems:
@@ -10656,12 +10661,17 @@ A value indicating whether getters should be checked. Defaults to `false`.
 
 A value indicating whether getters should be checked. Defaults to `false`.
 
+<a name="eslint-plugin-jsdoc-rules-require-param-options-23-checkdestructured-1"></a>
+##### <code>checkDestructured</code>
+
+Whether to require destructured properties. Defaults to `true`.
+
 |          |                                                                                                               |
 | -------- | ------------------------------------------------------------------------------------------------------------- |
 | Context  | `ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled |
 | Tags     | `param`                                                                                                       |
 | Aliases  | `arg`, `argument`                                                                                             |
-| Options  | `autoIncrementBase`, `contexts`, `enableFixer`, `enableRootFixer`, `enableRestElementFixer`, `checkRestProperty`, `exemptedBy`, `checkConstructors`, `checkGetters`, `checkSetters`, `checkTypesPattern`, `unnamedRootBase`                                 |
+| Options  | `autoIncrementBase`, `checkDestructured`, `contexts`, `enableFixer`, `enableRootFixer`, `enableRestElementFixer`, `checkRestProperty`, `exemptedBy`, `checkConstructors`, `checkGetters`, `checkSetters`, `checkTypesPattern`, `unnamedRootBase`                                 |
 | Settings | `overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`                               |
 
 The following patterns are considered problems:

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -876,6 +876,24 @@ export default {
         },
       },
     },
+    {
+      code: `
+          /**
+           * @param root
+           * @param foo
+           */
+          function quux ({foo, bar}, baz) {
+
+          }
+      `,
+      errors: [{
+        line: 4,
+        message: 'Expected @param names to be "root, baz". Got "root, foo".',
+      }],
+      options: [{
+        checkDestructured: false,
+      }],
+    },
   ],
   valid: [
     {
@@ -1246,6 +1264,20 @@ export default {
       }
       `,
       parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+          /**
+           * @param foo
+           * @param root
+           */
+          function quux (foo, {bar}) {
+
+          }
+      `,
+      options: [{
+        checkDestructured: false,
+      }],
     },
   ],
 };


### PR DESCRIPTION
feat(`check-param-names`): add `checkDestructured` option to allow disabling of destructured checking; fixes part of #616

Also improves display of errors when destructured properties are present