### PR TITLE
docs: add meta docs url for all rules

### DIFF
--- a/src/rules/checkAccess.js
+++ b/src/rules/checkAccess.js
@@ -37,7 +37,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Checks that `@access` tags have a valid value.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-access.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-access',
     },
     type: 'suggestion',
   },

--- a/src/rules/checkAccess.js
+++ b/src/rules/checkAccess.js
@@ -37,6 +37,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Checks that `@access` tags have a valid value.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-access.md',
     },
     type: 'suggestion',
   },

--- a/src/rules/checkAlignment.js
+++ b/src/rules/checkAlignment.js
@@ -50,6 +50,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Reports invalid alignment of JSDoc block asterisks.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-alignment.md',
     },
     fixable: 'code',
     type: 'layout',

--- a/src/rules/checkAlignment.js
+++ b/src/rules/checkAlignment.js
@@ -50,7 +50,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Reports invalid alignment of JSDoc block asterisks.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-alignment.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-alignment',
     },
     fixable: 'code',
     type: 'layout',

--- a/src/rules/checkExamples.js
+++ b/src/rules/checkExamples.js
@@ -293,7 +293,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Ensures that (JavaScript) examples within JSDoc adhere to ESLint rules.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-examples.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-examples',
     },
     schema: [
       {

--- a/src/rules/checkExamples.js
+++ b/src/rules/checkExamples.js
@@ -293,6 +293,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Ensures that (JavaScript) examples within JSDoc adhere to ESLint rules.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-examples.md',
     },
     schema: [
       {

--- a/src/rules/checkIndentation.js
+++ b/src/rules/checkIndentation.js
@@ -42,6 +42,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Reports invalid padding inside JSDoc blocks.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-indentation.md',
     },
     schema: [{
       additionalProperties: false,

--- a/src/rules/checkIndentation.js
+++ b/src/rules/checkIndentation.js
@@ -42,7 +42,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Reports invalid padding inside JSDoc blocks.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-indentation.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-indentation',
     },
     schema: [{
       additionalProperties: false,

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -242,6 +242,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Ensures that parameter names in JSDoc match those in the function declaration.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-param-names.md',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -242,7 +242,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Ensures that parameter names in JSDoc match those in the function declaration.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-param-names.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-param-names',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/checkPropertyNames.js
+++ b/src/rules/checkPropertyNames.js
@@ -102,7 +102,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Ensures that property names in JSDoc are not duplicated on the same block and that nested properties have defined roots.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-property-names.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-property-names',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/checkPropertyNames.js
+++ b/src/rules/checkPropertyNames.js
@@ -102,6 +102,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Ensures that property names in JSDoc are not duplicated on the same block and that nested properties have defined roots.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-property-names.md',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/checkSyntax.js
+++ b/src/rules/checkSyntax.js
@@ -25,7 +25,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Reports against syntax not valid for the mode (e.g., Google Closure Compiler in non-Closure mode).',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-syntax.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-syntax',
     },
     type: 'suggestion',
   },

--- a/src/rules/checkSyntax.js
+++ b/src/rules/checkSyntax.js
@@ -25,6 +25,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Reports against syntax not valid for the mode (e.g., Google Closure Compiler in non-Closure mode).',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-syntax.md',
     },
     type: 'suggestion',
   },

--- a/src/rules/checkTagNames.js
+++ b/src/rules/checkTagNames.js
@@ -78,6 +78,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Reports invalid block tag names.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-tag-names.md',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/checkTagNames.js
+++ b/src/rules/checkTagNames.js
@@ -78,7 +78,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Reports invalid block tag names.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-tag-names.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-tag-names',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/checkTypes.js
+++ b/src/rules/checkTypes.js
@@ -239,7 +239,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Reports invalid types.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-types.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-types',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/checkTypes.js
+++ b/src/rules/checkTypes.js
@@ -239,6 +239,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Reports invalid types.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-types.md',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/checkValues.js
+++ b/src/rules/checkValues.js
@@ -100,6 +100,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'This rule checks the values for a handful of tags: `@version`, `@since`, `@license` and `@author`.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-values.md',
     },
     schema: [
       {

--- a/src/rules/checkValues.js
+++ b/src/rules/checkValues.js
@@ -100,7 +100,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'This rule checks the values for a handful of tags: `@version`, `@since`, `@license` and `@author`.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/check-values.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-values',
     },
     schema: [
       {

--- a/src/rules/emptyTags.js
+++ b/src/rules/emptyTags.js
@@ -50,7 +50,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Expects specific tags to be empty of any content.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/empty-tags.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-empty-tags',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/emptyTags.js
+++ b/src/rules/emptyTags.js
@@ -50,6 +50,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Expects specific tags to be empty of any content.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/empty-tags.md',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/implementsOnClasses.js
+++ b/src/rules/implementsOnClasses.js
@@ -27,6 +27,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Reports an issue with any non-constructor function using `@implements`.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/implements-on-classes.md',
     },
     schema: [
       {

--- a/src/rules/implementsOnClasses.js
+++ b/src/rules/implementsOnClasses.js
@@ -27,7 +27,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Reports an issue with any non-constructor function using `@implements`.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/implements-on-classes.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-implements-on-classes',
     },
     schema: [
       {

--- a/src/rules/matchDescription.js
+++ b/src/rules/matchDescription.js
@@ -83,6 +83,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Enforces a regular expression pattern on descriptions.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/match-description.md',
     },
     schema: [
       {

--- a/src/rules/matchDescription.js
+++ b/src/rules/matchDescription.js
@@ -83,7 +83,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Enforces a regular expression pattern on descriptions.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/match-description.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-match-description',
     },
     schema: [
       {

--- a/src/rules/newlineAfterDescription.js
+++ b/src/rules/newlineAfterDescription.js
@@ -57,7 +57,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Enforces a consistent padding of the block description.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/newline-after-description.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-newline-after-description',
     },
     fixable: 'whitespace',
     schema: [

--- a/src/rules/newlineAfterDescription.js
+++ b/src/rules/newlineAfterDescription.js
@@ -57,6 +57,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Enforces a consistent padding of the block description.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/newline-after-description.md',
     },
     fixable: 'whitespace',
     schema: [

--- a/src/rules/noBadBlocks.js
+++ b/src/rules/noBadBlocks.js
@@ -28,7 +28,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'This rule checks for multi-line-style comments which fail to meet the criteria of a jsdoc block.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/no-bad-blocks.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-no-bad-blocks',
     },
     fixable: 'code',
     type: 'layout',

--- a/src/rules/noBadBlocks.js
+++ b/src/rules/noBadBlocks.js
@@ -28,6 +28,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'This rule checks for multi-line-style comments which fail to meet the criteria of a jsdoc block.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/no-bad-blocks.md',
     },
     fixable: 'code',
     type: 'layout',

--- a/src/rules/noDefaults.js
+++ b/src/rules/noDefaults.js
@@ -31,6 +31,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'This rule reports defaults being used on the relevant portion of `@param` or `@default`.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/no-defaults.md',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/noDefaults.js
+++ b/src/rules/noDefaults.js
@@ -31,7 +31,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'This rule reports defaults being used on the relevant portion of `@param` or `@default`.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/no-defaults.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-no-defaults',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/noTypes.js
+++ b/src/rules/noTypes.js
@@ -21,6 +21,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'This rule reports types being used on `@param` or `@returns`.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/no-types.md',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/noTypes.js
+++ b/src/rules/noTypes.js
@@ -21,7 +21,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'This rule reports types being used on `@param` or `@returns`.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/no-types.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-no-types',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -166,6 +166,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Checks that types in jsdoc comments are defined.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/no-undefined-types.md',
     },
     schema: [
       {

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -166,7 +166,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Checks that types in jsdoc comments are defined.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/no-undefined-types.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-no-undefined-types',
     },
     schema: [
       {

--- a/src/rules/requireDescription.js
+++ b/src/rules/requireDescription.js
@@ -78,6 +78,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that all functions have a description.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-description.md',
     },
     schema: [
       {

--- a/src/rules/requireDescription.js
+++ b/src/rules/requireDescription.js
@@ -78,7 +78,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that all functions have a description.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-description.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-description',
     },
     schema: [
       {

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -201,7 +201,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that block description, explicit `@description`, and `@param`/`@returns` tag descriptions are written in complete sentences.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-description-complete-sentence.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-description-complete-sentence',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -201,6 +201,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that block description, explicit `@description`, and `@param`/`@returns` tag descriptions are written in complete sentences.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-description-complete-sentence.md',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/requireExample.js
+++ b/src/rules/requireExample.js
@@ -47,7 +47,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that all functions have examples.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-example.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-example',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/requireExample.js
+++ b/src/rules/requireExample.js
@@ -47,6 +47,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that all functions have examples.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-example.md',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/requireFileOverview.js
+++ b/src/rules/requireFileOverview.js
@@ -92,7 +92,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Checks that all files have one `@file`, `@fileoverview`, or `@overview` tag at the beginning of the file.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-file-overview.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-file-overview',
     },
     schema: [
       {

--- a/src/rules/requireFileOverview.js
+++ b/src/rules/requireFileOverview.js
@@ -92,6 +92,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Checks that all files have one `@file`, `@fileoverview`, or `@overview` tag at the beginning of the file.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-file-overview.md',
     },
     schema: [
       {

--- a/src/rules/requireHyphenBeforeParamDescription.js
+++ b/src/rules/requireHyphenBeforeParamDescription.js
@@ -76,6 +76,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires a hyphen before the `@param` description.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-hyphen-before-param-description.md',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/requireHyphenBeforeParamDescription.js
+++ b/src/rules/requireHyphenBeforeParamDescription.js
@@ -76,7 +76,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires a hyphen before the `@param` description.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-hyphen-before-param-description.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-hyphen-before-param-description',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -333,7 +333,7 @@ export default {
       category: 'Stylistic Issues',
       description: 'Require JSDoc comments',
       recommended: 'true',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-jsdoc.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-jsdoc',
     },
 
     fixable: 'code',

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -333,7 +333,7 @@ export default {
       category: 'Stylistic Issues',
       description: 'Require JSDoc comments',
       recommended: 'true',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-jsdoc.md',
     },
 
     fixable: 'code',

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -264,7 +264,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that all function parameters are documented.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-param.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-param',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -264,6 +264,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that all function parameters are documented.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-param.md',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/requireParamDescription.js
+++ b/src/rules/requireParamDescription.js
@@ -18,6 +18,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that each `@param` tag has a `description` value.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-param-description.md',
     },
     schema: [
       {

--- a/src/rules/requireParamDescription.js
+++ b/src/rules/requireParamDescription.js
@@ -18,7 +18,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that each `@param` tag has a `description` value.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-param-description.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-param-description',
     },
     schema: [
       {

--- a/src/rules/requireParamName.js
+++ b/src/rules/requireParamName.js
@@ -18,7 +18,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that all function parameters have names.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-param-name.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-param-name',
     },
     schema: [
       {

--- a/src/rules/requireParamName.js
+++ b/src/rules/requireParamName.js
@@ -18,6 +18,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that all function parameters have names.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-param-name.md',
     },
     schema: [
       {

--- a/src/rules/requireParamType.js
+++ b/src/rules/requireParamType.js
@@ -18,7 +18,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that each `@param` tag has a `type` value.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-param-type.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-param-type',
     },
     schema: [
       {

--- a/src/rules/requireParamType.js
+++ b/src/rules/requireParamType.js
@@ -18,6 +18,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that each `@param` tag has a `type` value.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-param-type.md',
     },
     schema: [
       {

--- a/src/rules/requireProperty.js
+++ b/src/rules/requireProperty.js
@@ -37,7 +37,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that all `@typedef` and `@namespace` tags have `@property` when their type is a plain `object`, `Object`, or `PlainObject`.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-property.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-property',
     },
     fixable: 'code',
     type: 'suggestion',

--- a/src/rules/requireProperty.js
+++ b/src/rules/requireProperty.js
@@ -37,6 +37,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that all `@typedef` and `@namespace` tags have `@property` when their type is a plain `object`, `Object`, or `PlainObject`.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-property.md',
     },
     fixable: 'code',
     type: 'suggestion',

--- a/src/rules/requirePropertyDescription.js
+++ b/src/rules/requirePropertyDescription.js
@@ -18,6 +18,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that each `@property` tag has a `description` value.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-property-description.md',
     },
     type: 'suggestion',
   },

--- a/src/rules/requirePropertyDescription.js
+++ b/src/rules/requirePropertyDescription.js
@@ -18,7 +18,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that each `@property` tag has a `description` value.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-property-description.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-property-description',
     },
     type: 'suggestion',
   },

--- a/src/rules/requirePropertyName.js
+++ b/src/rules/requirePropertyName.js
@@ -18,6 +18,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that all function `@property` tags have names.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-property-name.md',
     },
     type: 'suggestion',
   },

--- a/src/rules/requirePropertyName.js
+++ b/src/rules/requirePropertyName.js
@@ -18,7 +18,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that all function `@property` tags have names.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-property-name.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-property-name',
     },
     type: 'suggestion',
   },

--- a/src/rules/requirePropertyType.js
+++ b/src/rules/requirePropertyType.js
@@ -18,6 +18,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that each `@property` tag has a `type` value.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-property-type.md',
     },
     type: 'suggestion',
   },

--- a/src/rules/requirePropertyType.js
+++ b/src/rules/requirePropertyType.js
@@ -18,7 +18,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that each `@property` tag has a `type` value.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-property-type.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-property-type',
     },
     type: 'suggestion',
   },

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -96,7 +96,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires returns are documented.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-returns.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-returns',
     },
     schema: [
       {

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -96,6 +96,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires returns are documented.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-returns.md',
     },
     schema: [
       {

--- a/src/rules/requireReturnsCheck.js
+++ b/src/rules/requireReturnsCheck.js
@@ -65,6 +65,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires a return statement in function body if a `@returns` tag is specified in jsdoc comment.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-returns-check.md',
     },
     type: 'suggestion',
   },

--- a/src/rules/requireReturnsCheck.js
+++ b/src/rules/requireReturnsCheck.js
@@ -65,7 +65,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires a return statement in function body if a `@returns` tag is specified in jsdoc comment.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-returns-check.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-returns-check',
     },
     type: 'suggestion',
   },

