### PR TITLE
fix(`no-bad-blocks`): allow TypeScript directive comments

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -490,6 +490,8 @@ selector).
 {"gitdown": "include", "file": "./rules/implements-on-classes.md"}
 {"gitdown": "include", "file": "./rules/match-description.md"}
 {"gitdown": "include", "file": "./rules/newline-after-description.md"}
+{"gitdown": "include", "file": "./rules/no-bad-blocks.md"}
+{"gitdown": "include", "file": "./rules/no-defaults.md"}
 {"gitdown": "include", "file": "./rules/no-types.md"}
 {"gitdown": "include", "file": "./rules/no-undefined-types.md"}
 {"gitdown": "include", "file": "./rules/require-description-complete-sentence.md"}

--- a/.README/rules/no-bad-blocks.md
+++ b/.README/rules/no-bad-blocks.md
@@ -6,9 +6,22 @@ but which appear to be intended as jsdoc blocks due to the presence
 of whitespace followed by whitespace or asterisks, and
 an at-sign (`@`) and some non-whitespace (as with a jsdoc block tag).
 
+#### Options
+
+Takes an optional options object with the following.
+
+##### `ignore`
+
+An array of directives that will not be reported if present at the beginning of
+a multi-comment block and at-sign `/* @`.
+
+Defaults to `['ts-check', 'ts-expect-error', 'ts-ignore', 'ts-nocheck']`
+(some directives [used by TypeScript](https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html#ts-check)).
+
 |||
 |---|---|
 |Context|Everywhere|
+|Options|`ignore`|
 |Tags|N/A|
 
 <!-- assertions noBadBlocks -->

--- a/src/rules/noBadBlocks.js
+++ b/src/rules/noBadBlocks.js
@@ -1,6 +1,6 @@
 import iterateJsdoc from '../iterateJsdoc';
 
-const regexp = /^\/\*(?!\*)[\s*]*(@[\w-]+)/;
+const regexp = /^\/\*(?!\*)[\s*]*@([\w-]+)/;
 
 export default iterateJsdoc(({
   context,
@@ -11,10 +11,10 @@ export default iterateJsdoc(({
   const [
     {
       ignore = [
-        '@ts-check',
-        '@ts-expect-error',
-        '@ts-ignore',
-        '@ts-nocheck',
+        'ts-check',
+        'ts-expect-error',
+        'ts-ignore',
+        'ts-nocheck',
       ],
     } = {},
   ] = context.options;

--- a/src/rules/noBadBlocks.js
+++ b/src/rules/noBadBlocks.js
@@ -1,5 +1,14 @@
 import iterateJsdoc from '../iterateJsdoc';
 
+const regexp = /^\/\*(?!\*)[\s*]*(@[\w-]+)/;
+
+const allowed = new Set([
+  '@ts-check',
+  '@ts-expect-error',
+  '@ts-ignore',
+  '@ts-nocheck',
+]);
+
 export default iterateJsdoc(({
   context,
   sourceCode,
@@ -7,7 +16,12 @@ export default iterateJsdoc(({
   makeReport,
 }) => {
   const nonJsdocNodes = allComments.filter((comment) => {
-    return (/^\/\*(?!\*)[\s*]*@\w/).test(sourceCode.getText(comment));
+    const match = regexp.exec(sourceCode.getText(comment));
+    if (!match) {
+      return false;
+    }
+
+    return !allowed.has(match[1]);
   });
   if (!nonJsdocNodes.length) {
     return;

--- a/src/rules/noBadBlocks.js
+++ b/src/rules/noBadBlocks.js
@@ -2,26 +2,29 @@ import iterateJsdoc from '../iterateJsdoc';
 
 const regexp = /^\/\*(?!\*)[\s*]*(@[\w-]+)/;
 
-const allowed = new Set([
-  '@ts-check',
-  '@ts-expect-error',
-  '@ts-ignore',
-  '@ts-nocheck',
-]);
-
 export default iterateJsdoc(({
   context,
   sourceCode,
   allComments,
   makeReport,
 }) => {
+  const [
+    {
+      ignore = [
+        '@ts-check',
+        '@ts-expect-error',
+        '@ts-ignore',
+        '@ts-nocheck',
+      ],
+    } = {},
+  ] = context.options;
   const nonJsdocNodes = allComments.filter((comment) => {
     const match = regexp.exec(sourceCode.getText(comment));
     if (!match) {
       return false;
     }
 
-    return !allowed.has(match[1]);
+    return !ignore.includes(match[1]);
   });
   if (!nonJsdocNodes.length) {
     return;
@@ -45,6 +48,20 @@ export default iterateJsdoc(({
       url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-no-bad-blocks',
     },
     fixable: 'code',
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          ignore: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
     type: 'layout',
   },
 });

--- a/test/rules/assertions/noBadBlocks.js
+++ b/test/rules/assertions/noBadBlocks.js
@@ -63,6 +63,15 @@ export default {
         },
       },
     },
+    {
+      code: '/* @ts-ignore */',
+      errors: [{
+        line: 1,
+        message: 'Expected JSDoc-like comment to begin with two asterisks.',
+      }],
+      options: [{ignore: []}],
+      output: '/** @ts-ignore */',
+    },
   ],
   valid: [
     {
@@ -118,6 +127,10 @@ export default {
     },
     {
       code: '/* @ts-nocheck */',
+    },
+    {
+      code: '/* @custom */',
+      options: [{ignore: ['@custom']}],
     },
   ],
 };

--- a/test/rules/assertions/noBadBlocks.js
+++ b/test/rules/assertions/noBadBlocks.js
@@ -130,7 +130,7 @@ export default {
     },
     {
       code: '/* @custom */',
-      options: [{ignore: ['@custom']}],
+      options: [{ignore: ['custom']}],
     },
   ],
 };

--- a/test/rules/assertions/noBadBlocks.js
+++ b/test/rules/assertions/noBadBlocks.js
@@ -107,5 +107,17 @@ export default {
            }
       `,
     },
+    {
+      code: '/* @ts-check */',
+    },
+    {
+      code: '/* @ts-expect-error */',
+    },
+    {
+      code: '/* @ts-ignore */',
+    },
+    {
+      code: '/* @ts-nocheck */',
+    },
   ],
 };


### PR DESCRIPTION
This allows TypeScript directive comments in block comments.

Although these comments are mostly written using line comments, block comments must be used in some situations, e.g. when inside JSX tags.