### PR TITLE
feat(`check-line-alignment`): `tags` option

### DIFF
--- a/.README/rules/check-line-alignment.md
+++ b/.README/rules/check-line-alignment.md
@@ -11,11 +11,19 @@ problem is raised when the lines are not aligned. If it is `"never"` then
 a problem should be raised when there is more than one space between each
 line's parts. Defaults to `"never"`.
 
+After the string, an options object is allowed with the following properties.
+
+##### `tags`
+
+Use this to change the tags which are sought for alignment. Defaults to an
+array of
+`['param', 'arg', 'argument', 'property', 'prop', 'returns', 'return']`.
+
 |||
 |---|---|
 |Context|everywhere|
-|Options|(a string matching `"always"|"never"`)|
-|Tags|`param`, `property`, `returns`|
+|Options|(a string matching `"always"|"never"` and optional object with `tags`)|
+|Tags|`param`, `property`, `returns` and others added by `tags`|
 |Aliases|`arg`, `argument`, `prop`, `return`|
 |Recommended|false|
 

--- a/README.md
+++ b/README.md
@@ -2125,6 +2125,18 @@ const fn = ( lorem, sit ) => {}
  function quux () {}
 // Options: ["never",{"tags":["param","return"]}]
 // Message: Expected JSDoc block lines to not be aligned.
+
+/**
+ * Returns the value stored in the process.env for a given
+ * environment variable.
+ *
+ * @param  {string} withPercents    '%USERNAME%'
+ * @param  {string} withoutPercents 'USERNAME'
+ * @return {string}                 'bob' || '%USERNAME%'
+ */
+function quux () {}
+// Options: ["never"]
+// Message: Expected JSDoc block lines to not be aligned.
 ````
 
 The following patterns are not considered problems:

--- a/README.md
+++ b/README.md
@@ -1875,11 +1875,20 @@ problem is raised when the lines are not aligned. If it is `"never"` then
 a problem should be raised when there is more than one space between each
 line's parts. Defaults to `"never"`.
 
+After the string, an options object is allowed with the following properties.
+
+<a name="eslint-plugin-jsdoc-rules-check-line-alignment-options-3-tags"></a>
+##### <code>tags</code>
+
+Use this to change the tags which are sought for alignment. Defaults to an
+array of
+`['param', 'arg', 'argument', 'property', 'prop', 'returns', 'return']`.
+
 |||
 |---|---|
 |Context|everywhere|
-|Options|(a string matching `"always"|"never"`)|
-|Tags|`param`, `property`, `returns`|
+|Options|(a string matching `"always"|"never"` and optional object with `tags`)|
+|Tags|`param`, `property`, `returns` and others added by `tags`|
 |Aliases|`arg`, `argument`, `prop`, `return`|
 |Recommended|false|
 
@@ -2105,6 +2114,17 @@ const fn = ( lorem, sit ) => {}
  function quux () {}
 // Options: ["never"]
 // Message: Expected JSDoc block lines to not be aligned.
+
+/**
+ * Creates OS based shortcuts for files, folders, and applications.
+ *
+ * @param {object} options Options object for each OS.
+ * @param {object} other Other.
+ * @return  True = success, false = failed to create the icon
+ */
+ function quux () {}
+// Options: ["never",{"tags":["param","return"]}]
+// Message: Expected JSDoc block lines to not be aligned.
 ````
 
 The following patterns are not considered problems:
@@ -2244,6 +2264,16 @@ const fn = ( lorem, sit ) => {}
  * @return {boolean} True = success, false = failed to create the icon
  */
 function quux (options) {}
+
+/**
+ * Creates OS based shortcuts for files, folders, and applications.
+ *
+ * @param {object} options Options object for each OS.
+ * @param {object} other Other.
+ * @return  True = success, false = failed to create the icon
+ */
+ function quux () {}
+// Options: ["never",{"tags":["param"]}]
 ````
 
 
