### PR TITLE
Require yields

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -81,6 +81,7 @@ Finally, enable all of the rules that you would like to use.
         "jsdoc/require-returns-check": 1, // Recommended
         "jsdoc/require-returns-description": 1, // Recommended
         "jsdoc/require-returns-type": 1, // Recommended
+        "jsdoc/require-yields": 1, // Recommended
         "jsdoc/valid-types": 1 // Recommended
     }
 }
@@ -530,4 +531,5 @@ selector).
 {"gitdown": "include", "file": "./rules/require-returns-type.md"}
 {"gitdown": "include", "file": "./rules/require-returns.md"}
 {"gitdown": "include", "file": "./rules/require-throws.md"}
+{"gitdown": "include", "file": "./rules/require-yields.md"}
 {"gitdown": "include", "file": "./rules/valid-types.md"}

--- a/.README/rules/require-yields.md
+++ b/.README/rules/require-yields.md
@@ -4,6 +4,20 @@ Requires that yields are documented.
 
 Will also report if multiple `@yields` tags are present.
 
+See the `next`, `forceRequireNext`, and `nextWithGeneratorTag` options for an
+option to expect a non-standard `@next` tag.
+
+Note that there is currently no `yield` equivalent to the
+`require-returns-check` rule to ensure that if a `@yields` is present that a
+`yield` (or `yield` with a value) is present in the function body (or that if
+a `@next` is present that there is a `yield` with a return value present).
+
+Please also note that JavaScript does allow generators not to have `yield`
+(e.g., with just a return or even no explicit return), but if you want to
+enforce that all generators have a `yield` in the function body, you can
+use the ESLint
+[`require-yield`](https://eslint.org/docs/rules/require-yield) rule.
+
 #### Options
 
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the
@@ -12,15 +26,10 @@ Will also report if multiple `@yields` tags are present.
     so be sure to add back `inheritdoc` if you wish its presence to cause
     exemption of the rule.
 - `forceRequireYields` - Set to `true` to always insist on
-    `@yields` documentation even if there are only expressionless `yield`
-    statements in the function. May be desired to flag that a project is aware
-    of an `undefined`/`void` yield. Defaults to `false`.
-    Note that unlike `require-returns`, `require-yields` `forceRequire*` option
-    does not impose the requirement that all generators have a `yield` (since it
-    is possible a generator may not have even an implicit `yield` and merely
-    return). If you always want a `yield` present (and thus for this rule to
-    report the need for docs), you should also use the ESLint
-    [`require-yield`](https://eslint.org/docs/rules/require-yield) rule.
+    `@yields` documentation for generators even if there are only
+    expressionless `yield` statements in the function. May be desired to flag
+    that a project is aware of an `undefined`/`void` yield. Defaults to
+    `false`.
 - `contexts` - Set this to an array of strings representing the AST context
     where you wish the rule to be applied.
     Overrides the default contexts (see below). Set to `"any"` if you want
@@ -36,6 +45,25 @@ Will also report if multiple `@yields` tags are present.
 - `withGeneratorTag` - If a `@generator` tag is present on a block, require
     `@yields`/`@yield`. Defaults to `true`. See `contexts` to `any` if you want
     to catch `@generator` with `@callback` or such not attached to a function.
+- `next` - If `true`, this option will insist that any use of a `yield` return
+    value (e.g., `const rv = yield;` or `const rv = yield value;`) has a
+    (non-standard) `@next` tag (in addition to any `@yields` tag) so as to be
+    able to document the type expected to be supplied into the iterator
+    (the `Generator` iterator that is returned by the call to the generator
+    function) to the iterator (e.g., `it.next(value)`). The tag will not be
+    expected if the generator function body merely has plain `yield;` or
+    `yield value;` statements without returning the values. Defaults to
+    `false`.
+- `forceRequireNext` - Set to `true` to always insist on
+    `@next` documentation even if there are no `yield` statements in the
+    function or none return values. May be desired to flag that a project is
+    aware of the expected yield return being `undefined`. Defaults to `false`.
+- `nextWithGeneratorTag` - If a `@generator` tag is present on a block, require
+    (non-standard ) `@next` (see `next` option). This will require using `void`
+    or `undefined` in cases where generators do not use the `next()`-supplied
+    incoming `yield`-returned value. Defaults to `false`. See `contexts` to
+    `any` if you want to catch `@generator` with `@callback` or such not
+    attached to a function.
 
 |||
 |---|---|
@@ -43,7 +71,7 @@ Will also report if multiple `@yields` tags are present.
 |Tags|`yields`|
 |Aliases|`yield`|
 |Recommended|true|
-| Options  | `contexts`,  `exemptedBy`, `withGeneratorTag`, `forceRequireYields` |
+| Options  | `contexts`,  `exemptedBy`, `withGeneratorTag`, `nextWithGeneratorTag`, `forceRequireYields`, `next` |
 | Settings | `overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs` |
 
 <!-- assertions requireYields -->

--- a/.README/rules/require-yields.md
+++ b/.README/rules/require-yields.md
@@ -1,0 +1,49 @@
+### `require-yields`
+
+Requires that yields are documented.
+
+Will also report if multiple `@yields` tags are present.
+
+#### Options
+
+- `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the
+    document block avoids the need for a `@yields`. Defaults to an array
+    with `inheritdoc`. If you set this array, it will overwrite the default,
+    so be sure to add back `inheritdoc` if you wish its presence to cause
+    exemption of the rule.
+- `forceRequireYields` - Set to `true` to always insist on
+    `@yields` documentation even if there are only expressionless `yield`
+    statements in the function. May be desired to flag that a project is aware
+    of an `undefined`/`void` yield. Defaults to `false`.
+    Note that unlike `require-returns`, `require-yields` `forceRequire*` option
+    does not impose the requirement that all generators have a `yield` (since it
+    is possible a generator may not have even an implicit `yield` and merely
+    return). If you always want a `yield` present (and thus for this rule to
+    report the need for docs), you should also use the ESLint
+    [`require-yield`](https://eslint.org/docs/rules/require-yield) rule.
+- `contexts` - Set this to an array of strings representing the AST context
+    where you wish the rule to be applied.
+    Overrides the default contexts (see below). Set to `"any"` if you want
+    the rule to apply to any jsdoc block throughout your files (as is necessary
+    for finding function blocks not attached to a function declaration or
+    expression, i.e., `@callback` or `@function` (or its aliases `@func` or
+    `@method`) (including those associated with an `@interface`). This
+    rule will only apply on non-default contexts when there is such a tag
+    present and the `forceRequireYields` option is set or if the
+    `withGeneratorTag` option is set with a present `@generator` tag
+    (since we are not checking against the actual `yield` values in these
+    cases).
+- `withGeneratorTag` - If a `@generator` tag is present on a block, require
+    `@yields`/`@yield`. Defaults to `true`. See `contexts` to `any` if you want
+    to catch `@generator` with `@callback` or such not attached to a function.
+
+|||
+|---|---|
+|Context|Generator functions (`FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled)|
+|Tags|`yields`|
+|Aliases|`yield`|
+|Recommended|true|
+| Options  | `contexts`,  `exemptedBy`, `withGeneratorTag`, `forceRequireYields` |
+| Settings | `overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs` |
+
+<!-- assertions requireYields -->

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ import requireReturnsCheck from './rules/requireReturnsCheck';
 import requireReturnsDescription from './rules/requireReturnsDescription';
 import requireReturnsType from './rules/requireReturnsType';
 import requireThrows from './rules/requireThrows';
+import requireYields from './rules/requireYields';
 import validTypes from './rules/validTypes';
 
 export default {
@@ -80,6 +81,7 @@ export default {
         'jsdoc/require-returns-check': 'warn',
         'jsdoc/require-returns-description': 'warn',
         'jsdoc/require-returns-type': 'warn',
+        'jsdoc/require-yields': 'warn',
         'jsdoc/valid-types': 'warn',
       },
     },
@@ -123,6 +125,7 @@ export default {
     'require-returns-description': requireReturnsDescription,
     'require-returns-type': requireReturnsType,
     'require-throws': requireThrows,
+    'require-yields': requireYields,
     'valid-types': validTypes,
   },
 };

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -465,6 +465,10 @@ const getUtils = (
     return jsdocUtils.hasYieldValue(node);
   };
 
