### PR TITLE
`check-examples`: add options to allow checking `@default` values and `@param`/`@property` defaults

### DIFF
--- a/.README/rules/check-examples.md
+++ b/.README/rules/check-examples.md
@@ -100,7 +100,10 @@ by decreasing precedence:
   with JavaScript Markdown lintable by
   [other plugins](https://github.com/eslint/eslint-plugin-markdown), e.g.,
   if one sets `matchingFileName` to `dummy.md` so that `@example` rules will
-  follow one's Markdown rules).
+  follow one's Markdown rules). For `@example` only.
+* `matchingFileNameDefaults` - As with `matchingFileName` but for use with `checkDefaults`.
+* `matchingFileNameParams` - As with `matchingFileName` but for use with `checkParams`.
+* `matchingFileNameProperties` As with `matchingFileName` but for use with `checkProperties`.
 * `checkEslintrc` - Defaults to `true` in adding rules
   based on an `.eslintrc.*` file. Setting to `false` corresponds to
   ESLint's [`--no-eslintrc`](https://eslint.org/docs/user-guide/command-line-interface#--no-eslintrc).

--- a/.README/rules/check-examples.md
+++ b/.README/rules/check-examples.md
@@ -1,6 +1,8 @@
 ### `check-examples`
 
-Ensures that (JavaScript) examples within JSDoc adhere to ESLint rules.
+Ensures that (JavaScript) examples within JSDoc adhere to ESLint rules. Also
+has options to lint the default values of optional `@param`/`@arg`/`@argument`
+and `@property`/`@prop` tags or the values of `@default`/`@defaultvalue` tags.
 
 #### Options
 
@@ -13,6 +15,8 @@ JSDoc specs use of an optional `<caption>` element at the beginning of
 
 The option `captionRequired` insists on a `<caption>` being present at
 the beginning of any `@example`.
+
+Used only for `@example`.
 
 ##### `exampleCodeRegex` and `rejectExampleCodeRegex`
 
@@ -55,10 +59,12 @@ out before evaluation.
 /**
  * @example
  *     anArray.filter((a) => {
- *      return a.b;
+ *       return a.b;
  *     });
  */
 ```
+
+Only applied to `@example` linting.
 
 ##### `reportUnusedDisableDirectives`
 
@@ -66,17 +72,18 @@ If not set to `false`, `reportUnusedDisableDirectives` will report disabled
 directives which are not used (and thus not needed). Defaults to `true`.
 Corresponds to ESLint's [`--report-unused-disable-directives`](https://eslint.org/docs/user-guide/command-line-interface#--report-unused-disable-directives).
 
-Inline ESLint config within `@example` JavaScript is allowed, though the
-disabling of ESLint directives which are not needed by the resolved rules
-will be reported as with the ESLint `--report-unused-disable-directives`
-command.
+Inline ESLint config within `@example` JavaScript is allowed (or within
+`@default`, etc.), though the disabling of ESLint directives which are not
+needed by the resolved rules will be reported as with the ESLint
+`--report-unused-disable-directives` command.
 
 #### Options for Determining ESLint Rule Applicability (`allowInlineConfig`, `noDefaultExampleRules`, `matchingFileName`, `configFile`, `checkEslintrc`, and `baseConfig`)
 
 The following options determine which individual ESLint rules will be
 applied to the JavaScript found within the `@example` tags (as determined
-to be applicable by the above regex options). They are ordered by
-decreasing precedence:
+to be applicable by the above regex options) or for the other tags checked by
+`checkDefaults`, `checkParams`, or `checkProperties` options. They are ordered
+by decreasing precedence:
 
 * `allowInlineConfig` - If not set to `false`, will allow
   inline config within the `@example` to override other config. Defaults
@@ -135,6 +142,12 @@ decreasing precedence:
   include full import/export info.
 * `node/no-missing-import` - See `import/no-unresolved`.
 * `node/no-missing-require` -  See `import/no-unresolved`.
+
+##### Options for checking other than `@example` (`checkDefaults`, `checkParams`, or `checkProperties`)
+
+* `checkDefaults` - Whether to check the values of `@default`/`@defaultvalue` tags
+* `checkParams` - Whether to check `@param`/`@arg`/`@argument` default values
+* `checkProperties` - Whether to check `@property`/`@prop` default values
 
 |||
 |---|---|

--- a/.README/rules/check-line-alignment.md
+++ b/.README/rules/check-line-alignment.md
@@ -15,6 +15,7 @@ line's parts. **Only the non-default `"always"` is implemented for now.**
 |---|---|
 |Context|everywhere|
 |Options|(a string matching `"always"|"never"`)|
-|Tags|`param`, `arg`, `argument`, `property`, `prop`|
+|Tags|`param`, `property`|
+|Aliases|`arg`, `argument`, `prop`|
 
 <!-- assertions checkLineAlignment -->

--- a/.README/rules/check-param-names.md
+++ b/.README/rules/check-param-names.md
@@ -62,5 +62,5 @@ Whether to check destructured properties. Defaults to `true`.
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
 |Options|`allowExtraTrailingParamDocs`, `checkDestructured`, `checkRestProperty`, `checkTypesPattern`|
 |Tags|`param`|
-
+|Aliases|`arg`, `argument`|
 <!-- assertions checkParamNames -->

--- a/.README/rules/check-property-names.md
+++ b/.README/rules/check-property-names.md
@@ -19,5 +19,6 @@ be removed even if it has a different type or description).
 |Context|Everywhere|
 |Options|`enableFixer`|
 |Tags|`property`|
+|Aliases|`prop`|
 
 <!-- assertions checkPropertyNames -->

--- a/.README/rules/empty-tags.md
+++ b/.README/rules/empty-tags.md
@@ -11,6 +11,7 @@ Expects the following tags to be empty of any content:
 - `@inheritdoc`
 - `@inner`
 - `@instance`
+- `@internal` (used by TypeScript)
 - `@override`
 - `@readonly`
 
@@ -46,7 +47,6 @@ add them within this option.
 |||
 |---|---|
 |Context|everywhere|
-|Tags| and others added by `tags`|
-|Aliases||
+|Tags| `abstract`, `async`, `generator`, `global`, `hideconstructor`, `ignore`, `inheritdoc`, `inner`, `instance`, `internal`, `override`, `readonly`, `package`, `private`, `protected`, `public`, `static` and others added by `tags`|
 |Options|`tags`|
 <!-- assertions emptyTags -->

--- a/.README/rules/require-property-description.md
+++ b/.README/rules/require-property-description.md
@@ -5,6 +5,7 @@ Requires that each `@property` tag has a `description` value.
 |||
 |---|---|
 |Context|everywhere|
-|Tags|N/A|
+|Tags|`property`|
+|Aliases|`prop`|
 
 <!-- assertions requirePropertyDescription -->

--- a/.README/rules/require-property-name.md
+++ b/.README/rules/require-property-name.md
@@ -5,6 +5,7 @@ Requires that all function `@property` tags have names.
 |||
 |---|---|
 |Context|everywhere|
-|Tags|N/A|
+|Tags|`property`|
+|Aliases|`prop`|
 
 <!-- assertions requirePropertyName -->

--- a/.README/rules/require-property-type.md
+++ b/.README/rules/require-property-type.md
@@ -5,6 +5,7 @@ Requires that each `@property` tag has a `type` value.
 |||
 |---|---|
 |Context|everywhere|
-|Tags|N/A|
+|Tags|`property`|
+|Aliases|`prop`|
 
 <!-- assertions requirePropertyType -->

--- a/README.md
+++ b/README.md
@@ -974,7 +974,10 @@ by decreasing precedence:
   with JavaScript Markdown lintable by
   [other plugins](https://github.com/eslint/eslint-plugin-markdown), e.g.,
   if one sets `matchingFileName` to `dummy.md` so that `@example` rules will
-  follow one's Markdown rules).
+  follow one's Markdown rules). For `@example` only.
+* `matchingFileNameDefaults` - As with `matchingFileName` but for use with `checkDefaults`.
+* `matchingFileNameParams` - As with `matchingFileName` but for use with `checkParams`.
+* `matchingFileNameProperties` As with `matchingFileName` but for use with `checkProperties`.
 * `checkEslintrc` - Defaults to `true` in adding rules
   based on an `.eslintrc.*` file. Setting to `false` corresponds to
   ESLint's [`--no-eslintrc`](https://eslint.org/docs/user-guide/command-line-interface#--no-eslintrc).
@@ -1509,20 +1512,20 @@ const obj = {};
  * @default 'abc'
  */
 const str = 'abc';
-// Options: [{"checkDefaults":false}]
+// Options: [{"checkDefaults":false,"matchingFileNameDefaults":"dummy.js"}]
 
 /**
  * @param {myType} [name='abc']
  */
 function quux () {
 }
-// Options: [{"checkParams":false}]
+// Options: [{"checkParams":false,"matchingFileNameParams":"dummy.js"}]
 
 /**
  * @property {myType} [name='abc']
  */
 const obj = {};
-// Options: [{"checkProperties":false}]
+// Options: [{"checkProperties":false,"matchingFileNameProperties":"dummy.js"}]
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -868,7 +868,9 @@ function quux (foo) {
 <a name="eslint-plugin-jsdoc-rules-check-examples"></a>
 ### <code>check-examples</code>
 
-Ensures that (JavaScript) examples within JSDoc adhere to ESLint rules.
+Ensures that (JavaScript) examples within JSDoc adhere to ESLint rules. Also
+has options to lint the default values of optional `@param`/`@arg`/`@argument`
+and `@property`/`@prop` tags or the values of `@default`/`@defaultvalue` tags.
 
 <a name="eslint-plugin-jsdoc-rules-check-examples-options-1"></a>
 #### Options
@@ -883,6 +885,8 @@ JSDoc specs use of an optional `<caption>` element at the beginning of
 
 The option `captionRequired` insists on a `<caption>` being present at
 the beginning of any `@example`.
+
+Used only for `@example`.
 
 <a name="eslint-plugin-jsdoc-rules-check-examples-options-1-examplecoderegex-and-rejectexamplecoderegex"></a>
 ##### <code>exampleCodeRegex</code> and <code>rejectExampleCodeRegex</code>
@@ -927,10 +931,12 @@ out before evaluation.
 /**
  * @example
  *     anArray.filter((a) => {
- *      return a.b;
+ *       return a.b;
  *     });
  */
 ```
+
+Only applied to `@example` linting.
 
 <a name="eslint-plugin-jsdoc-rules-check-examples-options-1-reportunuseddisabledirectives"></a>
 ##### <code>reportUnusedDisableDirectives</code>
@@ -939,18 +945,19 @@ If not set to `false`, `reportUnusedDisableDirectives` will report disabled
 directives which are not used (and thus not needed). Defaults to `true`.
 Corresponds to ESLint's [`--report-unused-disable-directives`](https://eslint.org/docs/user-guide/command-line-interface#--report-unused-disable-directives).
 
-Inline ESLint config within `@example` JavaScript is allowed, though the
-disabling of ESLint directives which are not needed by the resolved rules
-will be reported as with the ESLint `--report-unused-disable-directives`
-command.
+Inline ESLint config within `@example` JavaScript is allowed (or within
+`@default`, etc.), though the disabling of ESLint directives which are not
+needed by the resolved rules will be reported as with the ESLint
+`--report-unused-disable-directives` command.
 
 <a name="eslint-plugin-jsdoc-rules-check-examples-options-for-determining-eslint-rule-applicability-allowinlineconfig-nodefaultexamplerules-matchingfilename-configfile-checkeslintrc-and-baseconfig"></a>
 #### Options for Determining ESLint Rule Applicability (<code>allowInlineConfig</code>, <code>noDefaultExampleRules</code>, <code>matchingFileName</code>, <code>configFile</code>, <code>checkEslintrc</code>, and <code>baseConfig</code>)
 
 The following options determine which individual ESLint rules will be
 applied to the JavaScript found within the `@example` tags (as determined
-to be applicable by the above regex options). They are ordered by
-decreasing precedence:
+to be applicable by the above regex options) or for the other tags checked by
+`checkDefaults`, `checkParams`, or `checkProperties` options. They are ordered
+by decreasing precedence:
 
 * `allowInlineConfig` - If not set to `false`, will allow
   inline config within the `@example` to override other config. Defaults