@@ -5525,7 +5555,7 @@ Similarly, `@internal` will still be checked for content by this rule even with
 <a name="eslint-plugin-jsdoc-rules-empty-tags-options-9"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-empty-tags-options-9-tags"></a>
+<a name="eslint-plugin-jsdoc-rules-empty-tags-options-9-tags-1"></a>
 ##### <code>tags</code>
 
 If you want additional tags to be checked for their descriptions, you may
@@ -5905,7 +5935,7 @@ You can supply your own expression to override the default, passing a
 As with the default, the supplied regular expression will be applied with the
 Unicode (`"u"`) flag and is *not* case-insensitive.
 
-<a name="eslint-plugin-jsdoc-rules-match-description-options-11-tags-1"></a>
+<a name="eslint-plugin-jsdoc-rules-match-description-options-11-tags-2"></a>
 ##### <code>tags</code>
 
 If you want different regular expressions to apply to tags, you may use
@@ -7891,7 +7921,7 @@ Requires that block description, explicit `@description`, and
 <a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-17"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-17-tags-2"></a>
+<a name="eslint-plugin-jsdoc-rules-require-description-complete-sentence-options-17-tags-3"></a>
 ##### <code>tags</code>
 
 If you want additional tags to be checked for their descriptions, you may
@@ -9375,7 +9405,7 @@ Checks that:
 <a name="eslint-plugin-jsdoc-rules-require-file-overview-options-20"></a>
 #### Options
 
-<a name="eslint-plugin-jsdoc-rules-require-file-overview-options-20-tags-3"></a>
+<a name="eslint-plugin-jsdoc-rules-require-file-overview-options-20-tags-4"></a>
 ##### <code>tags</code>
 
 The keys of this object are tag names, and the values are configuration

--- a/src/rules/checkLineAlignment.js
+++ b/src/rules/checkLineAlignment.js
@@ -3,8 +3,6 @@ import {
 } from 'lodash';
 import iterateJsdoc from '../iterateJsdoc';
 
-const applicableTags = ['param', 'arg', 'argument', 'property', 'prop', 'returns', 'return'];
-
 /**
  * Aux method until we consider the dev envs support `String.prototype.matchAll` (Node 12+).
  *
@@ -189,13 +187,13 @@ const checkNotAlignedPerTag = (utils, tag) => {
    */
   let spacerProps;
   let contentProps;