+  utils.hasYieldReturnValue = () => {
+    return jsdocUtils.hasYieldValue(node, true);
+  };
+
   utils.hasThrowValue = () => {
     return jsdocUtils.hasThrowValue(node);
   };

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -307,6 +307,13 @@ const getUtils = (
     return jsdocUtils.hasParams(node);
   };
 
+  utils.isGenerator = () => {
+    return node && (
+      node.generator ||
+      node.type === 'MethodDefinition' && node.value.generator
+    );
+  };
+
   utils.isConstructor = () => {
     return jsdocUtils.isConstructor(node);
   };
@@ -452,6 +459,10 @@ const getUtils = (
 
   utils.hasReturnValue = () => {
     return jsdocUtils.hasReturnValue(node);
+  };
+
+  utils.hasYieldValue = () => {
+    return jsdocUtils.hasYieldValue(node);
   };
 
   utils.hasThrowValue = () => {

--- a/src/rules/requireYields.js
+++ b/src/rules/requireYields.js
@@ -1,0 +1,126 @@
+import iterateJsdoc from '../iterateJsdoc';
+
+/**
+ * We can skip checking for a yield value, in case the documentation is inherited
+ * or the method has a constructor or abstract tag.
+ *
+ * In either of these cases the yield value is optional or not defined.
+ *
+ * @param {*} utils
+ *   a reference to the utils which are used to probe if a tag is present or not.
+ * @returns {boolean}
+ *   true in case deep checking can be skipped; otherwise false.
+ */
+const canSkip = (utils) => {
+  return utils.hasATag([
+    // inheritdoc implies that all documentation is inherited
+    // see https://jsdoc.app/tags-inheritdoc.html
+    //
+    // Abstract methods are by definition incomplete,
+    // so it is not an error if it declares a yield value but does not implement it.
+    'abstract',
+    'virtual',
+
+    // Constructors do not have a yield value
+    // so we can bail out here, too.
+    'class',
+    'constructor',
+
+    // Yield type is specified accompanying the targeted @type
+    'type',
+
+    // This seems to imply a class as well
+    'interface',
+  ]) ||
+    utils.avoidDocs();
+};
+
+export default iterateJsdoc(({
+  report,
+  utils,
+  context,
+}) => {
+  const {
+    forceRequireYields = false,
+    withGeneratorTag = true,
+  } = context.options[0] || {};
+
+  // A preflight check. We do not need to run a deep check
+  // in case the @yield comment is optional or undefined.
+  if (canSkip(utils)) {
+    return;
+  }
+
+  const tagName = utils.getPreferredTagName({tagName: 'yields'});
+  if (!tagName) {
+    return;
+  }
+
+  const tags = utils.getTags(tagName);
+
+  if (tags.length > 1) {
+    report(`Found more than one @${tagName} declaration.`);
+  }
+
+  const iteratingFunction = utils.isIteratingFunction();
+
+  // In case the code yields something, we expect a yields value in JSDoc.
+  const [tag] = tags;
+  const missingYieldTag = typeof tag === 'undefined' || tag === null;
+
+  const shouldReport = () => {
+    if (!missingYieldTag) {
+      return false;
+    }
+
+    if (
+      withGeneratorTag && utils.hasTag('generator') ||
+      forceRequireYields && iteratingFunction && utils.isGenerator()
+    ) {
+      return true;
+    }
+
+    return iteratingFunction && utils.isGenerator() && utils.hasYieldValue();
+  };
+
+  if (shouldReport()) {
+    report(`Missing JSDoc @${tagName} declaration.`);
+  }
+}, {
+  contextDefaults: true,
+  meta: {
+    docs: {
+      description: 'Requires yields are documented.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-yields',
+    },
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          contexts: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+          exemptedBy: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+          forceRequireYields: {
+            default: false,
+            type: 'boolean',
+          },
+          withGeneratorTag: {
+            default: true,
+            type: 'boolean',
+          },
+        },
+        type: 'object',
+      },
+    ],
+    type: 'suggestion',
+  },
+});