--- a/src/rules/requireReturnsDescription.js
+++ b/src/rules/requireReturnsDescription.js
@@ -20,6 +20,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that the `@returns` tag has a `description` value.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-returns-description.md',
     },
     schema: [
       {

--- a/src/rules/requireReturnsDescription.js
+++ b/src/rules/requireReturnsDescription.js
@@ -20,7 +20,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that the `@returns` tag has a `description` value.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-returns-description.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-returns-description',
     },
     schema: [
       {

--- a/src/rules/requireReturnsType.js
+++ b/src/rules/requireReturnsType.js
@@ -14,7 +14,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that `@returns` tag has `type` value.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-returns-type.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-returns-type',
     },
     schema: [
       {

--- a/src/rules/requireReturnsType.js
+++ b/src/rules/requireReturnsType.js
@@ -14,6 +14,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires that `@returns` tag has `type` value.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-returns-type.md',
     },
     schema: [
       {

--- a/src/rules/requireThrows.js
+++ b/src/rules/requireThrows.js
@@ -61,6 +61,9 @@ export default iterateJsdoc(({
 }, {
   contextDefaults: true,
   meta: {
+    docs: {
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-returns.md',
+    },
     schema: [
       {
         additionalProperties: false,

--- a/src/rules/requireThrows.js
+++ b/src/rules/requireThrows.js
@@ -62,7 +62,7 @@ export default iterateJsdoc(({
   contextDefaults: true,
   meta: {
     docs: {
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-returns.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-returns',
     },
     schema: [
       {

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -172,7 +172,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires all types to be valid JSDoc or Closure compiler types without syntax errors.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/valid-types.md',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-valid-types',
     },
     schema: [
       {

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -172,6 +172,7 @@ export default iterateJsdoc(({
   meta: {
     docs: {
       description: 'Requires all types to be valid JSDoc or Closure compiler types without syntax errors.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/valid-types.md',
     },
     schema: [
       {


### PR DESCRIPTION
This URL is used to create links in some various places. For example VS Code makes the rule name clickable in the warnings panel if the URL is available.