@@ -1010,6 +1017,13 @@ decreasing precedence:
   include full import/export info.
 * `node/no-missing-import` - See `import/no-unresolved`.
 * `node/no-missing-require` -  See `import/no-unresolved`.
+
+<a name="eslint-plugin-jsdoc-rules-check-examples-options-for-determining-eslint-rule-applicability-allowinlineconfig-nodefaultexamplerules-matchingfilename-configfile-checkeslintrc-and-baseconfig-options-for-checking-other-than-example-checkdefaults-checkparams-or-checkproperties"></a>
+##### Options for checking other than <code>@example</code> (<code>checkDefaults</code>, <code>checkParams</code>, or <code>checkProperties</code>)
+
+* `checkDefaults` - Whether to check the values of `@default`/`@defaultvalue` tags
+* `checkParams` - Whether to check `@param`/`@arg`/`@argument` default values
+* `checkProperties` - Whether to check `@property`/`@prop` default values
 
 |||
 |---|---|
@@ -1302,6 +1316,28 @@ function quux () {
 }
 // Options: [{"baseConfig":{"rules":{"indent":["error"]}},"checkEslintrc":false,"noDefaultExampleRules":false}]
 // Message: @example error (indent): Expected indentation of 0 spaces but found 2.
+
+/**
+ * @default 'abc'
+ */
+const str = 'abc';
+// Options: [{"checkDefaults":true}]
+// Message: @default error (semi): Missing semicolon.
+
+/**
+ * @param {myType} [name='abc']
+ */
+function quux () {
+}
+// Options: [{"checkParams":true}]
+// Message: @param error (semi): Missing semicolon.
+
+/**
+ * @property {myType} [name='abc']
+ */
+const obj = {};
+// Options: [{"checkProperties":true}]
+// Message: @property error (semi): Missing semicolon.
 ````
 
 The following patterns are not considered problems:
