### PR TITLE
Require yields check

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -532,4 +532,5 @@ selector).
 {"gitdown": "include", "file": "./rules/require-returns.md"}
 {"gitdown": "include", "file": "./rules/require-throws.md"}
 {"gitdown": "include", "file": "./rules/require-yields.md"}
+{"gitdown": "include", "file": "./rules/require-yields-check.md"}
 {"gitdown": "include", "file": "./rules/valid-types.md"}

--- a/.README/rules/require-yields-check.md
+++ b/.README/rules/require-yields-check.md
@@ -1,0 +1,44 @@
+### `require-yields-check`
+
+Ensures that if a `@yields` is present that a `yield` (or `yield` with a
+value) is present in the function body (or that if a `@next` is present that
+there is a `yield` with a return value present).
+
+Please also note that JavaScript does allow generators not to have `yield`
+(e.g., with just a return or even no explicit return), but if you want to
+enforce that all generators (except wholly empty ones) have a `yield` in the
+function body, you can use the ESLint
+[`require-yield`](https://eslint.org/docs/rules/require-yield) rule. In
+conjunction with this, you can also use the `checkGeneratorsOnly` option
+as an optimization so that this rule won't need to do its own checking within
+function bodies.
+
+Will also report if multiple `@yields` tags are present.
+
+#### Options
+
+- `checkGeneratorsOnly` - Avoids checking the function body and merely insists
+    that all generators have `@yields`. This can be an optimization with the
+    ESLint `require-yield` rule, as that rule already ensures a `yield` is
+    present in generators, albeit assuming the generator is not empty).
+    Defaults to `false`.
+- `next` - If `true`, this option will insist that any use of a (non-standard)
+    `@next` tag (in addition to any `@yields` tag) will be matched by a `yield`
+    which uses a return value in the body of the generator (e.g.,
+    `const rv = yield;` or `const rv = yield value;`). This (non-standard)
+    tag is intended to be used to indicate a type and/or description of
+    the value expected to be supplied by the user when supplied to the iterator
+    by its `next` method, as with `it.next(value)` (with the iterator being
+    the `Generator` iterator that is returned by the call to the generator
+    function). This option will report an error if the generator function body
+    merely has plain `yield;` or `yield value;` statements without returning
+    the values. Defaults to `false`.
+
+|||
+|---|---|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Tags|`yields`|
+|Aliases|`yield`|
+|Recommended|true|
+|Options|`checkGeneratorsOnly`|
+<!-- assertions requireYieldsCheck -->

--- a/.README/rules/require-yields.md
+++ b/.README/rules/require-yields.md
@@ -7,17 +7,6 @@ Will also report if multiple `@yields` tags are present.
 See the `next`, `forceRequireNext`, and `nextWithGeneratorTag` options for an
 option to expect a non-standard `@next` tag.
 