--- a/test/rules/assertions/requireYields.js
+++ b/test/rules/assertions/requireYields.js
@@ -1,0 +1,1088 @@
+export default {
+  invalid: [
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux (foo) {
+
+            yield foo;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux (foo) {
+
+            const a = yield foo;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux (foo) {
+            yield foo;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yield declaration.',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            yields: 'yield',
+          },
+        },
+      },
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux() {
+            yield 5;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+      options: [{
+        forceRequireYields: true,
+      }],
+      parserOptions: {
+        ecmaVersion: 8,
+      },
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux() {
+            yield;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+      options: [{
+        forceRequireYields: true,
+      }],
+      parserOptions: {
+        ecmaVersion: 8,
+      },
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          const quux = async function * () {
+            yield;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+      options: [{
+        forceRequireYields: true,
+      }],
+      parserOptions: {
+        ecmaVersion: 2_018,
+      },
+    },
+    {
+      code: `
+           /**
+            *
+            */
+           async function * quux () {
+             yield;
+           }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+      options: [{
+        forceRequireYields: true,
+      }],
+      parserOptions: {
+        ecmaVersion: 2_018,
+      },
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            yield;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+        forceRequireYields: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @function
+           * @generator
+           */
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+        forceRequireYields: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           * @generator
+           */
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+        forceRequireYields: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @yields {undefined}
+           * @yields {void}
+           */
+          function * quux (foo) {
+
+            return foo;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Found more than one @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @yields
+           */
+          function * quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Unexpected tag `@yields`',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            yields: false,
+          },
+        },
+      },
+    },
+    {
+      code: `
+          /**
+           * @param foo
+           */
+          function * quux (foo) {
+            yield 'bar';
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+      options: [
+        {
+          exemptedBy: ['notPresent'],
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @param {array} a
+       */
+      async function * foo(a) {
+        return;
+      }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+      options: [{
+        forceRequireYields: true,
+      }],
+      parserOptions: {
+        ecmaVersion: 2_018,
+      },
+    },
+    {
+      code: `
+      /**
+       * @param {array} a
+       */
+      async function * foo(a) {
+        yield Promise.all(a);
+      }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+      options: [{
+        forceRequireYields: true,
+      }],
+      parserOptions: {
+        ecmaVersion: 2_018,
+      },
+    },
+    {
+      code: `
+      class quux {
+        /**
+         *
+         */
+        * quux () {
+          yield;
+        }
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+        forceRequireYields: true,
+      }],
+    },
+    {
+      code: `
+      /**
+       * @param {array} a
+       */
+      async function * foo(a) {
+        yield Promise.all(a);
+      }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+      parserOptions: {
+        ecmaVersion: 2_018,
+      },
+    },
+    {
+      code: `
+          /**
+           * @generator
+           */
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+        withGeneratorTag: true,
+      }],
+      parserOptions: {
+        ecmaVersion: 2_018,
+      },
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            if (true) {
+              yield;
+            }
+            yield true;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            try {
+              yield true;
+            } catch (err) {
+            }
+            yield;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            try {
+            } finally {
+              yield true;
+            }
+            yield;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            try {
+              yield;
+            } catch (err) {
+            }
+            yield true;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            try {
+              something();
+            } catch (err) {
+              yield true;
+            }
+            yield;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            switch (true) {
+            case 'abc':
+              yield true;
+            }
+            yield;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            switch (true) {
+            case 'abc':
+              yield;
+            }
+            yield true;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            for (const i of abc) {
+              yield true;
+            }
+            yield;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            for (const a in b) {
+              yield true;
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            for (let i=0; i<n; i+=1) {
+              yield true;
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            while(true) {
+              yield true
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            do {
+              yield true
+            }
+            while(true)
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            if (true) {
+              yield;
+            }
+            yield true;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            if (true) {
+              yield true;
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            var a = {};
+            with (a) {
+              yield true;
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            if (true) {
+              yield;
+            } else {
+              yield true;
+            }
+            yield;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+    },
+  ],
+  valid: [
+    {
+      code: `
+          /**
+           * @yields Foo.
+           */
+          function * quux () {
+
+            yield foo;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields Foo.
+           */
+          function * quux () {
+
+            yield foo;
+          }
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            yield;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (bar) {
+            bar.doSomething(function * (baz) {
+              yield baz.corge();
+            })
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {Array}
+           */
+          function * quux (bar) {
+            yield bar.doSomething(function * (baz) {
+              yield baz.corge();
+            })
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @inheritdoc
+           */
+          function * quux (foo) {
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @override
+           */
+          function * quux (foo) {
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @constructor
+           */
+          function * quux (foo) {
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @implements
+           */
+          function * quux (foo) {
+            yield;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @override
+           */
+          function * quux (foo) {
+
+            yield foo;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @class
+           */
+          function * quux (foo) {
+            yield foo;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @constructor
+           */
+          function * quux (foo) {
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {object}
+           */
+          function * quux () {
+
+            yield {a: foo};
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {void}
+           */
+          function * quux () {
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {undefined}
+           */
+          function * quux () {
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {void}
+           */
+          function quux () {
+          }
+      `,
+      options: [{
+        forceRequireYields: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @yields {void}
+           */
+          function * quux () {
+            yield undefined;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {void}
+           */
+          function * quux () {
+            yield undefined;
+          }
+      `,
+      options: [{
+        forceRequireYields: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @yields {void}
+           */
+          function * quux () {
+            yield;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {void}
+           */
+          function * quux () {
+          }
+      `,
+      options: [{
+        forceRequireYields: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @yields {void}
+           */
+          function * quux () {
+            yield;
+          }
+      `,
+      options: [{
+        forceRequireYields: true,
+      }],
+    },
+    {
+      code: `
+          /** @type {SpecialIterator} */
+          function * quux () {
+            yield 5;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {Something}
+           */
+          async function * quux () {
+          }
+      `,
+      options: [{
+        forceRequireYields: true,
+      }],
+      parserOptions: {
+        ecmaVersion: 2_018,
+      },
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          async function * quux () {}
+      `,
+      parserOptions: {
+        ecmaVersion: 2_018,
+      },
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          const quux = async function * () {}
+      `,
+      parserOptions: {
+        ecmaVersion: 2_018,
+      },
+    },
+    {
+      code: `
+          /**
+           * @type {MyCallback}
+           */
+          function * quux () {
+            yield;
+          }
+      `,
+      options: [
+        {
+          exemptedBy: ['type'],
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @param {array} a
+       */
+      async function * foo (a) {
+        yield;
+      }
+      `,
+      parserOptions: {
+        ecmaVersion: 2_018,
+      },
+    },
+    {
+      code: `
+          /**
+           *
+           */
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @function
+           */
+      `,
+      options: [
+        {
+          contexts: ['any'],
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @function
+           */
+      `,
+      options: [{
+        forceRequireYields: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @callback
+           */
+      `,
+      options: [{
+        forceRequireYields: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @generator
+           */
+      `,
+      options: [{
+        withGeneratorTag: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @generator
+           * @yields
+           */
+      `,
+      options: [{
+        contexts: ['any'],
+        withGeneratorTag: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @generator
+           */
+      `,
+      options: [{
+        contexts: ['any'],
+        withGeneratorTag: false,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @yields
+           */
+          function * quux (foo) {
+
+            const a = yield foo;
+          }
+      `,
+    },
+  ],
+};

--- a/test/rules/assertions/requireYields.js
+++ b/test/rules/assertions/requireYields.js
@@ -20,6 +20,83 @@ export default {
     {
       code: `
           /**
+           * @yields
+           */
+          function * quux (foo) {
+
+            const retVal = yield foo;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @next declaration.',
+        },
+      ],
+      options: [{
+        next: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @yields
+           */
+          function * quux (foo) {
+
+            const retVal = yield;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @next declaration.',
+        },
+      ],
+      options: [{
+        next: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @yields {void}
+           */
+          function * quux () {
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @next declaration.',
+        },
+      ],
+      options: [{
+        forceRequireNext: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @yields {void}
+           */
+          function * quux () {
+            yield;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @next declaration.',
+        },
+      ],
+      options: [{
+        forceRequireNext: true,
+      }],
+    },
+    {
+      code: `
+          /**
            *
            */
           function * quux (foo) {
@@ -53,6 +130,58 @@ export default {
         jsdoc: {
           tagNamePreference: {
             yields: 'yield',
+          },
+        },
+      },
+    },
+    {
+      code: `
+          /**
+           * @yields
+           */
+          function * quux (foo) {
+            const val = yield foo;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yield-returns declaration.',
+        },
+      ],
+      options: [{
+        next: true,
+      }],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            next: 'yield-returns',
+          },
+        },
+      },
+    },
+    {
+      code: `
+          /**
+           * @yields
+           * @next
+           */
+          function * quux () {
+            const ret = yield 5;
+          }
+      `,
+      errors: [
+        {
+          message: 'Unexpected tag `@next`',
+        },
+      ],
+      options: [{
+        next: true,
+      }],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            next: false,
           },
         },
       },
@@ -362,6 +491,27 @@ export default {
       options: [{
         contexts: ['any'],
         withGeneratorTag: true,
+      }],
+      parserOptions: {
+        ecmaVersion: 2_018,
+      },
+    },
+    {
+      code: `
+          /**
+           * @generator
+           * @yields
+           */
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @next declaration.',
+        },
+      ],
+      options: [{
+        contexts: ['any'],
+        nextWithGeneratorTag: true,
       }],
       parserOptions: {
         ecmaVersion: 2_018,
@@ -869,6 +1019,19 @@ export default {
       code: `
           /**
            * @yields {void}
+           * @next {void}
+           */
+          function * quux () {
+          }
+      `,
+      options: [{
+        forceRequireNext: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @yields {void}
            */
           function * quux () {
             yield undefined;
@@ -1054,12 +1217,35 @@ export default {
       code: `
           /**
            * @generator
+           */
+      `,
+      options: [{
+        nextWithGeneratorTag: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @generator
            * @yields
            */
       `,
       options: [{
         contexts: ['any'],
         withGeneratorTag: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @generator
+           * @yields
+           * @next
+           */
+      `,
+      options: [{
+        contexts: ['any'],
+        nextWithGeneratorTag: true,
       }],
     },
     {
@@ -1076,6 +1262,18 @@ export default {
     {
       code: `
           /**
+           * @generator
+           * @yields
+           */
+      `,
+      options: [{
+        contexts: ['any'],
+        nextWithGeneratorTag: false,
+      }],
+    },
+    {
+      code: `
+          /**
            * @yields
            */
           function * quux (foo) {
@@ -1083,6 +1281,81 @@ export default {
             const a = yield foo;
           }
       `,
+    },
+    {
+      code: `
+          /**
+           * @yields
+           * @next
+           */
+          function * quux (foo) {
+            let a = yield;
+          }
+      `,
+      options: [{
+        next: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @yields
+           * @next
+           */
+          function * quux (foo) {
+            const a = yield foo;
+          }
+      `,
+      options: [{
+        next: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+      `,
+      options: [{
+        contexts: ['any'],
+        nextWithGeneratorTag: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+      `,
+      options: [{
+        contexts: ['any'],
+        next: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {}
+      `,
+      options: [{
+        contexts: ['any'],
+        next: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @yields {void}
+           */
+          function * quux () {
+            yield;
+          }
+      `,
+      options: [{
+        next: true,
+      }],
     },
   ],
 };

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -45,6 +45,7 @@ const ruleTester = new RuleTester();
   'require-returns-description',
   'require-returns-type',
   'require-throws',
+  'require-yields',
   'valid-types',
 ]).forEach((ruleName) => {
   const rule = config.rules[ruleName];


### PR DESCRIPTION
- feat(`require-yields`): add new rule to check that `yield` has documentation; for #354
- feat(`require-yields`): add options to check that `next` has documentation

Note that Gajus approved the rule concept in the referenced issue.

(Btw, your earlier refactoring on `hasReturnValue`, @golopot , also helped inspire a more minimal version of what was needed for `hasYieldValue`.)