### PR TITLE
`require-param` and `check-param-names`: `useDefaultObjectProperties` option

### DIFF
--- a/.README/rules/check-param-names.md
+++ b/.README/rules/check-param-names.md
@@ -57,10 +57,17 @@ their presence within the function signature. Other inconsistencies between
 
 Whether to check destructured properties. Defaults to `true`.
 
+##### `useDefaultObjectProperties`
+
+Set to `true` if you wish to avoid reporting of child property documentation
+where instead of destructuring, a whole plain object is supplied as default
+value but you wish its keys to be considered as signalling that the properties
+are present and can therefore be documented. Defaults to `false`.
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
-|Options|`allowExtraTrailingParamDocs`, `checkDestructured`, `checkRestProperty`, `checkTypesPattern`|
+|Options|`allowExtraTrailingParamDocs`, `checkDestructured`, `checkRestProperty`, `checkTypesPattern`, `useDefaultObjectProperties`|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
 |Recommended|true|

--- a/.README/rules/require-param.md
+++ b/.README/rules/require-param.md
@@ -359,13 +359,18 @@ implied to be `false` (i.e., the inside of the roots will not be checked
 either, e.g., it will also not complain if `a` or `b` do not have their own
 documentation). Defaults to `true`.
 
-|          |                                                                                                               |
-| -------- | ------------------------------------------------------------------------------------------------------------- |
+##### `useDefaultObjectProperties`
+
+Set to `true` if you wish to expect documentation of properties on objects
+supplied as default values. Defaults to `false`.
+
+|          |                      |
+| -------- | ----------------------------------------------------------------------------- |
 | Context  | `ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled |
-| Tags     | `param`                                                                                                       |
-| Aliases  | `arg`, `argument`                                                                                             |
-|Recommended|true|
-| Options  | `autoIncrementBase`, `checkDestructured`, `checkDestructuredRoots`, `contexts`, `enableFixer`, `enableRootFixer`, `enableRestElementFixer`, `checkRestProperty`, `exemptedBy`, `checkConstructors`, `checkGetters`, `checkSetters`, `checkTypesPattern`, `unnamedRootBase`                                 |
-| Settings | `overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`                               |
+| Tags     | `param` |
+| Aliases  | `arg`, `argument` |
+|Recommended | true|
+| Options  | `autoIncrementBase`, `checkDestructured`, `checkDestructuredRoots`, `contexts`, `enableFixer`, `enableRootFixer`, `enableRestElementFixer`, `checkRestProperty`, `exemptedBy`, `checkConstructors`, `checkGetters`, `checkSetters`, `checkTypesPattern`, `unnamedRootBase`, `useDefaultObjectProperties`|
+| Settings | `overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`|
 
 <!-- assertions requireParam -->

--- a/README.md
+++ b/README.md
@@ -2266,10 +2266,18 @@ their presence within the function signature. Other inconsistencies between
 
 Whether to check destructured properties. Defaults to `true`.
 
+<a name="eslint-plugin-jsdoc-rules-check-param-names-options-4-usedefaultobjectproperties"></a>
+##### <code>useDefaultObjectProperties</code>
+
+Set to `true` if you wish to avoid reporting of child property documentation
+where instead of destructuring, a whole plain object is supplied as default
+value but you wish its keys to be considered as signalling that the properties
+are present and can therefore be documented. Defaults to `false`.
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
-|Options|`allowExtraTrailingParamDocs`, `checkDestructured`, `checkRestProperty`, `checkTypesPattern`|
+|Options|`allowExtraTrailingParamDocs`, `checkDestructured`, `checkRestProperty`, `checkTypesPattern`, `useDefaultObjectProperties`|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
 |Recommended|true|
@@ -2664,6 +2672,19 @@ function quux ({ foo: { bar } }) {}
  */
 function foo({ foo: { bar: { baz } }}) {}
 // Message: Missing @param "options.foo.bar.baz"
+
+/**
+* Returns a number.
+* @param {Object} props Props.
+* @param {Object} props.prop Prop.
+* @param {string} props.prop.a String.
+* @param {string} props.prop.b String.
+* @return {number} A number.
+*/
+export function testFn1 ({ prop = { a: 1, b: 2 } }) {
+}
+// Options: [{"useDefaultObjectProperties":false}]
+// Message: @param "props.prop.a" does not exist on props
 ````
 
 The following patterns are not considered problems:
@@ -2995,6 +3016,18 @@ function Item({
   defaulting: [quux, xyz] = []
 }) {
 }
+
+/**
+* Returns a number.
+* @param {Object} props Props.
+* @param {Object} props.prop Prop.
+* @param {string} props.prop.a String.
+* @param {string} props.prop.b String.
+* @return {number} A number.
+*/
+export function testFn1 ({ prop = { a: 1, b: 2 } }) {
+}
+// Options: [{"useDefaultObjectProperties":true}]
 ````
 
 
@@ -11930,14 +11963,20 @@ implied to be `false` (i.e., the inside of the roots will not be checked
 either, e.g., it will also not complain if `a` or `b` do not have their own
 documentation). Defaults to `true`.
 
-|          |                                                                                                               |
-| -------- | ------------------------------------------------------------------------------------------------------------- |
+<a name="eslint-plugin-jsdoc-rules-require-param-options-26-usedefaultobjectproperties-1"></a>
+##### <code>useDefaultObjectProperties</code>
+
+Set to `true` if you wish to expect documentation of properties on objects
+supplied as default values. Defaults to `false`.
+
+|          |                      |
+| -------- | ----------------------------------------------------------------------------- |
 | Context  | `ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled |
-| Tags     | `param`                                                                                                       |
-| Aliases  | `arg`, `argument`                                                                                             |
-|Recommended|true|
-| Options  | `autoIncrementBase`, `checkDestructured`, `checkDestructuredRoots`, `contexts`, `enableFixer`, `enableRootFixer`, `enableRestElementFixer`, `checkRestProperty`, `exemptedBy`, `checkConstructors`, `checkGetters`, `checkSetters`, `checkTypesPattern`, `unnamedRootBase`                                 |
-| Settings | `overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`                               |
+| Tags     | `param` |
+| Aliases  | `arg`, `argument` |
+|Recommended | true|
+| Options  | `autoIncrementBase`, `checkDestructured`, `checkDestructuredRoots`, `contexts`, `enableFixer`, `enableRootFixer`, `enableRestElementFixer`, `checkRestProperty`, `exemptedBy`, `checkConstructors`, `checkGetters`, `checkSetters`, `checkTypesPattern`, `unnamedRootBase`, `useDefaultObjectProperties`|
+| Settings | `overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs`|
 
 The following patterns are considered problems:
 
@@ -12582,6 +12621,17 @@ function quux ({ foo: { bar } }) {}
  */
 function foo({ foo: { bar: { baz } }}) {}
 // Message: Missing JSDoc @param "options.foo.bar.baz" declaration.
+
+/**
+* Returns a number.
+* @param {Object} props Props.
+* @param {Object} props.prop Prop.
+* @return {number} A number.
+*/
+export function testFn1 ({ prop = { a: 1, b: 2 } }) {
+}
+// Options: [{"useDefaultObjectProperties":true}]
+// Message: Missing JSDoc @param "props.prop.a" declaration.
 ````
 
 The following patterns are not considered problems:
@@ -13195,6 +13245,16 @@ function Item({
   defaulting: [quux, xyz] = []
 }) {
 }
+
+/**
+* Returns a number.
+* @param {Object} props Props.
+* @param {Object} props.prop Prop.
+* @return {number} A number.
+*/
+export function testFn1 ({ prop = { a: 1, b: 2 } }) {
+}
+// Options: [{"useDefaultObjectProperties":false}]
 ````
 
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -299,8 +299,8 @@ const getUtils = (
     return jsdocUtils.flattenRoots(params);
   };
 