-Note that there is currently no `yield` equivalent to the
-`require-returns-check` rule to ensure that if a `@yields` is present that a
-`yield` (or `yield` with a value) is present in the function body (or that if
-a `@next` is present that there is a `yield` with a return value present).
-
-Please also note that JavaScript does allow generators not to have `yield`
-(e.g., with just a return or even no explicit return), but if you want to
-enforce that all generators have a `yield` in the function body, you can
-use the ESLint
-[`require-yield`](https://eslint.org/docs/rules/require-yield) rule.
-
 #### Options
 
 - `exemptedBy` - Array of tags (e.g., `['type']`) whose presence on the

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ JSDoc linting rules for ESLint.
         * [`require-returns`](#eslint-plugin-jsdoc-rules-require-returns)
         * [`require-throws`](#eslint-plugin-jsdoc-rules-require-throws)
         * [`require-yields`](#eslint-plugin-jsdoc-rules-require-yields)
+        * [`require-yields-check`](#eslint-plugin-jsdoc-rules-require-yields-check)
         * [`valid-types`](#eslint-plugin-jsdoc-rules-valid-types)
 
 
@@ -15899,6 +15900,497 @@ function * quux () {
 ````
 
 
+<a name="eslint-plugin-jsdoc-rules-require-yields-check"></a>
+### <code>require-yields-check</code>
+
+Ensures that if a `@yields` is present that a `yield` (or `yield` with a
+value) is present in the function body (or that if a `@next` is present that
+there is a `yield` with a return value present).
+
+Please also note that JavaScript does allow generators not to have `yield`
+(e.g., with just a return or even no explicit return), but if you want to
+enforce that all generators (except wholly empty ones) have a `yield` in the
+function body, you can use the ESLint
+[`require-yield`](https://eslint.org/docs/rules/require-yield) rule. In
+conjunction with this, you can also use the `checkGeneratorsOnly` option
+as an optimization so that this rule won't need to do its own checking within
+function bodies.
+
+Will also report if multiple `@yields` tags are present.
+
+<a name="eslint-plugin-jsdoc-rules-require-yields-check-options-32"></a>
+#### Options
+
+- `checkGeneratorsOnly` - Avoids checking the function body and merely insists
+    that all generators have `@yields`. This can be an optimization with the
+    ESLint `require-yield` rule, as that rule already ensures a `yield` is
+    present in generators, albeit assuming the generator is not empty).
+    Defaults to `false`.
+- `next` - If `true`, this option will insist that any use of a (non-standard)
+    `@next` tag (in addition to any `@yields` tag) will be matched by a `yield`
+    which uses a return value in the body of the generator (e.g.,
+    `const rv = yield;` or `const rv = yield value;`). This (non-standard)
+    tag is intended to be used to indicate a type and/or description of
+    the value expected to be supplied by the user when supplied to the iterator
+    by its `next` method, as with `it.next(value)` (with the iterator being
+    the `Generator` iterator that is returned by the call to the generator
+    function). This option will report an error if the generator function body
+    merely has plain `yield;` or `yield value;` statements without returning
+    the values. Defaults to `false`.
+
+|||
+|---|---|
+|Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
+|Tags|`yields`|
+|Aliases|`yield`|
+|Recommended|true|
+|Options|`checkGeneratorsOnly`|
+The following patterns are considered problems:
+
+````js
+/**
+ * @yields
+ */
+function * quux (foo) {
+
+}
+// Message: JSDoc @yields declaration present but yield expression not available in function.
+
+/**
+ * @yields
+ */
+function quux (foo) {
+
+}
+// Options: [{"checkGeneratorsOnly":true}]
+// Message: JSDoc @yields declaration present but yield expression not available in function.
+
+/**
+ * @next
+ */
+function quux (foo) {
+
+}
+// Options: [{"checkGeneratorsOnly":true,"next":true}]
+// Message: JSDoc @next declaration present but yield expression with return value not available in function.
+
+/**
+ * @next {SomeType}
+ */
+function * quux (foo) {
+
+}
+// Options: [{"next":true}]
+// Message: JSDoc @next declaration present but yield expression with return value not available in function.
+
+/**
+ * @next {SomeType}
+ */
+function * quux (foo) {
+  yield;
+}
+// Options: [{"next":true}]
+// Message: JSDoc @next declaration present but yield expression with return value not available in function.
+
+/**
+ * @next {SomeType}
+ */
+function * quux (foo) {
+  yield 5;
+}
+// Options: [{"next":true}]
+// Message: JSDoc @next declaration present but yield expression with return value not available in function.
+
+/**
+ * @yield
+ */
+function * quux (foo) {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"yields":"yield"}}}
+// Message: JSDoc @yield declaration present but yield expression not available in function.
+
+/**
+ * @yield-returns {Something}
+ */
+function * quux (foo) {
+  yield;
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"next":"yield-returns"}}}
+// Options: [{"next":true}]
+// Message: JSDoc @yield-returns declaration present but yield expression with return value not available in function.
+
+/**
+ * @yields {undefined} Foo.
+ * @yields {String} Foo.
+ */
+function * quux () {
+
+  yield foo;
+}
+// Message: Found more than one @yields declaration.
+
+class Foo {
+  /**
+   * @yields {string}
+   */
+  * bar () {
+  }
+}
+// Message: JSDoc @yields declaration present but yield expression not available in function.
+
+/**
+ * @yields
+ */
+function * quux () {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"yields":false}}}
+// Message: Unexpected tag `@yields`
+
+/**
+ * @next
+ */
+function * quux () {
+
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"next":false}}}
+// Options: [{"next":true}]
+// Message: Unexpected tag `@next`
+
+/**
+ * @yields {string}
+ */
+function * f () {
+  function * g() {
+    yield 'foo'
+  }
+}
+// Message: JSDoc @yields declaration present but yield expression not available in function.
+
+/**
+ * @yields {Promise<void>}
+ */
+async function * quux() {}
+// Message: JSDoc @yields declaration present but yield expression not available in function.
+
+/**
+ * @yields {Promise<void>}
+ */
+const quux = async function * () {}
+// Message: JSDoc @yields declaration present but yield expression not available in function.
+````
+
+The following patterns are not considered problems:
+
+````js
+/**
+ * @yields Foo.
+ */
+function * quux () {
+
+  yield foo;
+}
+
+/**
+ * @yields {string} Foo.
+ */
+function * quux () {
+
+  yield foo;
+}
+
+/**
+ * @yields {string} Foo.
+ */
+function * quux () {
+
+  yield foo;
+}
+
+/**
+ *
+ */
+function * quux () {
+}
+
+/**
+ * @yields {undefined} Foo.
+ */
+function * quux () {}
+
+/**
+ * @yields { void } Foo.
+ */
+function quux () {}
+
+/**
+ * @yields Foo.
+ * @abstract
+ */
+function * quux () {
+  throw new Error('must be implemented by subclass!');
+}
+
+/**
+ * @yields Foo.
+ * @virtual
+ */
+function * quux () {
+  throw new Error('must be implemented by subclass!');
+}
+
+/**
+ * @yields Foo.
+ * @constructor
+ */
+function * quux () {
+}
+
+/**
+ * @interface
+ */
+class Foo {
+  /**
+   * @yields {string}
+   */
+  * bar () {
+  }
+}
+
+/**
+ * @record
+ */
+class Foo {
+  /**
+   * @yields {string}
+   */
+  * bar () {
+  }
+}
+// Settings: {"jsdoc":{"mode":"closure"}}
+
+/**
+ * @yields {undefined} Foo.
+ */
+function * quux () {
+}
+
+/**
+ * @yields {void} Foo.
+ */
+function * quux () {
+}
+
+/**
+ * @yields {void} Foo.
+ */
+function * quux () {
+  yield undefined;
+}
+
+/**
+ * @yields {void} Foo.
+ */
+function * quux () {
+  yield;
+}
+
+/**
+ *
+ */
+function * quux () {
+  yield undefined;
+}
+
+/**
+ *
+ */
+function * quux () {
+  yield;
+}
+
+/**
+ * @yields {true}
+ */
+function * quux () {
+  try {
+    yield true;
+  } catch (err) {
+  }
+  yield;
+}
+
+/**
+ * @yields {true}
+ */
+function * quux () {
+  try {
+  } finally {
+    yield true;
+  }
+  yield;
+}
+
+/**
+ * @yields {true}
+ */
+function * quux () {
+  try {
+    yield;
+  } catch (err) {
+  }
+  yield true;
+}
+
+/**
+ * @yields {true}
+ */
+function * quux () {
+  try {
+    something();
+  } catch (err) {
+    yield true;
+  }
+  yield;
+}
+
+/**
+ * @yields {true}
+ */
+function * quux () {
+  switch (true) {
+  case 'abc':
+    yield true;
+  }
+  yield;
+}
+
+/**
+ * @yields {true}
+ */
+function * quux () {
+  switch (true) {
+  case 'abc':
+    yield;
+  }
+  yield true;
+}
+
+/**
+ * @yields {true}
+ */
+function * quux () {
+  for (const i of abc) {
+    yield true;
+  }
+  yield;
+}
+
+/**
+ * @yields {true}
+ */
+function * quux () {
+  for (const a in b) {
+    yield true;
+  }
+}
+
+/**
+ * @yields {true}
+ */
+function * quux () {
+  for (let i=0; i<n; i+=1) {
+    yield true;
+  }
+}
+
+/**
+ * @yields {true}
+ */
+function * quux () {
+  while(true) {
+    yield true
+  }
+}
+
+/**
+ * @yields {true}
+ */
+function * quux () {
+  do {
+    yield true
+  }
+  while(true)
+}
+
+/**
+ * @yields {true}
+ */
+function * quux () {
+  if (true) {
+    yield;
+  }
+  yield true;
+}
+
+/**
+ * @yields {true}
+ */
+function * quux () {
+  if (true) {
+    yield true;
+  }
+}
+
+/**
+ * @yields {true}
+ */
+function * quux () {
+  var a = {};
+  with (a) {
+    yield true;
+  }
+}
+
+/**
+ * @yields {true}
+ */
+function * quux () {
+  if (true) {
+    yield;
+  } else {
+    yield true;
+  }
+  yield;
+}
+
+/**
+ * @next {void}
+ */
+function * quux (foo) {
+
+}
+// Options: [{"next":true}]
+
+/**
+ * @next {SomeType}
+ */
+function * quux (foo) {
+  const a = yield;
+}
+// Options: [{"next":true}]
+
+/**
+ * @next {SomeType}
+ */
+function * quux (foo) {
+  const a = yield 5;
+}
+// Options: [{"next":true}]
+````
+
+
 <a name="eslint-plugin-jsdoc-rules-valid-types"></a>
 ### <code>valid-types</code>
 
