### PR TITLE
fix(`require-jsdoc`): support `TSInterfaceDeclaration` with `publicOnly`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9989,6 +9989,13 @@ export enum testEnum {
 }
 // Options: [{"contexts":["TSEnumDeclaration"],"publicOnly":true}]
 // Message: Missing JSDoc comment.
+
+export interface Test {
+  aFunc: () => void;
+  aVar: string;
+}
+// Options: [{"contexts":["TSInterfaceDeclaration"],"publicOnly":true}]
+// Message: Missing JSDoc comment.
 ````
 
 The following patterns are not considered problems:

--- a/src/exportParser.js
+++ b/src/exportParser.js
@@ -81,7 +81,7 @@ const getSymbol = function (node, globals, scope, opt) {
     /* istanbul ignore next */
     return null;
   }
-  case 'TSEnumDeclaration':
+  case 'TSEnumDeclaration': case 'TSInterfaceDeclaration':
   case 'ClassDeclaration': case 'ClassExpression':
   case 'FunctionExpression': case 'FunctionDeclaration':
   case 'ArrowFunctionExpression': {
@@ -152,6 +152,7 @@ createSymbol = function (node, globals, value, scope, isGlobal) {
   switch (node.type) {
   case 'TSEnumDeclaration':
   case 'FunctionDeclaration':
+  case 'TSInterfaceDeclaration':
 
     // Fallthrough
   case 'ClassDeclaration': {

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -2585,6 +2585,39 @@ export default {
         sourceType: 'module',
       },
     },
+    {
+      code: `
+      export interface Test {
+        aFunc: () => void;
+        aVar: string;
+      }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc comment.',
+        },
+      ],
+      options: [
+        {
+          contexts: ['TSInterfaceDeclaration'],
+          publicOnly: true,
+        },
+      ],
+      output: `
+      /**
+       *
+       */
+      export interface Test {
+        aFunc: () => void;
+        aVar: string;
+      }
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: {
+        sourceType: 'module',
+      },
+    },
   ],
   valid: [{
     code: `


### PR DESCRIPTION
As discussed in #640, adding support for Typescript interfaces