### PR TITLE
`require-returns`: check for `Promise` executor

### DIFF
--- a/.README/rules/require-returns.md
+++ b/.README/rules/require-returns.md
@@ -22,10 +22,11 @@ Will also report if multiple `@returns` tags are present.
 - `forceReturnsWithAsync` - By default `async` functions that do not explicitly
     return a value pass this rule as an `async` function will always return a
     `Promise`, even if the `Promise` resolves to void. You can force all
-    `async` functions to require `@return` documentation by setting
-    `forceReturnsWithAsync` to `true` on the options object. This may be useful
-    for flagging that there has been consideration of return type. Defaults
-    to `false`.
+    `async` functions (including ones with an explicit `Promise` but no
+    detected non-`undefined` `resolve` value) to require `@return`
+    documentation by setting `forceReturnsWithAsync` to `true` on the options
+    object. This may be useful for flagging that there has been consideration
+    of return type. Defaults to `false`.
 - `contexts` - Set this to an array of strings representing the AST context
     where you wish the rule to be applied.
     Overrides the default contexts (see below). Set to `"any"` if you want

--- a/README.md
+++ b/README.md
@@ -14923,19 +14923,6 @@ function quux () {
  *
  */
 function quux () {
-  return new Promise((resolve, reject) => {
-    return () => {
-      identifierForCoverage;
-      resolve(true);
-    };
-  });
-}
-// Message: Missing JSDoc @returns declaration.
-
-/**
- *
- */
-function quux () {
   return new Promise();
 }
 // Options: [{"forceReturnsWithAsync":true}]

--- a/README.md
+++ b/README.md
@@ -14435,10 +14435,11 @@ Will also report if multiple `@returns` tags are present.
 - `forceReturnsWithAsync` - By default `async` functions that do not explicitly
     return a value pass this rule as an `async` function will always return a
     `Promise`, even if the `Promise` resolves to void. You can force all
-    `async` functions to require `@return` documentation by setting
-    `forceReturnsWithAsync` to `true` on the options object. This may be useful
-    for flagging that there has been consideration of return type. Defaults
-    to `false`.
+    `async` functions (including ones with an explicit `Promise` but no
+    detected non-`undefined` `resolve` value) to require `@return`
+    documentation by setting `forceReturnsWithAsync` to `true` on the options
+    object. This may be useful for flagging that there has been consideration
+    of return type. Defaults to `false`.
 - `contexts` - Set this to an array of strings representing the AST context
     where you wish the rule to be applied.
     Overrides the default contexts (see below). Set to `"any"` if you want
@@ -14685,6 +14686,277 @@ class quux {
 async function foo(a) {
   return Promise.all(a);
 }
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux (foo) {
+
+  return new Promise(function (resolve, reject) {
+    resolve(foo);
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux (foo) {
+
+  return new Promise(function (resolve, reject) {
+    setTimeout(() => {
+      resolve(true);
+    });
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux (foo) {
+
+  return new Promise(function (resolve, reject) {
+    foo(resolve);
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux () {
+  return new Promise((resolve, reject) => {
+    while(true) {
+      resolve(true);
+    }
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux () {
+  return new Promise((resolve, reject) => {
+    do {
+      resolve(true);
+    }
+    while(true)
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux () {
+  return new Promise((resolve, reject) => {
+    if (true) {
+      resolve(true);
+    }
+    return;
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux () {
+  return new Promise((resolve, reject) => {
+    if (true) {
+      resolve(true);
+    }
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux () {
+  var a = {};
+  return new Promise((resolve, reject) => {
+    with (a) {
+      resolve(true);
+    }
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux () {
+  var a = {};
+  return new Promise((resolve, reject) => {
+    try {
+      resolve(true);
+    } catch (err) {}
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux () {
+  var a = {};
+  return new Promise((resolve, reject) => {
+    try {
+    } catch (err) {
+      resolve(true);
+    }
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux () {
+  var a = {};
+  return new Promise((resolve, reject) => {
+    try {
+    } catch (err) {
+    } finally {
+      resolve(true);
+    }
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux () {
+  var a = {};
+  return new Promise((resolve, reject) => {
+    switch (a) {
+    case 'abc':
+      resolve(true);
+    }
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux () {
+  return new Promise((resolve, reject) => {
+    if (true) {
+      resolve();
+    } else {
+      resolve(true);
+    }
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux () {
+  return new Promise((resolve, reject) => {
+    for (let i = 0; i < 5 ; i++) {
+      resolve(true);
+    }
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux () {
+  return new Promise((resolve, reject) => {
+    for (const i of obj) {
+      resolve(true);
+    }
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux () {
+  return new Promise((resolve, reject) => {
+    for (const i in obj) {
+      resolve(true);
+    }
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux () {
+  return new Promise((resolve, reject) => {
+    if (true) {
+      return;
+    } else {
+      resolve(true);
+    }
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux () {
+  return new Promise((resolve, reject) => {
+    function a () {
+      resolve(true);
+    }
+    a();
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux () {
+  return new Promise((resolve, reject) => {
+    return () => {
+      identifierForCoverage;
+      resolve(true);
+    };
+  });
+}
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+function quux () {
+  return new Promise();
+}
+// Options: [{"forceReturnsWithAsync":true}]
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+async function quux () {
+  return new Promise();
+}
+// Options: [{"forceReturnsWithAsync":true}]
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ *
+ */
+async function quux () {
+  return new Promise((resolve, reject) => {});
+}
+// Options: [{"forceReturnsWithAsync":true}]
 // Message: Missing JSDoc @returns declaration.
 ````
 
@@ -15087,6 +15359,88 @@ class TestClass {
   }
 }
 // Options: [{"checkGetters":false}]
+
+/**
+ *
+ */
+function quux (foo) {
+
+  return new Promise(function (resolve, reject) {
+    resolve();
+  });
+}
+
+/**
+ *
+ */
+function quux (foo) {
+
+  return new Promise(function (resolve, reject) {
+    setTimeout(() => {
+      resolve();
+    });
+  });
+}
+
+/**
+ *
+ */
+function quux (foo) {
+
+  return new Promise(function (resolve, reject) {
+    foo();
+  });
+}
+
+/**
+ *
+ */
+function quux (foo) {
+
+  return new Promise(function (resolve, reject) {
+    abc((resolve) => {
+      resolve(true);
+    });
+  });
+}
+
+/**
+ *
+ */
+function quux (foo) {
+
+  return new Promise(function (resolve, reject) {
+    abc(function (resolve) {
+      resolve(true);
+    });
+  });
+}
+
+/**
+ *
+ */
+function quux () {
+  return new Promise((resolve, reject) => {
+    if (true) {
+      resolve();
+    }
+  });
+  return;
+}
+
+/**
+ *
+ */
+function quux () {
+  return new Promise();
+}
+
+/**
+ * Description.
+ */
+async function foo() {
+  return new Promise(resolve => resolve());
+}
 ````
 
 

--- a/src/bin/generateReadme.js
+++ b/src/bin/generateReadme.js
@@ -7,6 +7,10 @@ import Gitdown from 'gitdown';
 import glob from 'glob';
 import _ from 'lodash';
 
+const removeReadmeIgnores = ({ignoreReadme}) => {
+  return !ignoreReadme;
+};
+
 const trimCode = (code) => {
   let lines = code.replace(/^\n/u, '').trimEnd().split('\n');
 
@@ -59,8 +63,8 @@ const getAssertions = () => {
     const codes = require(filePath);
 
     return {
-      invalid: _.map(codes.invalid, formatCodeSnippet),
-      valid: _.map(codes.valid, formatCodeSnippet),
+      invalid: codes.invalid.filter(removeReadmeIgnores).map(formatCodeSnippet),
+      valid: codes.valid.filter(removeReadmeIgnores).map(formatCodeSnippet),
     };
   });
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -461,6 +461,10 @@ const getUtils = (
     return jsdocUtils.hasReturnValue(node);
   };
 
+  utils.hasValueOrExecutorHasNonEmptyResolveValue = (anyPromiseAsReturn) => {
+    return jsdocUtils.hasValueOrExecutorHasNonEmptyResolveValue(node, anyPromiseAsReturn);
+  };
+
   utils.hasYieldValue = () => {
     return jsdocUtils.hasYieldValue(node);
   };

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -747,8 +747,10 @@ const hasYieldValue = (node, checkYieldReturnValue) => {
   case 'WithStatement': {
     return hasYieldValue(node.body, checkYieldReturnValue);
   }
+  case 'ConditionalExpression':
   case 'IfStatement': {
-    return hasYieldValue(node.consequent, checkYieldReturnValue) ||
+    return hasYieldValue(node.test, checkYieldReturnValue) ||
+      hasYieldValue(node.consequent, checkYieldReturnValue) ||
       hasYieldValue(node.alternate, checkYieldReturnValue);
   }
   case 'TryStatement': {

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -834,6 +834,7 @@ const hasYieldValue = (node, checkYieldReturnValue) => {
  * @param {boolean} innerFunction
  * @returns {boolean}
  */
+// eslint-disable-next-line complexity
 const hasThrowValue = (node, innerFunction) => {
   if (!node) {
     return false;
@@ -849,6 +850,7 @@ const hasThrowValue = (node, innerFunction) => {
       return bodyNode.type !== 'FunctionDeclaration' && hasThrowValue(bodyNode);
     });
   }
+  case 'LabeledStatement':
   case 'WhileStatement':
   case 'DoWhileStatement':
   case 'ForStatement':

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -768,6 +768,7 @@ const hasYieldValue = (node, checkYieldReturnValue) => {
   case 'ExpressionStatement': {
     return hasYieldValue(node.expression, checkYieldReturnValue);
   }
+  case 'LabeledStatement':
   case 'WhileStatement':
   case 'DoWhileStatement':
   case 'ForStatement':

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -662,27 +662,41 @@ const hasNonEmptyResolverCall = (node, resolverName) => {
     });
   }
 
-  /*
-  case 'ArrayExpression': case 'AssignmentPattern':
+  case 'ArrayExpression':
+    return node.elements.some((bodyNode) => {
+      return hasNonEmptyResolverCall(bodyNode, resolverName);
+    });
+
   case 'AwaitExpression':
-  case 'MemberExpression': case 'OptionalMemberExpression':
-  case 'VariableDeclaration':
-  case 'OptionalCallExpression':
-  case 'TaggedTemplateExpression':
-  case 'TemplateElement': case 'TemplateLiteral': case 'UnaryExpression':
   case 'SpreadElement':
+  case 'UnaryExpression':
+  case 'YieldExpression':
+    return hasNonEmptyResolverCall(node.argument, resolverName);
+
+  /*
+  case 'LabeledStatement':
+  case 'VariableDeclaration':
+
+  case 'MemberExpression': case 'OptionalMemberExpression': // ?.
+  case 'OptionalCallExpression': ?.x()
+
+  case 'TaggedTemplateExpression':
+  case 'TemplateElement': case 'TemplateLiteral':
+
+  case 'AssignmentPattern':
   case 'ArrayPattern': case 'ObjectPattern':
+
   case 'ObjectExpression':
   case 'Property':
+
   case 'ClassProperty':
   case 'ClassDeclaration': case 'ClassExpression': case 'MethodDefinition':
   case 'Super':
+
   case 'ExportDefaultDeclaration': case 'ExportNamedDeclaration':
-  case 'LabeledStatement':
   case 'Import':
   case 'ImportExpression':
   case 'Decorator':
-  case 'YieldExpression':
 
     // Todo: Add these (and also add to Yield/Throw checks)
     return false;

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -524,6 +524,7 @@ const hasReturnValue = (node, promFilter) => {
       return bodyNode.type !== 'FunctionDeclaration' && hasReturnValue(bodyNode, promFilter);
     });
   }
+  case 'LabeledStatement':
   case 'WhileStatement':
   case 'DoWhileStatement':
   case 'ForStatement':

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -627,8 +627,10 @@ const hasNonEmptyResolverCall = (node, resolverName) => {
   case 'WithStatement': {
     return hasNonEmptyResolverCall(node.body, resolverName);
   }
+  case 'ConditionalExpression':
   case 'IfStatement': {
-    return hasNonEmptyResolverCall(node.consequent, resolverName) ||
+    return hasNonEmptyResolverCall(node.test, resolverName) ||
+      hasNonEmptyResolverCall(node.consequent, resolverName) ||
       hasNonEmptyResolverCall(node.alternate, resolverName);
   }
   case 'TryStatement': {
@@ -646,12 +648,24 @@ const hasNonEmptyResolverCall = (node, resolverName) => {
     );
   }
 
-  /*
+  case 'AssignmentExpression':
+  case 'BinaryExpression':
+  case 'LogicalExpression': {
+    return hasNonEmptyResolverCall(node.left, resolverName) ||
+      hasNonEmptyResolverCall(node.right, resolverName);
+  }
+
   // Comma
-  case 'SequenceExpression':
-  case 'ArrayExpression': case 'AssignmentExpression': case 'AssignmentPattern':
-  case 'AwaitExpression': case 'BinaryExpression': case 'ConditionalExpression':
-  case 'LogicalExpression': case 'MemberExpression': case 'OptionalMemberExpression':
+  case 'SequenceExpression': {
+    return node.expressions.some((subExpression) => {
+      return hasNonEmptyResolverCall(subExpression, resolverName);
+    });
+  }
+
+  /*
+  case 'ArrayExpression': case 'AssignmentPattern':
+  case 'AwaitExpression':
+  case 'MemberExpression': case 'OptionalMemberExpression':
   case 'VariableDeclaration':
   case 'OptionalCallExpression':
   case 'TaggedTemplateExpression':

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -39,8 +39,7 @@ export default iterateJsdoc(({
   let definedPreferredTypes = [];
   const {preferredTypes, mode} = settings;
   if (Object.keys(preferredTypes).length) {
-    // Replace `_.values` with `Object.values` when we may start requiring Node 7+
-    definedPreferredTypes = _.values(preferredTypes).map((preferredType) => {
+    definedPreferredTypes = Object.values(preferredTypes).map((preferredType) => {
       if (typeof preferredType === 'string') {
         // May become an empty string but will be filtered out below
         return stripPseudoTypes(preferredType);
@@ -157,7 +156,7 @@ export default iterateJsdoc(({
       if (type === 'NAME') {
         if (!allDefinedTypes.has(name)) {
           report(`The type '${name}' is undefined.`, null, tag);
-        } else if (!_.includes(extraTypes, name)) {
+        } else if (!extraTypes.includes(name)) {
           context.markVariableAsUsed(name);
         }
       }

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -85,7 +85,7 @@ const validateDescription = (
       let text = sourceCode.getText(jsdocNode);
 
       if (!/[.:?!]$/u.test(paragraph)) {
-        const line = _.last(paragraph.split('\n'));
+        const line = paragraph.split('\n').pop();
 
         text = text.replace(new RegExp(`${_.escapeRegExp(line)}$`, 'mu'), `${line}.`);
       }

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -85,7 +85,9 @@ export default iterateJsdoc(({
       return true;
     }
 
-    return iteratingFunction && utils.hasReturnValue();
+    return iteratingFunction && utils.hasValueOrExecutorHasNonEmptyResolveValue(
+      forceReturnsWithAsync,
+    );
   };
 
   if (shouldReport()) {

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -525,6 +525,471 @@ export default {
         ecmaVersion: 8,
       },
     },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+
+            return new Promise(function (resolve, reject) {
+              resolve(foo);
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+
+            return new Promise(function (resolve, reject) {
+              setTimeout(() => {
+                resolve(true);
+              });
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+
+            return new Promise(function (resolve, reject) {
+              foo(resolve);
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              while(true) {
+                resolve(true);
+              }
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              do {
+                resolve(true);
+              }
+              while(true)
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              if (true) {
+                resolve(true);
+              }
+              return;
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              if (true) {
+                resolve(true);
+              }
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            var a = {};
+            return new Promise((resolve, reject) => {
+              with (a) {
+                resolve(true);
+              }
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            var a = {};
+            return new Promise((resolve, reject) => {
+              try {
+                resolve(true);
+              } catch (err) {}
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            var a = {};
+            return new Promise((resolve, reject) => {
+              try {
+              } catch (err) {
+                resolve(true);
+              }
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            var a = {};
+            return new Promise((resolve, reject) => {
+              try {
+              } catch (err) {
+              } finally {
+                resolve(true);
+              }
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            var a = {};
+            return new Promise((resolve, reject) => {
+              switch (a) {
+              case 'abc':
+                resolve(true);
+              }
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              if (true) {
+                resolve();
+              } else {
+                resolve(true);
+              }
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              for (let i = 0; i < 5 ; i++) {
+                resolve(true);
+              }
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              for (const i of obj) {
+                resolve(true);
+              }
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              for (const i in obj) {
+                resolve(true);
+              }
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              if (true) {
+                return;
+              } else {
+                resolve(true);
+              }
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              function a () {
+                resolve(true);
+              }
+              a();
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              return () => {
+                identifierForCoverage;
+                resolve(true);
+              };
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise();
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      options: [
+        {
+          forceReturnsWithAsync: true,
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          async function quux () {
+            return new Promise();
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      options: [
+        {
+          forceReturnsWithAsync: true,
+        },
+      ],
+      parserOptions: {
+        ecmaVersion: 8,
+      },
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          async function quux () {
+            return new Promise((resolve, reject) => {});
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      options: [
+        {
+          forceReturnsWithAsync: true,
+        },
+      ],
+      parserOptions: {
+        ecmaVersion: 8,
+      },
+    },
   ],
   valid: [
     {
@@ -1184,6 +1649,115 @@ export default {
           checkGetters: false,
         },
       ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+
+            return new Promise(function (resolve, reject) {
+              resolve();
+            });
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+
+            return new Promise(function (resolve, reject) {
+              setTimeout(() => {
+                resolve();
+              });
+            });
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+
+            return new Promise(function (resolve, reject) {
+              foo();
+            });
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+
+            return new Promise(function (resolve, reject) {
+              abc((resolve) => {
+                resolve(true);
+              });
+            });
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux (foo) {
+
+            return new Promise(function (resolve, reject) {
+              abc(function (resolve) {
+                resolve(true);
+              });
+            });
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              if (true) {
+                resolve();
+              }
+            });
+            return;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise();
+          }
+      `,
+    },
+    {
+      code: `
+        /**
+         * Description.
+         */
+        async function foo() {
+          return new Promise(resolve => resolve());
+        }
+      `,
+      parserOptions: {
+        ecmaVersion: 8,
+      },
     },
   ],
 };

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -22,6 +22,25 @@ export default {
           /**
            *
            */
+          function quux (foo) {
+            someLabel: {
+              return foo;
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      ignoreReadme: true,
+    },
+    {
+      code: `
+          /**
+           *
+           */
           const foo = () => ({
             bar: 'baz'
           })

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -653,6 +653,28 @@ export default {
            */
           function quux () {
             return new Promise((resolve, reject) => {
+              if (resolve(true)) {
+                return;
+              }
+              return;
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      ignoreReadme: true,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
               if (true) {
                 resolve(true);
               }
@@ -665,6 +687,26 @@ export default {
           message: 'Missing JSDoc @returns declaration.',
         },
       ],
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              true ? resolve(true) : null;
+              return;
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      ignoreReadme: true,
     },
     {
       code: `
@@ -920,6 +962,83 @@ export default {
           message: 'Missing JSDoc @returns declaration.',
         },
       ],
+      ignoreReadme: true,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              a || resolve(true);
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      ignoreReadme: true,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              (r = resolve(true));
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      ignoreReadme: true,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              a + (resolve(true));
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      ignoreReadme: true,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              a, resolve(true);
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      ignoreReadme: true,
     },
     {
       code: `

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -1068,7 +1068,7 @@ export default {
             return new Promise((resolve, reject) => {
               +resolve();
               [...resolve()];
-              [resolve(true)];
+              [...+resolve(true)];
             });
           }
       `,
@@ -1120,6 +1120,70 @@ export default {
       parserOptions: {
         ecmaVersion: 8,
       },
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              someLabel: {
+                resolve(true);
+              }
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      ignoreReadme: true,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              var obj = {
+                [someKey]: 'val',
+                anotherKey: resolve(true)
+              }
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      ignoreReadme: true,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise((resolve, reject) => {
+              var obj = {
+                [resolve(true)]: 'val',
+              }
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      ignoreReadme: true,
     },
     {
       code: `

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -1046,6 +1046,68 @@ export default {
            *
            */
           function quux () {
+            return new Promise((resolve, reject) => {
+              +resolve();
+              [...resolve()];
+              [resolve(true)];
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      ignoreReadme: true,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise(function * (resolve, reject) {
+              yield resolve(true)
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      ignoreReadme: true,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
+            return new Promise(async function (resolve, reject) {
+              await resolve(true)
+            });
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      ignoreReadme: true,
+      parserOptions: {
+        ecmaVersion: 8,
+      },
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function quux () {
             return new Promise();
           }
       `,

--- a/test/rules/assertions/requireThrows.js
+++ b/test/rules/assertions/requireThrows.js
@@ -21,6 +21,25 @@ export default {
           /**
            *
            */
+          function quux (foo) {
+            someLabel: {
+              throw new Error('err')
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @throws declaration.',
+        },
+      ],
+      ignoreReadme: true,
+    },
+    {
+      code: `
+          /**
+           *
+           */
           const quux = function (foo) {
             throw new Error('err')
           }

--- a/test/rules/assertions/requireYields.js
+++ b/test/rules/assertions/requireYields.js
@@ -542,6 +542,42 @@ export default {
            *
            */
           function * quux () {
+            if (yield false) {
+
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+      ignoreReadme: true,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
+            b ? yield false : true
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+      ignoreReadme: true,
+    },
+    {
+      code: `
+          /**
+           *
+           */
+          function * quux () {
             try {
               yield true;
             } catch (err) {

--- a/test/rules/assertions/requireYields.js
+++ b/test/rules/assertions/requireYields.js
@@ -20,6 +20,25 @@ export default {
     {
       code: `
           /**
+           *
+           */
+          function * quux (foo) {
+            someLabel: {
+              yield foo;
+            }
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @yields declaration.',
+        },
+      ],
+      ignoreReadme: true,
+    },
+    {
+      code: `
+          /**
            * @yields
            */
           function * quux (foo) {

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -74,12 +74,14 @@ const ruleTester = new RuleTester();
   }
 
   assertions.invalid = assertions.invalid.map((assertion) => {
+    Reflect.deleteProperty(assertion, 'ignoreReadme');
     assertion.parserOptions = _.defaultsDeep(assertion.parserOptions, parserOptions);
 
     return assertion;
   });
 
   assertions.valid = assertions.valid.map((assertion) => {
+    Reflect.deleteProperty(assertion, 'ignoreReadme');
     if (assertion.errors) {
       throw new Error(`Valid assertions for rule ${ruleName} should not have an \`errors\` array.`);
     }


### PR DESCRIPTION
feat(`require-returns`): if function returns a Promise whose executor resolves with undefined, avoid need to document unless `forceReturnsWithAsync` is set; fixes #550

Note that if this is merged, #682 will need to add mention that our `resolve` detection is not fully complete either, since there are more edge cases where this PR does not check. But I expect it is a good beginning.