@@ -15979,7 +16471,7 @@ for valid types (based on the tag's `type` value), and either portion checked
 for presence (based on `false` `name` or `type` values or their `required`
 value). See the setting for more details.
 
-<a name="eslint-plugin-jsdoc-rules-valid-types-options-32"></a>
+<a name="eslint-plugin-jsdoc-rules-valid-types-options-33"></a>
 #### Options
 
 - `allowEmptyNamepaths` (default: true) - Set to `false` to bulk disallow

--- a/README.md
+++ b/README.md
@@ -15117,17 +15117,6 @@ Will also report if multiple `@yields` tags are present.
 See the `next`, `forceRequireNext`, and `nextWithGeneratorTag` options for an
 option to expect a non-standard `@next` tag.
 
-Note that there is currently no `yield` equivalent to the
-`require-returns-check` rule to ensure that if a `@yields` is present that a
-`yield` (or `yield` with a value) is present in the function body (or that if
-a `@next` is present that there is a `yield` with a return value present).
-
-Please also note that JavaScript does allow generators not to have `yield`
-(e.g., with just a return or even no explicit return), but if you want to
-enforce that all generators have a `yield` in the function body, you can
-use the ESLint
-[`require-yield`](https://eslint.org/docs/rules/require-yield) rule.
-
 <a name="eslint-plugin-jsdoc-rules-require-yields-options-31"></a>
 #### Options
 

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ import requireReturnsDescription from './rules/requireReturnsDescription';
 import requireReturnsType from './rules/requireReturnsType';
 import requireThrows from './rules/requireThrows';
 import requireYields from './rules/requireYields';
+import requireYieldsCheck from './rules/requireYieldsCheck';
 import validTypes from './rules/validTypes';
 
 export default {
@@ -82,6 +83,7 @@ export default {
         'jsdoc/require-returns-description': 'warn',
         'jsdoc/require-returns-type': 'warn',
         'jsdoc/require-yields': 'warn',
+        'jsdoc/require-yields-Check': 'warn',
         'jsdoc/valid-types': 'warn',
       },
     },
@@ -126,6 +128,7 @@ export default {
     'require-returns-type': requireReturnsType,
     'require-throws': requireThrows,
     'require-yields': requireYields,
+    'require-yields-check': requireYieldsCheck,
     'valid-types': validTypes,
   },
 };

--- a/src/rules/requireYieldsCheck.js
+++ b/src/rules/requireYieldsCheck.js
@@ -1,0 +1,141 @@
+import iterateJsdoc from '../iterateJsdoc';
+
+const canSkip = (utils, settings) => {
+  const voidingTags = [
+    // An abstract function is by definition incomplete
+    // so it is perfectly fine if a yield is documented but
+    // not present within the function.
+    // A subclass may inherit the doc and implement the
+    // missing yield.
+    'abstract',
+    'virtual',
+
+    // Constructor functions do not have a yield value
+    //  so we can bail here, too.
+    'class',
+    'constructor',
+
+    // This seems to imply a class as well
+    'interface',
+  ];
+
+  if (settings.mode === 'closure') {
+    // Structural Interface in GCC terms, equivalent to @interface tag as far as this rule is concerned
+    voidingTags.push('record');
+  }
+
+  return utils.hasATag(voidingTags) ||
+    utils.isConstructor() ||
+    utils.classHasTag('interface') ||
+    settings.mode === 'closure' && utils.classHasTag('record');
+};
+
+const checkTagName = (utils, report, tagName) => {
+  const preferredTagName = utils.getPreferredTagName({tagName});
+  if (!preferredTagName) {
+    return [];
+  }
+
+  const tags = utils.getTags(preferredTagName);
+
+  if (tags.length === 0) {
+    return [];
+  }
+
+  if (tags.length > 1) {
+    report(`Found more than one @${preferredTagName} declaration.`);
+
+    return [];
+  }
+
+  return [preferredTagName, tags[0]];
+};
+
+export default iterateJsdoc(({
+  context,
+  report,
+  settings,
+  utils,
+}) => {
+  if (canSkip(utils, settings)) {
+    return;
+  }
+
+  const {
+    next = false,
+    checkGeneratorsOnly = false,
+  } = context.options[0] || {};
+
+  const [preferredYieldTagName, yieldTag] = checkTagName(
+    utils, report, 'yields',
+  );
+  if (preferredYieldTagName) {
+    const shouldReportYields = () => {
+      if (checkGeneratorsOnly && !utils.isGenerator()) {
+        return true;
+      }
+
+      return utils.hasDefinedTypeTag(yieldTag) && !utils.hasYieldValue();
+    };
+
+    // In case a yield value is declared in JSDoc, we also expect one in the code.
+    if (shouldReportYields()) {
+      report(`JSDoc @${preferredYieldTagName} declaration present but yield expression not available in function.`);
+    }
+  }
+
+  if (next) {
+    const [preferredNextTagName, nextTag] = checkTagName(
+      utils, report, 'next',
+    );
+    if (preferredNextTagName) {
+      const shouldReportNext = () => {
+        if (checkGeneratorsOnly && !utils.isGenerator()) {
+          return true;
+        }
+
+        return utils.hasDefinedTypeTag(nextTag) && !utils.hasYieldReturnValue();
+      };
+
+      if (shouldReportNext()) {
+        report(`JSDoc @${preferredNextTagName} declaration present but yield expression with return value not available in function.`);
+      }
+    }
+  }
+}, {
+  meta: {
+    docs: {
+      description: 'Requires a yield statement in function body if a `@yields` tag is specified in jsdoc comment.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-yields-check',
+    },
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          checkGeneratorsOnly: {
+            default: false,
+            type: 'boolean',
+          },
+          contexts: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+          exemptedBy: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+          next: {
+            default: false,
+            type: 'boolean',
+          },
+        },
+        type: 'object',
+      },
+    ],
+    type: 'suggestion',
+  },
+});