@@ -1449,6 +1485,44 @@ function f () {
 function quux () {
 }
 // Options: [{"baseConfig":{"plugins":["jsdoc"],"rules":{"jsdoc/require-file-overview":["error"]}},"checkEslintrc":false,"noDefaultExampleRules":false}]
+
+/**
+ * @default 'abc';
+ */
+const str = 'abc';
+// Options: [{"checkDefaults":true}]
+
+/**
+ * @param {myType} [name='abc';]
+ */
+function quux () {
+}
+// Options: [{"checkParams":true}]
+
+/**
+ * @property {myType} [name='abc';]
+ */
+const obj = {};
+// Options: [{"checkProperties":true}]
+
+/**
+ * @default 'abc'
+ */
+const str = 'abc';
+// Options: [{"checkDefaults":false}]
+
+/**
+ * @param {myType} [name='abc']
+ */
+function quux () {
+}
+// Options: [{"checkParams":false}]
+
+/**
+ * @property {myType} [name='abc']
+ */
+const obj = {};
+// Options: [{"checkProperties":false}]
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -1717,7 +1717,8 @@ line's parts. **Only the non-default `"always"` is implemented for now.**
 |---|---|
 |Context|everywhere|
 |Options|(a string matching `"always"|"never"`)|
-|Tags|`param`, `arg`, `argument`, `property`, `prop`|
+|Tags|`param`, `property`|
+|Aliases|`arg`, `argument`, `prop`|
 
 The following patterns are considered problems:
 
@@ -2049,7 +2050,7 @@ Whether to check destructured properties. Defaults to `true`.
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
 |Options|`allowExtraTrailingParamDocs`, `checkDestructured`, `checkRestProperty`, `checkTypesPattern`|
 |Tags|`param`|
-
+|Aliases|`arg`, `argument`|
 The following patterns are considered problems:
 
 ````js
@@ -2799,6 +2800,7 @@ be removed even if it has a different type or description).
 |Context|Everywhere|
 |Options|`enableFixer`|
 |Tags|`property`|