-  const isReturnTag = ['return', 'returns'].includes(tag.tag);
-  if (isReturnTag) {
-    spacerProps = ['postDelimiter', 'postTag', 'postType'];
-    contentProps = ['tag', 'type', 'description'];
-  } else {
+  const mightHaveNamepath = utils.tagMightHaveNamepath(tag.tag);
+  if (mightHaveNamepath) {
     spacerProps = ['postDelimiter', 'postTag', 'postType', 'postName'];
     contentProps = ['tag', 'type', 'name', 'description'];
+  } else {
+    spacerProps = ['postDelimiter', 'postTag', 'postType'];
+    contentProps = ['tag', 'type', 'description'];
   }
 
   const {tokens} = tag.source[0];
@@ -268,6 +266,10 @@ export default iterateJsdoc(({
   indent,
   utils,
 }) => {
+  const {
+    tags: applicableTags = ['param', 'arg', 'argument', 'property', 'prop', 'returns', 'return'],
+  } = context.options[1] || {};
+
   if (context.options[0] === 'always') {
     // Skip if it contains only a single line.
     if (!jsdocNode.value.includes('\n')) {
@@ -300,6 +302,18 @@ export default iterateJsdoc(({
       {
         enum: ['always', 'never'],
         type: 'string',
+      },
+      {
+        additionalProperties: false,
+        properties: {
+          tags: {
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
       },
     ],
     type: 'layout',

--- a/src/rules/checkLineAlignment.js
+++ b/src/rules/checkLineAlignment.js
@@ -1,5 +1,5 @@
 import {
-  set,
+  set, escapeRegExp,
 } from 'lodash';
 import iterateJsdoc from '../iterateJsdoc';
 
@@ -112,7 +112,7 @@ const createFixer = (comment, expectedPositions, partsMatrix, lineRegExp, tagInd
  * @param {Function} report         Report function.
  */
 const checkAlignedPerTag = (comment, tag, tagIndentation, report) => {
-  const lineRegExp = new RegExp(`.*@${tag}[\\s].*`, 'gm');
+  const lineRegExp = new RegExp(`.*@${escapeRegExp(tag)}[\\s].*`, 'gm');
   const lines = comment.value.match(lineRegExp);
 
   if (!lines) {

--- a/test/rules/assertions/checkLineAlignment.js
+++ b/test/rules/assertions/checkLineAlignment.js
@@ -633,6 +633,38 @@ export default {
        function quux () {}
       `,
     },
+    {
+      code: `
+      /**
+       * Creates OS based shortcuts for files, folders, and applications.
+       *
+       * @param {object} options Options object for each OS.
+       * @param {object} other Other.
+       * @return  True = success, false = failed to create the icon
+       */
+       function quux () {}
+      `,
+      errors: [
+        {
+          line: 7,
+          message: 'Expected JSDoc block lines to not be aligned.',
+          type: 'Block',
+        },
+      ],
+      options: ['never', {
+        tags: ['param', 'return'],
+      }],
+      output: `
+      /**
+       * Creates OS based shortcuts for files, folders, and applications.
+       *
+       * @param {object} options Options object for each OS.
+       * @param {object} other Other.
+       * @return True = success, false = failed to create the icon
+       */
+       function quux () {}
+      `,
+    },
   ],
   valid: [
     {
@@ -845,6 +877,21 @@ export default {
        */
       function quux (options) {}
       `,
+    },
+    {
+      code: `
+      /**
+       * Creates OS based shortcuts for files, folders, and applications.
+       *
+       * @param {object} options Options object for each OS.
+       * @param {object} other Other.
+       * @return  True = success, false = failed to create the icon
+       */
+       function quux () {}
+      `,
+      options: ['never', {
+        tags: ['param'],
+      }],
     },
   ],
 };

--- a/test/rules/assertions/checkLineAlignment.js
+++ b/test/rules/assertions/checkLineAlignment.js
@@ -665,6 +665,48 @@ export default {
        function quux () {}
       `,
     },
+    {
+      code: `
+      /**
+       * Returns the value stored in the process.env for a given
+       * environment variable.
+       *
+       * @param  {string} withPercents    '%USERNAME%'
+       * @param  {string} withoutPercents 'USERNAME'
+       * @return {string}                 'bob' || '%USERNAME%'
+       */
+      function quux () {}
+      `,
+      errors: [
+        {
+          line: 6,
+          message: 'Expected JSDoc block lines to not be aligned.',
+          type: 'Block',
+        },
+        {
+          line: 7,
+          message: 'Expected JSDoc block lines to not be aligned.',
+          type: 'Block',
+        },
+        {
+          line: 8,
+          message: 'Expected JSDoc block lines to not be aligned.',
+          type: 'Block',
+        },
+      ],
+      options: ['never'],
+      output: `
+      /**
+       * Returns the value stored in the process.env for a given
+       * environment variable.
+       *
+       * @param {string} withPercents '%USERNAME%'
+       * @param  {string} withoutPercents 'USERNAME'
+       * @return {string}                 'bob' || '%USERNAME%'
+       */
+      function quux () {}
+      `,
+    },
   ],
   valid: [
     {


### PR DESCRIPTION
feat(`check-line-alignment`): allow `tags` option to configure which tags should be aligned.

We also allow other tags to be detected which might not have a name portion (and thus need special handling)

Addresses this [comment](https://github.com/gajus/eslint-plugin-jsdoc/issues/680#issuecomment-766488802).