### PR TITLE
Add lines alignment rule

### DIFF
--- a/.README/rules/check-lines-alignment.md
+++ b/.README/rules/check-lines-alignment.md
@@ -1,6 +1,7 @@
 ### `check-alignment`
 
-Reports invalid alignment of JSDoc block lines.
+Reports invalid alignment of JSDoc block lines. This is a
+[standard recommended to WordPress code](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/#aligning-comments), for example.
 
 |||
 |---|---|

--- a/.README/rules/check-lines-alignment.md
+++ b/.README/rules/check-lines-alignment.md
@@ -1,0 +1,51 @@
+### `check-alignment`
+
+Reports invalid alignment of JSDoc block lines.
+
+|||
+|---|---|
+|Context|everywhere|
+|Tags|`param`, `arg`, `argument`, `property`, `prop`|
+
+The following patterns are considered problems:
+
+````js
+/**
+ * Function description.
+ *
+ * @param {string} lorem Description.
+ * @param {int} sit Description multi words.
+ */
+const fn = ( lorem, sit ) => {}
+// Message: Expected JSDoc block lines to be aligned.
+
+/**
+ * My object.
+ *
+ * @typedef {Object} MyObject
+ *
+ * @property {string} lorem Description.
+ * @property {int} sit Description multi words.
+ */
+// Message: Expected JSDoc block lines to be aligned.
+
+The following patterns are not considered problems:
+
+````js
+/**
+ * Function description.
+ *
+ * @param {string} lorem Description.
+ * @param {int}    sit   Description multi words.
+ */
+const fn = ( lorem, sit ) => {}
+
+/**
+ * My object.
+ *
+ * @typedef {Object} MyObject
+ *
+ * @property {string} lorem Description.
+ * @property {int}    sit   Description multi words.
+ */
+````

--- a/.README/rules/check-lines-alignment.md
+++ b/.README/rules/check-lines-alignment.md
@@ -3,9 +3,17 @@
 Reports invalid alignment of JSDoc block lines. This is a
 [standard recommended to WordPress code](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/#aligning-comments), for example.
 
+#### Options
+
+This rule allows one optional string argument. If it is `"always"` then a
+problem is raised when the lines are not aligned. If it is `"never"` then
+a problem should be raised when there is more than one space between the
+lines parts. Only the non-default `"always"` is implemented for now.
+
 |||
 |---|---|
 |Context|everywhere|
+|Options|(a string matching `"always"|"never"`)|
 |Tags|`param`, `arg`, `argument`, `property`, `prop`|
 
 The following patterns are considered problems:
@@ -18,6 +26,7 @@ The following patterns are considered problems:
  * @param {int} sit Description multi words.
  */
 const fn = ( lorem, sit ) => {}
+// Options: ["always"]
 // Message: Expected JSDoc block lines to be aligned.
 
 /**
@@ -28,6 +37,7 @@ const fn = ( lorem, sit ) => {}
  * @property {string} lorem Description.
  * @property {int} sit Description multi words.
  */
+// Options: ["always"]
 // Message: Expected JSDoc block lines to be aligned.
 
 The following patterns are not considered problems:
@@ -40,6 +50,7 @@ The following patterns are not considered problems:
  * @param {int}    sit   Description multi words.
  */
 const fn = ( lorem, sit ) => {}
+// Options: ["always"]
 
 /**
  * My object.
@@ -49,4 +60,5 @@ const fn = ( lorem, sit ) => {}
  * @property {string} lorem Description.
  * @property {int}    sit   Description multi words.
  */
+// Options: ["always"]
 ````

--- a/.README/rules/check-lines-alignment.md
+++ b/.README/rules/check-lines-alignment.md
@@ -1,4 +1,4 @@
-### `check-alignment`
+### `check-lines-alignment`
 
 Reports invalid alignment of JSDoc block lines. This is a
 [standard recommended to WordPress code](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/#aligning-comments), for example.

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ export default {
         'jsdoc/check-alignment': 'warn',
         'jsdoc/check-examples': 'off',
         'jsdoc/check-indentation': 'off',
-        'jsdoc/check-lines-alignment': 'warn',
+        'jsdoc/check-lines-alignment': 'off',
         'jsdoc/check-param-names': 'warn',
         'jsdoc/check-property-names': 'warn',
         'jsdoc/check-syntax': 'off',

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import checkAccess from './rules/checkAccess';
 import checkAlignment from './rules/checkAlignment';
 import checkExamples from './rules/checkExamples';
 import checkIndentation from './rules/checkIndentation';
+import checkLinesAlignment from './rules/checkLinesAlignment';
 import checkParamNames from './rules/checkParamNames';
 import checkPropertyNames from './rules/checkPropertyNames';
 import checkSyntax from './rules/checkSyntax';
@@ -47,6 +48,7 @@ export default {
         'jsdoc/check-alignment': 'warn',
         'jsdoc/check-examples': 'off',
         'jsdoc/check-indentation': 'off',
+        'jsdoc/check-lines-alignment': 'warn',
         'jsdoc/check-param-names': 'warn',
         'jsdoc/check-property-names': 'warn',
         'jsdoc/check-syntax': 'off',
@@ -88,6 +90,7 @@ export default {
     'check-alignment': checkAlignment,
     'check-examples': checkExamples,
     'check-indentation': checkIndentation,
+    'check-lines-alignment': checkLinesAlignment,
     'check-param-names': checkParamNames,
     'check-property-names': checkPropertyNames,
     'check-syntax': checkSyntax,

--- a/src/rules/checkLinesAlignment.js
+++ b/src/rules/checkLinesAlignment.js
@@ -175,7 +175,6 @@ const checkCommentPerTag = (comment, tag, tagIndentation, report) => {
         lineRegExp,
         tagIndentation,
       ),
-      comment.loc,
     );
   }
 };

--- a/src/rules/checkLinesAlignment.js
+++ b/src/rules/checkLinesAlignment.js
@@ -45,13 +45,12 @@ const getFullDescription = (lineString) => {
 /**
  * Get the expected positions for each part.
  *
- * @param {Array[]} partsMatrix    Parts matrix.
- * @param {int[]}   partsMaxLength Max length of each part.
- * @param {int}     indentLevel    JSDoc indent level.
+ * @param {int[]} partsMaxLength Max length of each part.
+ * @param {int}   indentLevel    JSDoc indent level.
  *
  * @returns {int[]} Expected position for each part.
  */
-const getExpectedPositions = (partsMatrix, partsMaxLength, indentLevel) => {
+const getExpectedPositions = (partsMaxLength, indentLevel) => {
   // eslint-disable-next-line unicorn/no-reduce
   return partsMaxLength.reduce(
     (acc, cur, index) => {
@@ -164,11 +163,7 @@ const checkCommentPerTag = (comment, tag, tagIndentation, report) => {
     );
   });
 
-  const expectedPositions = getExpectedPositions(
-    partsMatrix,
-    partsMaxLength,
-    tagIndentation.length,
-  );
+  const expectedPositions = getExpectedPositions(partsMaxLength, tagIndentation.length);
 
   if (isNotAligned(expectedPositions, partsMatrix)) {
     report(

--- a/src/rules/checkLinesAlignment.js
+++ b/src/rules/checkLinesAlignment.js
@@ -174,8 +174,17 @@ const checkCommentPerTag = (comment, tag, tagIndentation, report) => {
 export default iterateJsdoc(({
   jsdocNode,
   report,
+  context,
   indent,
 }) => {
+  if (context.options[0] === 'never') {
+    throw new Error('The `never` option is not yet implemented for this rule.');
+  }
+
+  if (context.options[0] !== 'always') {
+    return;
+  }
+
   // `indent` is whitespace from line 1 (`/**`), so slice and account for "/".
   const tagIndentation = indent + ' ';
 
@@ -190,6 +199,12 @@ export default iterateJsdoc(({
       url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-lines-alignment',
     },
     fixable: 'whitespace',
+    schema: [
+      {
+        enum: ['always', 'never'],
+        type: 'string',
+      },
+    ],
     type: 'layout',
   },
 });

--- a/src/rules/checkLinesAlignment.js
+++ b/src/rules/checkLinesAlignment.js
@@ -10,6 +10,8 @@ import iterateJsdoc from '../iterateJsdoc';
  * @param {RegExp}   regexp   Regular expression to run.
  * @param {Function} callback Function to be called each iteration.
  * @param {int}      limit    Limit of matches that we want to exec.
+ *
+ * @todo [engine:node@>=12]: Remove function and use `String.prototype.matchAll` instead.
  */
 const matchAll = (string, regexp, callback, limit) => {
   let result;

--- a/src/rules/checkLinesAlignment.js
+++ b/src/rules/checkLinesAlignment.js
@@ -4,16 +4,6 @@ import {
 import iterateJsdoc from '../iterateJsdoc';
 
 /**
- * Create a sequence of chars with a specific size.
- *
- * @param {string} char   The char.
- * @param {int}    length The length.
- */
-const createSequence = (char, length) => {
-  return new Array(length + 1).join(char);
-};
-
-/**
  * Aux method until we consider the dev envs support `String.prototype.matchAll` (Node 12+).
  *
  * @param {string}   string   String that will be checked.
@@ -99,7 +89,7 @@ const createFixer = (comment, expectedPositions, partsMatrix, lineRegExp, tagInd
       // eslint-disable-next-line unicorn/no-reduce
       return partsMatrix[lineIndex++].reduce(
         (acc, {string}, index) => {
-          const spacings = createSequence(' ', expectedPositions[index] - acc.length);
+          const spacings = ''.padStart(expectedPositions[index] - acc.length, ' ');
 
           return acc + (index === 0 ? tagIndentation : spacings) + string;
         },

--- a/src/rules/checkLinesAlignment.js
+++ b/src/rules/checkLinesAlignment.js
@@ -178,7 +178,9 @@ export default iterateJsdoc(({
   indent,
 }) => {
   if (context.options[0] === 'never') {
-    throw new Error('The `never` option is not yet implemented for this rule.');
+    report('The `never` option is not yet implemented for this rule.');
+
+    return;
   }
 
   if (context.options[0] !== 'always') {

--- a/src/rules/checkLinesAlignment.js
+++ b/src/rules/checkLinesAlignment.js
@@ -91,7 +91,7 @@ const createFixer = (comment, expectedPositions, partsMatrix, lineRegExp, tagInd
       // eslint-disable-next-line unicorn/no-reduce
       return partsMatrix[lineIndex++].reduce(
         (acc, {string}, index) => {
-          const spacings = ''.padStart(expectedPositions[index] - acc.length, ' ');
+          const spacings = ' '.repeat(expectedPositions[index] - acc.length);
 
           return acc + (index === 0 ? tagIndentation : spacings) + string;
         },

--- a/src/rules/checkLinesAlignment.js
+++ b/src/rules/checkLinesAlignment.js
@@ -1,0 +1,209 @@
+import {
+  set,
+} from 'lodash';
+import iterateJsdoc from '../iterateJsdoc';
+
+/**
+ * Create a sequence of chars with a specific size.
+ *
+ * @param {string} char   The char.
+ * @param {int}    length The length.
+ */
+const createSequence = (char, length) => {
+  return new Array(length + 1).join(char);
+};
+
+/**
+ * Aux method until we consider the dev envs support `String.prototype.matchAll` (Node 12+).
+ *
+ * @param {string}   string   String that will be checked.
+ * @param {RegExp}   regexp   Regular expression to run.
+ * @param {Function} callback Function to be called each iteration.
+ * @param {int}      limit    Limit of matches that we want to exec.
+ */
+const matchAll = (string, regexp, callback, limit) => {
+  let result;
+  let index = 0;
+
+  while ((result = regexp.exec(string)) && index <= limit - 1) {
+    // eslint-disable-next-line promise/prefer-await-to-callbacks
+    callback(result, index++);
+  }
+};
+
+/**
+ * Get the full description from a line.
+ *
+ * @param {string} lineString The line string.
+ *
+ * @returns {string} The full description.
+ */
+const getFullDescription = (lineString) => {
+  return /(?:\S+\s+){4}(.*)/.exec(lineString)[1];
+};
+
+/**
+ * Get the expected positions for each part.
+ *
+ * @param {Array[]} partsMatrix    Parts matrix.
+ * @param {int[]}   partsMaxLength Max length of each part.
+ * @param {int}     indentLevel    JSDoc indent level.
+ *
+ * @returns {int[]} Expected position for each part.
+ */
+const getExpectedPositions = (partsMatrix, partsMaxLength, indentLevel) => {
+  // eslint-disable-next-line unicorn/no-reduce
+  return partsMaxLength.reduce(
+    (acc, cur, index) => {
+      return [...acc, cur + acc[index] + 1];
+    },
+    [indentLevel],
+  );
+};
+
+/**
+ * Check is not aligned.
+ *
+ * @param {int[]}   expectedPositions Expected position for each part.
+ * @param {Array[]} partsMatrix       Parts matrix.
+ *
+ * @returns {boolean}
+ */
+const isNotAligned = (expectedPositions, partsMatrix) => {
+  return partsMatrix.some((line) => {
+    return line.some(
+      ({position}, partIndex) => {
+        return position !== expectedPositions[partIndex];
+      },
+    );
+  });
+};
+
+/**
+ * Fix function creator for the report. It creates a function which fix
+ * the JSDoc with the correct alignment.
+ *
+ * @param {object}  comment           Comment node.
+ * @param {int[]}   expectedPositions Array with the expected positions.
+ * @param {Array[]} partsMatrix       Parts matrix.
+ * @param {RegExp}  lineRegExp        Line regular expression.
+ * @param {string}  tagIndentation    Tag indentation.
+ *
+ * @returns {Function} Function which fixes the JSDoc alignment.
+ */
+const createFixer = (comment, expectedPositions, partsMatrix, lineRegExp, tagIndentation) => {
+  return (fixer) => {
+    let lineIndex = 0;
+
+    // Replace every line with the correct spacings.
+    const fixed = comment.value.replace(lineRegExp, () => {
+      // eslint-disable-next-line unicorn/no-reduce
+      return partsMatrix[lineIndex++].reduce(
+        (acc, {string}, index) => {
+          const spacings = createSequence(' ', expectedPositions[index] - acc.length);
+
+          return acc + (index === 0 ? tagIndentation : spacings) + string;
+        },
+        '',
+      );
+    });
+
+    return fixer.replaceText(comment, '/*' + fixed + '*/');
+  };
+};
+
+/**
+ * Check comment per tag.
+ *
+ * @param {object}   comment        Comment node.
+ * @param {string}   tag            Tag string.
+ * @param {string}   tagIndentation Tag indentation.
+ * @param {Function} report         Report function.
+ */
+const checkCommentPerTag = (comment, tag, tagIndentation, report) => {
+  const lineRegExp = new RegExp(`.*@${tag}[\\s].*`, 'gm');
+  const lines = comment.value.match(lineRegExp);
+
+  if (!lines) {
+    return;
+  }
+
+  /**
+   * A matrix containing the current position and the string of each part for each line.
+   * 0 - Asterisk.
+   * 1 - Tag.
+   * 2 - Type.
+   * 3 - Variable name.
+   * 4 - Description (Optional).
+   */
+  const partsMatrix = [];
+
+  /**
+   * The max length of each part, comparing all the lines.
+   */
+  const partsMaxLength = [];
+
+  // Loop (lines x parts) to populate partsMatrix and partsMaxLength.
+  lines.forEach((lineString, lineIndex) => {
+    // All line parts until the first word of the description (if description exists).
+    matchAll(
+      lineString,
+      /\S+/g,
+      ({0: match, index: position}, partIndex) => {
+        set(partsMatrix, [lineIndex, partIndex], {
+          position,
+          string: partIndex === 4 ? getFullDescription(lineString) : match,
+        });
+
+        const partLength = match.length;
+        const maxLength = partsMaxLength[partIndex];
+
+        partsMaxLength[partIndex] = maxLength > partLength ? maxLength : partLength;
+      },
+      5,
+    );
+  });
+
+  const expectedPositions = getExpectedPositions(
+    partsMatrix,
+    partsMaxLength,
+    tagIndentation.length,
+  );
+
+  if (isNotAligned(expectedPositions, partsMatrix)) {
+    report(
+      'Expected JSDoc block lines to be aligned.',
+      createFixer(
+        comment,
+        expectedPositions,
+        partsMatrix,
+        lineRegExp,
+        tagIndentation,
+      ),
+      comment.loc,
+    );
+  }
+};
+
+export default iterateJsdoc(({
+  jsdocNode,
+  report,
+  indent,
+}) => {
+  // `indent` is whitespace from line 1 (`/**`), so slice and account for "/".
+  const tagIndentation = indent + ' ';
+
+  ['param', 'arg', 'argument', 'property', 'prop'].forEach((tag) => {
+    checkCommentPerTag(jsdocNode, tag, tagIndentation, report);
+  });
+}, {
+  iterateAllJsdocs: true,
+  meta: {
+    docs: {
+      description: 'Reports invalid alignment of JSDoc block lines.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-check-lines-alignment',
+    },
+    fixable: 'whitespace',
+    type: 'layout',
+  },
+});

--- a/test/rules/assertions/checkLinesAlignment.js
+++ b/test/rules/assertions/checkLinesAlignment.js
@@ -1,0 +1,461 @@
+export default {
+  invalid: [
+    {
+      code: `
+        /**
+         * Function description.
+         *
+         * @param {string} lorem Description.
+         * @param {int} sit Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      output: `
+        /**
+         * Function description.
+         *
+         * @param {string} lorem Description.
+         * @param {int}    sit   Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+    },
+    {
+      code: `
+        /**
+         * Function description.
+         *
+         * @param {string} lorem - Description.
+         * @param {int} sit - Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      output: `
+        /**
+         * Function description.
+         *
+         * @param {string} lorem - Description.
+         * @param {int}    sit   - Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+    },
+    {
+      code: `
+        /**
+         * Function description.
+         *
+         * @param {string} lorem Description.
+         * @param {int} sit Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      output: `
+        /**
+         * Function description.
+         *
+         * @param {string} lorem Description.
+         * @param {int}    sit   Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+    },
+    {
+      code: `
+        /**
+         * Function description.
+         *
+         * @param  {string} lorem Description.
+         *  @param {int}    sit   Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      output: `
+        /**
+         * Function description.
+         *
+         * @param {string} lorem Description.
+         * @param {int}    sit   Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+    },
+    {
+      code: `
+        /**
+         * Function description.
+         *
+         * @param  {string} lorem Description.
+          * @param {int}    sit   Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      output: `
+        /**
+         * Function description.
+         *
+         * @param {string} lorem Description.
+         * @param {int}    sit   Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+    },
+    {
+      code: `
+        /**
+         * Function description.
+         *
+         * @param  {string} lorem Description.
+         * @param  {int}    sit   Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      output: `
+        /**
+         * Function description.
+         *
+         * @param {string} lorem Description.
+         * @param {int}    sit   Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+    },
+    {
+      code: `
+        /**
+         * Function description.
+         *
+         * @param {string} lorem Description.
+         * @param {int} sit Description multi words.
+         */
+        function fn( lorem, sit ) {}
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      output: `
+        /**
+         * Function description.
+         *
+         * @param {string} lorem Description.
+         * @param {int}    sit   Description multi words.
+         */
+        function fn( lorem, sit ) {}
+      `,
+    },
+    {
+      code: `
+        const object = {
+          /**
+           * Function description.
+           *
+           * @param {string} lorem Description.
+           * @param {int} sit Description multi words.
+           */
+          fn( lorem, sit ) {}
+        }
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      output: `
+        const object = {
+          /**
+           * Function description.
+           *
+           * @param {string} lorem Description.
+           * @param {int}    sit   Description multi words.
+           */
+          fn( lorem, sit ) {}
+        }
+      `,
+    },
+    {
+      code: `
+        class ClassName {
+          /**
+           * Function description.
+           *
+           * @param {string} lorem Description.
+           * @param {int} sit Description multi words.
+           */
+          fn( lorem, sit ) {}
+        }
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      output: `
+        class ClassName {
+          /**
+           * Function description.
+           *
+           * @param {string} lorem Description.
+           * @param {int}    sit   Description multi words.
+           */
+          fn( lorem, sit ) {}
+        }
+      `,
+    },
+    {
+      code: `
+        /**
+         * Function description.
+         *
+         * @arg {string} lorem Description.
+         * @arg {int} sit Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      output: `
+        /**
+         * Function description.
+         *
+         * @arg {string} lorem Description.
+         * @arg {int}    sit   Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+    },
+    {
+      code: `
+        /**
+         * @namespace
+         * @property {object} defaults Description.
+         * @property {int} defaults.lorem Description multi words.
+         */
+        const config = {
+            defaults: {
+                lorem: 1
+            }
+        }
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      output: `
+        /**
+         * @namespace
+         * @property {object} defaults       Description.
+         * @property {int}    defaults.lorem Description multi words.
+         */
+        const config = {
+            defaults: {
+                lorem: 1
+            }
+        }
+      `,
+    },
+    {
+      code: `
+        /**
+         * My object.
+         *
+         * @typedef {Object} MyObject
+         *
+         * @property {string} lorem Description.
+         * @property {int} sit Description multi words.
+         */
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      output: `
+        /**
+         * My object.
+         *
+         * @typedef {Object} MyObject
+         *
+         * @property {string} lorem Description.
+         * @property {int}    sit   Description multi words.
+         */
+      `,
+    },
+  ],
+  valid: [
+    {
+      code: `
+        /**
+         * Function description.
+         *
+         * @param {string} lorem Description.
+         * @param {int}    sit   Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+    },
+    {
+      code: `
+        /**
+         * Function description.
+         *
+         * @param {string} lorem - Description.
+         * @param {int}    sit   - Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+    },
+    {
+      code: `
+        /**
+         * @param {string} lorem Description.
+         * @param {int}    sit
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+    },
+    {
+      code: `
+        /**
+         * @param {int}    sit
+         * @param {string} lorem Description.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+    },
+    {
+      code: `
+        /**
+         * No params.
+         */
+        const fn = () => {}
+      `,
+    },
+    {
+      code: `
+        const fn = ( lorem, sit ) => {}
+      `,
+    },
+    {
+      code: `
+        /**
+         * Function description.
+         *
+         * @param {string} lorem Description.
+         * @param {int}    sit   Description multi words.
+         */
+        function fn( lorem, sit ) {}
+      `,
+    },
+    {
+      code: `
+        const object = {
+          /**
+           * Function description.
+           *
+           * @param {string} lorem Description.
+           * @param {int}    sit   Description multi words.
+           */
+          fn( lorem, sit ) {},
+        }
+      `,
+    },
+    {
+      code: `
+        class ClassName {
+          /**
+           * Function description.
+           *
+           * @param {string} lorem Description.
+           * @param {int}    sit   Description multi words.
+           */
+          fn( lorem, sit ) {}
+        }
+      `,
+    },
+    {
+      code: `
+        /**
+         * Function description.
+         *
+         * @arg {string} lorem Description.
+         * @arg {int}    sit   Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+    },
+    {
+      code: `
+        /**
+         * @namespace
+         * @property {object} defaults       Description.
+         * @property {int}    defaults.lorem Description multi words.
+         */
+        const config = {
+            defaults: {
+                lorem: 1
+            }
+        }
+      `,
+    },
+    {
+      code: `
+        /**
+         * My object.
+         *
+         * @typedef {Object} MyObject
+         *
+         * @property {string} lorem Description.
+         * @property {int}    sit   Description multi words.
+         */
+      `,
+    },
+  ],
+};

--- a/test/rules/assertions/checkLinesAlignment.js
+++ b/test/rules/assertions/checkLinesAlignment.js
@@ -16,6 +16,9 @@ export default {
           type: 'Block',
         },
       ],
+      options: [
+        'always',
+      ],
       output: `
         /**
          * Function description.
@@ -41,6 +44,9 @@ export default {
           message: 'Expected JSDoc block lines to be aligned.',
           type: 'Block',
         },
+      ],
+      options: [
+        'always',
       ],
       output: `
         /**
@@ -68,6 +74,9 @@ export default {
           type: 'Block',
         },
       ],
+      options: [
+        'always',
+      ],
       output: `
         /**
          * Function description.
@@ -93,6 +102,9 @@ export default {
           message: 'Expected JSDoc block lines to be aligned.',
           type: 'Block',
         },
+      ],
+      options: [
+        'always',
       ],
       output: `
         /**
@@ -120,6 +132,9 @@ export default {
           type: 'Block',
         },
       ],
+      options: [
+        'always',
+      ],
       output: `
         /**
          * Function description.
@@ -146,6 +161,9 @@ export default {
           type: 'Block',
         },
       ],
+      options: [
+        'always',
+      ],
       output: `
         /**
          * Function description.
@@ -171,6 +189,9 @@ export default {
           message: 'Expected JSDoc block lines to be aligned.',
           type: 'Block',
         },
+      ],
+      options: [
+        'always',
       ],
       output: `
         /**
@@ -199,6 +220,9 @@ export default {
           message: 'Expected JSDoc block lines to be aligned.',
           type: 'Block',
         },
+      ],
+      options: [
+        'always',
       ],
       output: `
         const object = {
@@ -229,6 +253,9 @@ export default {
           message: 'Expected JSDoc block lines to be aligned.',
           type: 'Block',
         },
+      ],
+      options: [
+        'always',
       ],
       output: `
         class ClassName {
@@ -258,6 +285,9 @@ export default {
           type: 'Block',
         },
       ],
+      options: [
+        'always',
+      ],
       output: `
         /**
          * Function description.
@@ -286,6 +316,9 @@ export default {
           message: 'Expected JSDoc block lines to be aligned.',
           type: 'Block',
         },
+      ],
+      options: [
+        'always',
       ],
       output: `
         /**
@@ -317,6 +350,9 @@ export default {
           type: 'Block',
         },
       ],
+      options: [
+        'always',
+      ],
       output: `
         /**
          * My object.
@@ -340,6 +376,9 @@ export default {
          */
         const fn = ( lorem, sit ) => {}
       `,
+      options: [
+        'always',
+      ],
     },
     {
       code: `
@@ -351,6 +390,9 @@ export default {
          */
         const fn = ( lorem, sit ) => {}
       `,
+      options: [
+        'always',
+      ],
     },
     {
       code: `
@@ -360,6 +402,9 @@ export default {
          */
         const fn = ( lorem, sit ) => {}
       `,
+      options: [
+        'always',
+      ],
     },
     {
       code: `
@@ -369,6 +414,9 @@ export default {
          */
         const fn = ( lorem, sit ) => {}
       `,
+      options: [
+        'always',
+      ],
     },
     {
       code: `
@@ -377,11 +425,17 @@ export default {
          */
         const fn = () => {}
       `,
+      options: [
+        'always',
+      ],
     },
     {
       code: `
         const fn = ( lorem, sit ) => {}
       `,
+      options: [
+        'always',
+      ],
     },
     {
       code: `
@@ -393,6 +447,9 @@ export default {
          */
         function fn( lorem, sit ) {}
       `,
+      options: [
+        'always',
+      ],
     },
     {
       code: `
@@ -406,6 +463,9 @@ export default {
           fn( lorem, sit ) {},
         }
       `,
+      options: [
+        'always',
+      ],
     },
     {
       code: `
@@ -419,6 +479,9 @@ export default {
           fn( lorem, sit ) {}
         }
       `,
+      options: [
+        'always',
+      ],
     },
     {
       code: `
@@ -430,6 +493,9 @@ export default {
          */
         const fn = ( lorem, sit ) => {}
       `,
+      options: [
+        'always',
+      ],
     },
     {
       code: `
@@ -444,6 +510,9 @@ export default {
             }
         }
       `,
+      options: [
+        'always',
+      ],
     },
     {
       code: `
@@ -454,6 +523,16 @@ export default {
          *
          * @property {string} lorem Description.
          * @property {int}    sit   Description multi words.
+         */
+      `,
+      options: [
+        'always',
+      ],
+    },
+    {
+      code: `
+        /**
+         * Not validating without option.
          */
       `,
     },

--- a/test/rules/assertions/checkLinesAlignment.js
+++ b/test/rules/assertions/checkLinesAlignment.js
@@ -364,6 +364,26 @@ export default {
          */
       `,
     },
+    {
+      code: `
+        /**
+         * Not implemented yet.
+         *
+         * @param {string} lorem Description.
+         * @param {int} sit Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+      errors: [
+        {
+          message: 'The `never` option is not yet implemented for this rule.',
+          type: 'Block',
+        },
+      ],
+      options: [
+        'never',
+      ],
+    },
   ],
   valid: [
     {
@@ -533,7 +553,11 @@ export default {
       code: `
         /**
          * Not validating without option.
+         *
+         * @param {string} lorem Description.
+         * @param {int} sit Description multi words.
          */
+        const fn = ( lorem, sit ) => {}
       `,
     },
   ],

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -9,6 +9,7 @@ const ruleTester = new RuleTester();
 (process.env.npm_config_rule ? process.env.npm_config_rule.split(',') : [
   'check-access',
   'check-alignment',
+  'check-lines-alignment',
   'check-examples',
   'check-indentation',
   'check-param-names',


### PR DESCRIPTION
## The PR

When developing for WordPress, there is a [recommended standard](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/#aligning-comments) to have the comment lines aligned.

Some days ago, we created an Eslint rule for that: https://github.com/Automattic/eslint-plugin-jsdoc-alignment/
It was created with the purpose to start using it and soon submit a contribution to add it to the `eslint-plugin-jsdoc`, which makes much more sense.

If this PR is approved, the current `eslint-plugin-jsdoc-alignment` will be deprecated in favor of this rule.

It's my first contribution to `eslint-plugin-jsdoc`, so I'm sorry if I missed something. But I'll be happy to fix anything if needed.

## Example

❌ Incorrect example:

```js
/**
 * Function description.
 *
 * @param {string} lorem Description.
 * @param {int} sit Description multi words.
 */
const fn = ( lorem, sit ) => {}
```

✅ Correct example:

```js
/**
 * Function description.
 *
 * @param {string} lorem Description.
 * @param {int}    sit   Description multi words.
 */
const fn = ( lorem, sit ) => {}
```