+|Aliases|`prop`|
 
 The following patterns are considered problems:
 
@@ -5090,6 +5092,7 @@ Expects the following tags to be empty of any content:
 - `@inheritdoc`
 - `@inner`
 - `@instance`
+- `@internal` (used by TypeScript)
 - `@override`
 - `@readonly`
 
@@ -5127,8 +5130,7 @@ add them within this option.
 |||
 |---|---|
 |Context|everywhere|
-|Tags| and others added by `tags`|
-|Aliases||
+|Tags| `abstract`, `async`, `generator`, `global`, `hideconstructor`, `ignore`, `inheritdoc`, `inner`, `instance`, `internal`, `override`, `readonly`, `package`, `private`, `protected`, `public`, `static` and others added by `tags`|
 |Options|`tags`|
 The following patterns are considered problems:
 
@@ -12825,7 +12827,8 @@ Requires that each `@property` tag has a `description` value.
 |||
 |---|---|
 |Context|everywhere|
-|Tags|N/A|
+|Tags|`property`|
+|Aliases|`prop`|
 
 The following patterns are considered problems:
 
@@ -12883,7 +12886,8 @@ Requires that all function `@property` tags have names.
 |||
 |---|---|
 |Context|everywhere|
-|Tags|N/A|
+|Tags|`property`|
+|Aliases|`prop`|
 
 The following patterns are considered problems:
 
