### PR TITLE
Fixed typo in check-types.md

### DIFF
--- a/.README/rules/check-types.md
+++ b/.README/rules/check-types.md
@@ -112,7 +112,7 @@ identity.)
 type name | `typeof` | check-types | testcase
 --|--|--|--
 **Array** | object | **Array** | `([]) instanceof Array` -> `true`
-**Function** | function | **function** | `(function f () {}) instanceof Function` -> `true`
+**Function** | function | **Function** | `(function f () {}) instanceof Function` -> `true`
 **Date** | object | **Date** | `(new Date()) instanceof Date` -> `true`
 **RegExp** | object | **RegExp** | `(new RegExp(/.+/)) instanceof RegExp` -> `true`
 Object | **object** | **object** | `({}) instanceof Object` -> `true` but `Object.create(null) instanceof Object` -> `false`

--- a/README.md
+++ b/README.md
@@ -3583,7 +3583,7 @@ identity.)
 type name | `typeof` | check-types | testcase
 --|--|--|--
 **Array** | object | **Array** | `([]) instanceof Array` -> `true`
-**Function** | function | **function** | `(function f () {}) instanceof Function` -> `true`
+**Function** | function | **Function** | `(function f () {}) instanceof Function` -> `true`
 **Date** | object | **Date** | `(new Date()) instanceof Date` -> `true`
 **RegExp** | object | **RegExp** | `(new RegExp(/.+/)) instanceof RegExp` -> `true`
 Object | **object** | **object** | `({}) instanceof Object` -> `true` but `Object.create(null) instanceof Object` -> `false`


### PR DESCRIPTION
It was a bad typo since the whole rule is about checking case.