### PR TITLE
Fix check line alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1847,6 +1847,19 @@ const config = {
 // Message: Expected JSDoc block lines to be aligned.
 
 /**
+ * My object.
+ *
+ * @typedef {Object} MyObject
+ *
+ * @property {{a: number, b: string, c}} lorem Description.
+ * @property {Object.<string, Class>} sit Description multi words.
+ * @property {Object.<string, Class>} amet Description} weird {multi} {{words}}.
+ * @property {Object.<string, Class>} dolor
+ */
+// Options: ["always"]
+// Message: Expected JSDoc block lines to be aligned.
+
+/**
  * Not implemented yet.
  *
  * @param {string} lorem Description.
@@ -1961,6 +1974,22 @@ const config = {
  * @property {string} lorem Description.
  * @property {int}    sit   Description multi words.
  */
+// Options: ["always"]
+
+/**
+ * My object.
+ *
+ * @typedef {Object} MyObject
+ *
+ * @property {{a: number, b: string, c}} lorem Description.
+ * @property {Object.<string, Class>}    sit   Description multi words.
+ * @property {Object.<string, Class>}    amet  Description} weird {multi} {{words}}.
+ * @property {Object.<string, Class>}    dolor
+ */
+// Options: ["always"]
+
+/** @param {number} lorem */
+const fn = ( lorem ) => {}
 // Options: ["always"]
 
 /**

--- a/src/rules/checkLineAlignment.js
+++ b/src/rules/checkLineAlignment.js
@@ -187,6 +187,11 @@ export default iterateJsdoc(({
     return;
   }
 
+  // Skip if it contains only a single line.
+  if (!jsdocNode.value.includes('\n')) {
+    return;
+  }
+
   // `indent` is whitespace from line 1 (`/**`), so slice and account for "/".
   const tagIndentation = indent + ' ';
 

--- a/src/rules/checkLineAlignment.js
+++ b/src/rules/checkLineAlignment.js
@@ -31,7 +31,7 @@ const matchAll = (string, regexp, callback, limit) => {
  * @returns {string} The full description.
  */
 const getFullDescription = (lineString) => {
-  return /(?:\S+\s+){4}(.*)/.exec(lineString)[1];
+  return /\S+\s+(?:{{.*?}}|{.*?})\s+\S+\s+(.*)/.exec(lineString)[1];
 };
 
 /**
@@ -139,7 +139,7 @@ const checkCommentPerTag = (comment, tag, tagIndentation, report) => {
     // All line parts until the first word of the description (if description exists).
     matchAll(
       lineString,
-      /\S+/g,
+      /{{.*?}}|{.*?}|\S+/g,
       ({0: match, index: position}, partIndex) => {
         set(partsMatrix, [lineIndex, partIndex], {
           position,

--- a/test/rules/assertions/checkLineAlignment.js
+++ b/test/rules/assertions/checkLineAlignment.js
@@ -367,6 +367,41 @@ export default {
     {
       code: `
         /**
+         * My object.
+         *
+         * @typedef {Object} MyObject
+         *
+         * @property {{a: number, b: string, c}} lorem Description.
+         * @property {Object.<string, Class>} sit Description multi words.
+         * @property {Object.<string, Class>} amet Description} weird {multi} {{words}}.
+         * @property {Object.<string, Class>} dolor
+         */
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      options: [
+        'always',
+      ],
+      output: `
+        /**
+         * My object.
+         *
+         * @typedef {Object} MyObject
+         *
+         * @property {{a: number, b: string, c}} lorem Description.
+         * @property {Object.<string, Class>}    sit   Description multi words.
+         * @property {Object.<string, Class>}    amet  Description} weird {multi} {{words}}.
+         * @property {Object.<string, Class>}    dolor
+         */
+      `,
+    },
+    {
+      code: `
+        /**
          * Not implemented yet.
          *
          * @param {string} lorem Description.
@@ -543,6 +578,23 @@ export default {
          *
          * @property {string} lorem Description.
          * @property {int}    sit   Description multi words.
+         */
+      `,
+      options: [
+        'always',
+      ],
+    },
+    {
+      code: `
+        /**
+         * My object.
+         *
+         * @typedef {Object} MyObject
+         *
+         * @property {{a: number, b: string, c}} lorem Description.
+         * @property {Object.<string, Class>}    sit   Description multi words.
+         * @property {Object.<string, Class>}    amet  Description} weird {multi} {{words}}.
+         * @property {Object.<string, Class>}    dolor
          */
       `,
       options: [

--- a/test/rules/assertions/checkLineAlignment.js
+++ b/test/rules/assertions/checkLineAlignment.js
@@ -603,6 +603,15 @@ export default {
     },
     {
       code: `
+        /** @param {number} lorem */
+        const fn = ( lorem ) => {}
+      `,
+      options: [
+        'always',
+      ],
+    },
+    {
+      code: `
         /**
          * Not validating without option.
          *


### PR DESCRIPTION
Some fixes for the rule `check-line-alignment`.

It skips single line comments and considers types with spaces.