### PR TITLE
fix(`check-examples`): disable jsdoc/require-jsdoc

### DIFF
--- a/src/rules/checkExamples.js
+++ b/src/rules/checkExamples.js
@@ -94,6 +94,9 @@ export default iterateJsdoc(({
     // Snippets likely too short to always include import/export info
     'import/unambiguous': 0,
 
+    // The end of a multiline comment would end the comment the example is in.
+    'jsdoc/require-jsdoc': 0,
+
     // Unlikely to have inadvertent debugging within examples
     'no-console': 0,
 


### PR DESCRIPTION
Examples inside JSDoc comments cant comply with the `jsdoc/require-jsdoc` rule, because the closing comment of the nested JSDoc would close the multiline comment that contains the example.