--- a/test/rules/assertions/requireYieldsCheck.js
+++ b/test/rules/assertions/requireYieldsCheck.js
@@ -1,0 +1,721 @@
+export default {
+  invalid: [
+    {
+      code: `
+          /**
+           * @yields
+           */
+          function * quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'JSDoc @yields declaration present but yield expression not available in function.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @yields
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'JSDoc @yields declaration present but yield expression not available in function.',
+        },
+      ],
+      options: [{
+        checkGeneratorsOnly: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @next
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'JSDoc @next declaration present but yield expression with return value not available in function.',
+        },
+      ],
+      options: [{
+        checkGeneratorsOnly: true,
+        next: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @next {SomeType}
+           */
+          function * quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'JSDoc @next declaration present but yield expression with return value not available in function.',
+        },
+      ],
+      options: [{
+        next: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @next {SomeType}
+           */
+          function * quux (foo) {
+            yield;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'JSDoc @next declaration present but yield expression with return value not available in function.',
+        },
+      ],
+      options: [{
+        next: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @next {SomeType}
+           */
+          function * quux (foo) {
+            yield 5;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'JSDoc @next declaration present but yield expression with return value not available in function.',
+        },
+      ],
+      options: [{
+        next: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @yield
+           */
+          function * quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'JSDoc @yield declaration present but yield expression not available in function.',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            yields: 'yield',
+          },
+        },
+      },
+    },
+    {
+      code: `
+          /**
+           * @yield-returns {Something}
+           */
+          function * quux (foo) {
+            yield;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'JSDoc @yield-returns declaration present but yield expression with return value not available in function.',
+        },
+      ],
+      options: [{
+        next: true,
+      }],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            next: 'yield-returns',
+          },
+        },
+      },
+    },
+    {
+      code: `
+          /**
+           * @yields {undefined} Foo.
+           * @yields {String} Foo.
+           */
+          function * quux () {
+
+            yield foo;
+          }
+        `,
+      errors: [
+        {
+          line: 2,
+          message: 'Found more than one @yields declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          class Foo {
+            /**
+             * @yields {string}
+             */
+            * bar () {
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'JSDoc @yields declaration present but yield expression not available in function.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @yields
+           */
+          function * quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Unexpected tag `@yields`',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            yields: false,
+          },
+        },
+      },
+    },
+    {
+      code: `
+          /**
+           * @next
+           */
+          function * quux () {
+
+          }
+      `,
+      errors: [
+        {
+          message: 'Unexpected tag `@next`',
+        },
+      ],
+      options: [{
+        next: true,
+      }],
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            next: false,
+          },
+        },
+      },
+    },
+    {
+      code: `
+        /**
+         * @yields {string}
+         */
+        function * f () {
+          function * g() {
+            yield 'foo'
+          }
+        }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'JSDoc @yields declaration present but yield expression not available in function.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @yields {Promise<void>}
+           */
+          async function * quux() {}
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'JSDoc @yields declaration present but yield expression not available in function.',
+        },
+      ],
+      parserOptions: {
+        ecmaVersion: 2_018,
+      },
+    },
+    {
+      code: `
+          /**
+           * @yields {Promise<void>}
+           */
+          const quux = async function * () {}
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'JSDoc @yields declaration present but yield expression not available in function.',
+        },
+      ],
+      parserOptions: {
+        ecmaVersion: 2_018,
+      },
+    },
+  ],
+  valid: [
+    {
+      code: `
+          /**
+           * @yields Foo.
+           */
+          function * quux () {
+
+            yield foo;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {string} Foo.
+           */
+          function * quux () {
+
+            yield foo;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {string} Foo.
+           */
+          function * quux () {
+
+            yield foo;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {undefined} Foo.
+           */
+          function * quux () {}
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields { void } Foo.
+           */
+          function quux () {}
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields Foo.
+           * @abstract
+           */
+          function * quux () {
+            throw new Error('must be implemented by subclass!');
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields Foo.
+           * @virtual
+           */
+          function * quux () {
+            throw new Error('must be implemented by subclass!');
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields Foo.
+           * @constructor
+           */
+          function * quux () {
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @interface
+           */
+          class Foo {
+            /**
+             * @yields {string}
+             */
+            * bar () {
+            }
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @record
+           */
+          class Foo {
+            /**
+             * @yields {string}
+             */
+            * bar () {
+            }
+          }
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'closure',
+        },
+      },
+    },
+    {
+      code: `
+          /**
+           * @yields {undefined} Foo.
+           */
+          function * quux () {
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {void} Foo.
+           */
+          function * quux () {
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {void} Foo.
+           */
+          function * quux () {
+            yield undefined;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {void} Foo.
+           */
+          function * quux () {
+            yield;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            yield undefined;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            yield;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {true}
+           */
+          function * quux () {
+            try {
+              yield true;
+            } catch (err) {
+            }
+            yield;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {true}
+           */
+          function * quux () {
+            try {
+            } finally {
+              yield true;
+            }
+            yield;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {true}
+           */
+          function * quux () {
+            try {
+              yield;
+            } catch (err) {
+            }
+            yield true;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {true}
+           */
+          function * quux () {
+            try {
+              something();
+            } catch (err) {
+              yield true;
+            }
+            yield;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {true}
+           */
+          function * quux () {
+            switch (true) {
+            case 'abc':
+              yield true;
+            }
+            yield;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {true}
+           */
+          function * quux () {
+            switch (true) {
+            case 'abc':
+              yield;
+            }
+            yield true;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {true}
+           */
+          function * quux () {
+            for (const i of abc) {
+              yield true;
+            }
+            yield;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {true}
+           */
+          function * quux () {
+            for (const a in b) {
+              yield true;
+            }
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {true}
+           */
+          function * quux () {
+            for (let i=0; i<n; i+=1) {
+              yield true;
+            }
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {true}
+           */
+          function * quux () {
+            while(true) {
+              yield true
+            }
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {true}
+           */
+          function * quux () {
+            do {
+              yield true
+            }
+            while(true)
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {true}
+           */
+          function * quux () {
+            if (true) {
+              yield;
+            }
+            yield true;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {true}
+           */
+          function * quux () {
+            if (true) {
+              yield true;
+            }
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {true}
+           */
+          function * quux () {
+            var a = {};
+            with (a) {
+              yield true;
+            }
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @yields {true}
+           */
+          function * quux () {
+            if (true) {
+              yield;
+            } else {
+              yield true;
+            }
+            yield;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @next {void}
+           */
+          function * quux (foo) {
+
+          }
+      `,
+      options: [{
+        next: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @next {SomeType}
+           */
+          function * quux (foo) {
+            const a = yield;
+          }
+      `,
+      options: [{
+        next: true,
+      }],
+    },
+    {
+      code: `
+          /**
+           * @next {SomeType}
+           */
+          function * quux (foo) {
+            const a = yield 5;
+          }
+      `,
+      options: [{
+        next: true,
+      }],
+    },
+  ],
+};

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -46,6 +46,7 @@ const ruleTester = new RuleTester();
   'require-returns-type',
   'require-throws',
   'require-yields',
+  'require-yields-check',
   'valid-types',
 ]).forEach((ruleName) => {
   const rule = config.rules[ruleName];


### PR DESCRIPTION
Builds on #674.

- feat(`require-yields-check`): add rule to check that `yield` (of proper form) is present in the function body; fixes #354
- docs(`require-yields`): remove info intended for `require-yields-check`