@@ -12941,7 +12945,8 @@ Requires that each `@property` tag has a `type` value.
 |||
 |---|---|
 |Context|everywhere|
-|Tags|N/A|
+|Tags|`property`|
+|Aliases|`prop`|
 
 The following patterns are considered problems:
 

--- a/test/rules/assertions/checkExamples.js
+++ b/test/rules/assertions/checkExamples.js
@@ -1093,6 +1093,7 @@ export default {
       options: [
         {
           checkDefaults: false,
+          matchingFileNameDefaults: 'dummy.js',
         },
       ],
     },
@@ -1107,6 +1108,7 @@ export default {
       options: [
         {
           checkParams: false,
+          matchingFileNameParams: 'dummy.js',
         },
       ],
     },
@@ -1120,6 +1122,7 @@ export default {
       options: [
         {
           checkProperties: false,
+          matchingFileNameProperties: 'dummy.js',
         },
       ],
     },

--- a/test/rules/assertions/checkExamples.js
+++ b/test/rules/assertions/checkExamples.js
@@ -691,6 +691,64 @@ export default {
         noDefaultExampleRules: false,
       }],
     },
+    {
+      code: `
+          /**
+           * @default 'abc'
+           */
+          const str = 'abc';
+      `,
+      errors: [
+        {
+          line: 2,
+          message: '@default error (semi): Missing semicolon.',
+        },
+      ],
+      options: [
+        {
+          checkDefaults: true,
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @param {myType} [name='abc']
+           */
+          function quux () {
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: '@param error (semi): Missing semicolon.',
+        },
+      ],
+      options: [
+        {
+          checkParams: true,
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @property {myType} [name='abc']
+           */
+          const obj = {};
+      `,
+      errors: [
+        {
+          line: 2,
+          message: '@property error (semi): Missing semicolon.',
+        },
+      ],
+      options: [
+        {
+          checkProperties: true,
+        },
+      ],
+    },
   ],
   valid: [
     {
@@ -984,6 +1042,86 @@ export default {
         checkEslintrc: false,
         noDefaultExampleRules: false,
       }],
+    },
+    {
+      code: `
+          /**
+           * @default 'abc';
+           */
+          const str = 'abc';
+      `,
+      options: [
+        {
+          checkDefaults: true,
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @param {myType} [name='abc';]
+           */
+          function quux () {
+          }
+      `,
+      options: [
+        {
+          checkParams: true,
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @property {myType} [name='abc';]
+           */
+          const obj = {};
+      `,
+      options: [
+        {
+          checkProperties: true,
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @default 'abc'
+           */
+          const str = 'abc';
+      `,
+      options: [
+        {
+          checkDefaults: false,
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @param {myType} [name='abc']
+           */
+          function quux () {
+          }
+      `,
+      options: [
+        {
+          checkParams: false,
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @property {myType} [name='abc']
+           */
+          const obj = {};
+      `,
+      options: [
+        {
+          checkProperties: false,
+        },
+      ],
     },
   ],
 };


### PR DESCRIPTION
feat(`check-examples`): add options `checkDefaults`, `checkParams`, `checkProperties`; fixes #473

This PR allows `check-examples` to also check the value of `@default`/`@defaultvalue` tags (which can include code subject to linting) as well as the default values of optional `@param` or `@property` tags.

Also adds `matchingFileNameDefaults`, `matchingFileNameParams`, and `matchingFileNameProperties` to simulate a file name which can cause content within these tags to be linted differently from `@example` (by use of `overrides`).