-  utils.getFunctionParameterNames = () => {
-    return jsdocUtils.getFunctionParameterNames(node);
+  utils.getFunctionParameterNames = (useDefaultObjectProperties) => {
+    return jsdocUtils.getFunctionParameterNames(node, useDefaultObjectProperties);
   };
 
   utils.hasParams = () => {

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -108,7 +108,9 @@ const validateParameterNames = (
       if (!hasPropertyRest || checkRestProperty) {
         actualNames.forEach((name, idx) => {
           const match = name.startsWith(tag.name.trim() + '.');
-          if (match && !expectedNames.some(utils.comparePaths(name)) && !utils.comparePaths(name)(tag.name)) {
+          if (match && !expectedNames.some(
+            utils.comparePaths(name),
+          ) && !utils.comparePaths(name)(tag.name)) {
             extraProperties.push([name, paramTags[idx][1]]);
           }
         });
@@ -219,6 +221,7 @@ export default iterateJsdoc(({
     checkRestProperty = false,
     checkTypesPattern = '/^(?:[oO]bject|[aA]rray|PlainObject|Generic(?:Object|Array))$/',
     enableFixer = false,
+    useDefaultObjectProperties = false,
   } = context.options[0] || {};
 
   const lastSlashPos = checkTypesPattern.lastIndexOf('/');
@@ -230,7 +233,7 @@ export default iterateJsdoc(({
   if (!jsdocParameterNamesDeep.length) {
     return;
   }
-  const functionParameterNames = utils.getFunctionParameterNames();
+  const functionParameterNames = utils.getFunctionParameterNames(useDefaultObjectProperties);
   const targetTagName = utils.getPreferredTagName({tagName: 'param'});
   const isError = validateParameterNames(
     targetTagName,
@@ -276,6 +279,9 @@ export default iterateJsdoc(({
             type: 'string',
           },
           enableFixer: {
+            type: 'boolean',
+          },
+          useDefaultObjectProperties: {
             type: 'boolean',
           },
         },

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -24,7 +24,6 @@ export default iterateJsdoc(({
   utils,
   context,
 }) => {
-  const functionParameterNames = utils.getFunctionParameterNames();
   const preferredTagName = utils.getPreferredTagName({tagName: 'param'});
   if (!preferredTagName) {
     return;
@@ -57,6 +56,7 @@ export default iterateJsdoc(({
     enableRootFixer = true,
     enableRestElementFixer = true,
     unnamedRootBase = ['root'],
+    useDefaultObjectProperties = false,
   } = context.options[0] || {};
 
   const lastSlashPos = checkTypesPattern.lastIndexOf('/');
@@ -65,6 +65,7 @@ export default iterateJsdoc(({
     new RegExp(checkTypesPattern.slice(1, lastSlashPos), checkTypesPattern.slice(lastSlashPos + 1));
 
   const missingTags = [];
+  const functionParameterNames = utils.getFunctionParameterNames(useDefaultObjectProperties);
   const flattenedRoots = utils.flattenRoots(functionParameterNames).names;
 
   const paramIndex = {};
@@ -371,6 +372,9 @@ export default iterateJsdoc(({
               type: 'string',
             },
             type: 'array',
+          },
+          useDefaultObjectProperties: {
+            type: 'boolean',
           },
         },
         type: 'object',

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -943,6 +943,34 @@ export default {
         },
       ],
     },
+    {
+      code: `
+      /**
+      * Returns a number.
+      * @param {Object} props Props.
+      * @param {Object} props.prop Prop.
+      * @param {string} props.prop.a String.
+      * @param {string} props.prop.b String.
+      * @return {number} A number.
+      */
+      export function testFn1 ({ prop = { a: 1, b: 2 } }) {
+      }
+      `,
+      errors: [
+        {
+          message: '@param "props.prop.a" does not exist on props',
+        },
+        {
+          message: '@param "props.prop.b" does not exist on props',
+        },
+      ],
+      options: [{
+        useDefaultObjectProperties: false,
+      }],
+      parserOptions: {
+        sourceType: 'module',
+      },
+    },
   ],
   valid: [
     {
@@ -1422,6 +1450,26 @@ export default {
       }) {
       }
       `,
+    },
+    {
+      code: `
+      /**
+      * Returns a number.
+      * @param {Object} props Props.
+      * @param {Object} props.prop Prop.
+      * @param {string} props.prop.a String.
+      * @param {string} props.prop.b String.
+      * @return {number} A number.
+      */
+      export function testFn1 ({ prop = { a: 1, b: 2 } }) {
+      }
+      `,
+      options: [{
+        useDefaultObjectProperties: true,
+      }],
+      parserOptions: {
+        sourceType: 'module',
+      },
     },
   ],
 };

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -2118,6 +2118,44 @@ export default {
       function foo({ foo: { bar: { baz } }}) {}
       `,
     },
+    {
+      code: `
+      /**
+      * Returns a number.
+      * @param {Object} props Props.
+      * @param {Object} props.prop Prop.
+      * @return {number} A number.
+      */
+      export function testFn1 ({ prop = { a: 1, b: 2 } }) {
+      }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "props.prop.a" declaration.',
+        },
+        {
+          message: 'Missing JSDoc @param "props.prop.b" declaration.',
+        },
+      ],
+      options: [{
+        useDefaultObjectProperties: true,
+      }],
+      output: `
+      /**
+      * Returns a number.
+      * @param {Object} props Props.
+      * @param {Object} props.prop Prop.
+      * @param props.prop.a
+      * @param props.prop.b
+      * @return {number} A number.
+      */
+      export function testFn1 ({ prop = { a: 1, b: 2 } }) {
+      }
+      `,
+      parserOptions: {
+        sourceType: 'module',
+      },
+    },
   ],
   valid: [
     {
@@ -3043,6 +3081,24 @@ export default {
       }) {
       }
       `,
+    },
+    {
+      code: `
+      /**
+      * Returns a number.
+      * @param {Object} props Props.
+      * @param {Object} props.prop Prop.
+      * @return {number} A number.
+      */
+      export function testFn1 ({ prop = { a: 1, b: 2 } }) {
+      }
+      `,
+      options: [{
+        useDefaultObjectProperties: false,
+      }],
+      parserOptions: {
+        sourceType: 'module',
+      },
     },
   ],
 };


### PR DESCRIPTION
fix(`require-param`, `check-param-names`): add option `useDefaultObjectProperties` for expecting documentation or avoiding reporting of documented; addresses part of #676