### PR TITLE
fix(`require-param`): check deeply destructured parameters (fixes #569)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12169,6 +12169,20 @@ function quux ({foo: bar}) {
 module.exports = function a(b) {
   console.info(b);
 };
+
+/**
+ * Description.
+ * @param {object} options Options.
+ * @param {FooBar} options.foo A description.
+ */
+function quux ({ foo: { bar } }) {}
+
+/**
+ * Description.
+ * @param {Foo} options Options.
+ * @param {FooBar} options.a A description.
+ */
+function quux ({ foo: { bar } }) {}
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -11595,6 +11595,14 @@ module.exports = class GraphQL {
 	}
 })();
 // Message: Missing JSDoc @param "param" declaration.
+
+/**
+ * Description.
+ * @param {Object} options Options.
+ * @param {Object} options.foo A description.
+ */
+function quux ({ foo: { bar } }) {}
+// Message: Missing JSDoc @param "options.foo.bar" declaration.
 ````
 
 The following patterns are not considered problems:
@@ -12174,13 +12182,6 @@ module.exports = function a(b) {
  * Description.
  * @param {object} options Options.
  * @param {FooBar} options.foo A description.
- */
-function quux ({ foo: { bar } }) {}
-
-/**
- * Description.
- * @param {Foo} options Options.
- * @param {FooBar} options.a A description.
  */
 function quux ({ foo: { bar } }) {}
 ````

--- a/README.md
+++ b/README.md
@@ -2132,6 +2132,31 @@ function quux ({foo, bar}, baz) {
 }
 // Options: [{"checkDestructured":false}]
 // Message: Expected @param names to be "root, baz". Got "root, foo".
+
+/**
+ * Description.
+ * @param {Object} options
+ * @param {FooBar} foo
+ */
+function quux ({ foo: { bar } }) {}
+// Message: Missing @param "options.foo"
+
+/**
+ * Description.
+ * @param {Object} options
+ * @param options.foo
+ */
+function quux ({ foo: { bar } }) {}
+// Message: Missing @param "options.foo.bar"
+
+/**
+ * Description.
+ * @param {object} options Options.
+ * @param {object} options.foo A description.
+ * @param {object} options.foo.bar
+ */
+function foo({ foo: { bar: { baz } }}) {}
+// Message: Missing @param "options.foo.bar.baz"
 ````
 
 The following patterns are not considered problems:
@@ -2408,6 +2433,29 @@ class A {
   {
   }
 }
+
+/**
+ * Description.
+ * @param {Object} options Options.
+ * @param {FooBar} options.foo foo description.
+ */
+function quux ({ foo: { bar }}) {}
+
+/**
+ * Description.
+ * @param {FooBar} options
+ * @param {Object} options.foo
+ */
+function quux ({ foo: { bar } }) {}
+// Options: [{"checkTypesPattern":"FooBar"}]
+
+/**
+ * Description.
+ * @param {Object} options
+ * @param {FooBar} options.foo
+ * @param {FooBar} options.baz
+ */
+function quux ({ foo: { bar }, baz: { cfg } }) {}
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -11628,6 +11628,15 @@ function quux ({ foo: { bar } }) {}
  */
 function quux ({ foo: { bar } }) {}
 // Message: Missing JSDoc @param "options.foo.bar" declaration.
+
+/**
+ * Description.
+ * @param {object} options Options.
+ * @param {object} options.foo A description.
+ * @param {object} options.foo.bar 
+ */
+function foo({ foo: { bar: { baz } }}) {}
+// Message: Missing JSDoc @param "options.foo.bar.baz" declaration.
 ````
 
 The following patterns are not considered problems:

--- a/README.md
+++ b/README.md
@@ -11598,8 +11598,33 @@ module.exports = class GraphQL {
 
 /**
  * Description.
- * @param {Object} options Options.
- * @param {Object} options.foo A description.
+ * @param {Object} options
+ * @param {Object} options.foo
+ */
+function quux ({ foo: { bar } }) {}
+// Message: Missing JSDoc @param "options.foo.bar" declaration.
+
+/**
+ * Description.
+ * @param {FooBar} options
+ * @param {FooBar} options.foo
+ */
+function quux ({ foo: { bar } }) {}
+// Options: [{"checkTypesPattern":"FooBar"}]
+// Message: Missing JSDoc @param "options.foo.bar" declaration.
+
+/**
+ * Description.
+ * @param {Object} options
+ * @param {FooBar} foo
+ */
+function quux ({ foo: { bar } }) {}
+// Message: Missing JSDoc @param "options.foo" declaration.
+
+/**
+ * Description.
+ * @param {Object} options
+ * @param options.foo
  */
 function quux ({ foo: { bar } }) {}
 // Message: Missing JSDoc @param "options.foo.bar" declaration.
@@ -12180,10 +12205,18 @@ module.exports = function a(b) {
 
 /**
  * Description.
- * @param {object} options Options.
- * @param {FooBar} options.foo A description.
+ * @param {Object} options Options.
+ * @param {FooBar} options.foo foo description.
  */
 function quux ({ foo: { bar } }) {}
+
+/**
+ * Description.
+ * @param {FooBar} options
+ * @param {Object} options.foo
+ */
+function quux ({ foo: { bar } }) {}
+// Options: [{"checkTypesPattern":"FooBar"}]
 ````
 
 

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -78,15 +78,29 @@ const validateParameterNames = (
       const actualNames = paramTags.map(([, paramTag]) => {
         return paramTag.name.trim();
       });
+      const actualTypes = paramTags.map(([, paramTag]) => {
+        return paramTag.type;
+      });
 
       const missingProperties = [];
+      const notCheckingNames = [];
 
       expectedNames.forEach((name, idx) => {
-        if (!actualNames.some(utils.comparePaths(name))) {
+        if (notCheckingNames.some((notCheckingName) => {
+          return name.startsWith(notCheckingName);
+        })) {
+          return;
+        }
+        const actualNameIdx = actualNames.findIndex((actualName) => {
+          return utils.comparePaths(name)(actualName);
+        });
+        if (actualNameIdx === -1) {
           if (!checkRestProperty && rests[idx]) {
             return;
           }
           missingProperties.push(name);
+        } else if (actualTypes[actualNameIdx].search(checkTypesRegex) === -1 && actualTypes[actualNameIdx] !== '') {
+          notCheckingNames.push(name);
         }
       });
 

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -179,9 +179,8 @@ export default iterateJsdoc(({
 
         const fullParamName = `${rootName}.${paramName}`;
 
-        // eslint-disable-next-line no-shadow
-        const notCheckingName = jsdocParameterNames.find(({name, type}) => {
-          return utils.comparePaths(name)(fullParamName) && type.search(checkTypesRegex) === -1 && type !== '';
+        const notCheckingName = jsdocParameterNames.find(({name, type: paramType}) => {
+          return utils.comparePaths(name)(fullParamName) && paramType.search(checkTypesRegex) === -1 && paramType !== '';
         });
 
         if (notCheckingName !== undefined) {

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -130,6 +130,7 @@ export default iterateJsdoc(({
       }
 
       const {hasRestElement, hasPropertyRest, rests, names} = functionParameterName[1];
+      const notCheckingNames = [];
       if (!enableRestElementFixer && hasRestElement) {
         return;
       }
@@ -177,6 +178,21 @@ export default iterateJsdoc(({
         }
 
         const fullParamName = `${rootName}.${paramName}`;
+
+        // eslint-disable-next-line no-shadow
+        const notCheckingName = jsdocParameterNames.find(({name, type}) => {
+          return utils.comparePaths(name)(fullParamName) && type.search(checkTypesRegex) === -1 && type !== '';
+        });
+
+        if (notCheckingName !== undefined) {
+          notCheckingNames.push(notCheckingName.name);
+        }
+
+        if (notCheckingNames.find((name) => {
+          return new RegExp('^' + name).test(fullParamName);
+        })) {
+          return;
+        }
 
         if (jsdocParameterNames && !jsdocParameterNames.find(({name}) => {
           return utils.comparePaths(name)(fullParamName);

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -188,7 +188,7 @@ export default iterateJsdoc(({
         }
 
         if (notCheckingNames.find((name) => {
-          return new RegExp('^' + name).test(fullParamName);
+          return fullParamName.startsWith(name);
         })) {
           return;
         }

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -894,6 +894,55 @@ export default {
         checkDestructured: false,
       }],
     },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {Object} options
+       * @param {FooBar} foo
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+      errors: [
+        {
+          message: 'Missing @param "options.foo"',
+        },
+        {
+          message: 'Missing @param "options.foo.bar"',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {Object} options
+       * @param options.foo
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+      errors: [
+        {
+          message: 'Missing @param "options.foo.bar"',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {object} options Options.
+       * @param {object} options.foo A description.
+       * @param {object} options.foo.bar
+       */
+      function foo({ foo: { bar: { baz } }}) {}
+      `,
+      errors: [
+        {
+          message: 'Missing @param "options.foo.bar.baz"',
+        },
+      ],
+    },
   ],
   valid: [
     {
@@ -1296,6 +1345,42 @@ export default {
       parserOptions: {
         sourceType: 'module',
       },
+    },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {Object} options Options.
+       * @param {FooBar} options.foo foo description.
+       */
+      function quux ({ foo: { bar }}) {}
+      `,
+    },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {FooBar} options
+       * @param {Object} options.foo
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+      options: [
+        {
+          checkTypesPattern: 'FooBar',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {Object} options
+       * @param {FooBar} options.foo
+       * @param {FooBar} options.baz
+       */
+      function quux ({ foo: { bar }, baz: { cfg } }) {}
+      `,
     },
   ],
 };

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -1991,8 +1991,8 @@ export default {
       code: `
       /**
        * Description.
-       * @param {Object} options Options.
-       * @param {Object} options.foo A description.
+       * @param {Object} options
+       * @param {Object} options.foo
        */
       function quux ({ foo: { bar } }) {}
       `,
@@ -2004,8 +2004,89 @@ export default {
       output: `
       /**
        * Description.
-       * @param {Object} options Options.
-       * @param {Object} options.foo A description.
+       * @param {Object} options
+       * @param {Object} options.foo
+       * @param options.foo.bar
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+    },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {FooBar} options
+       * @param {FooBar} options.foo
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "options.foo.bar" declaration.',
+        },
+      ],
+      options: [
+        {
+          checkTypesPattern: 'FooBar',
+        },
+      ],
+      output: `
+      /**
+       * Description.
+       * @param {FooBar} options
+       * @param {FooBar} options.foo
+       * @param options.foo.bar
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+    },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {Object} options
+       * @param {FooBar} foo
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "options.foo" declaration.',
+        },
+        {
+          message: 'Missing JSDoc @param "options.foo.bar" declaration.',
+        },
+      ],
+      output: `
+      /**
+       * Description.
+       * @param {Object} options
+       * @param options.foo
+       * @param {FooBar} foo
+       * @param options.foo.bar
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+    },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {Object} options
+       * @param options.foo
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "options.foo.bar" declaration.',
+        },
+      ],
+      output: `
+      /**
+       * Description.
+       * @param {Object} options
+       * @param options.foo
        * @param options.foo.bar
        */
       function quux ({ foo: { bar } }) {}
@@ -2882,11 +2963,26 @@ export default {
       code: `
       /**
        * Description.
-       * @param {object} options Options.
-       * @param {FooBar} options.foo A description.
+       * @param {Object} options Options.
+       * @param {FooBar} options.foo foo description.
        */
       function quux ({ foo: { bar } }) {}
       `,
+    },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {FooBar} options
+       * @param {Object} options.foo
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+      options: [
+        {
+          checkTypesPattern: 'FooBar',
+        },
+      ],
     },
   ],
 };

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -2092,6 +2092,32 @@ export default {
       function quux ({ foo: { bar } }) {}
       `,
     },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {object} options Options.
+       * @param {object} options.foo A description.
+       * @param {object} options.foo.bar 
+       */
+      function foo({ foo: { bar: { baz } }}) {}
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "options.foo.bar.baz" declaration.',
+        },
+      ],
+      output: `
+      /**
+       * Description.
+       * @param {object} options Options.
+       * @param {object} options.foo A description.
+       * @param {object} options.foo.bar
+       * @param options.foo.bar.baz
+       */
+      function foo({ foo: { bar: { baz } }}) {}
+      `,
+    },
   ],
   valid: [
     {

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -1987,6 +1987,30 @@ export default {
       `,
       /* eslint-enable no-tabs */
     },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {Object} options Options.
+       * @param {Object} options.foo A description.
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "options.foo.bar" declaration.',
+        },
+      ],
+      output: `
+      /**
+       * Description.
+       * @param {Object} options Options.
+       * @param {Object} options.foo A description.
+       * @param options.foo.bar
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+    },
   ],
   valid: [
     {
@@ -2860,16 +2884,6 @@ export default {
        * Description.
        * @param {object} options Options.
        * @param {FooBar} options.foo A description.
-       */
-      function quux ({ foo: { bar } }) {}
-      `,
-    },
-    {
-      code: `
-      /**
-       * Description.
-       * @param {Foo} options Options.
-       * @param {FooBar} options.a A description.
        */
       function quux ({ foo: { bar } }) {}
       `,

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -2859,9 +2859,9 @@ export default {
       /**
        * Description.
        * @param {object} options Options.
-       * @param {FooBar} options.a A description.
+       * @param {FooBar} options.foo A description.
        */
-      function foo({ a: { b } }) {}
+      function quux ({ foo: { bar } }) {}
       `,
     },
     {
@@ -2871,7 +2871,7 @@ export default {
        * @param {Foo} options Options.
        * @param {FooBar} options.a A description.
        */
-      function foo({ a: { b } }) {}
+      function quux ({ foo: { bar } }) {}
       `,
     },
   ],

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -2854,5 +2854,25 @@ export default {
       };
       `,
     },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {object} options Options.
+       * @param {FooBar} options.a A description.
+       */
+      function foo({ a: { b } }) {}
+      `,
+    },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {Foo} options Options.
+       * @param {FooBar} options.a A description.
+       */
+      function foo({ a: { b } }) {}
+      `,
+    },
   ],
 };


### PR DESCRIPTION
fixes [#569]([https://github.com/gajus/eslint-plugin-jsdoc/issues/569](https://github.com/gajus/eslint-plugin-jsdoc/issues/569))

Check the type of destructured parameters in the require-param rule.