### PR TITLE
Fix typescript interface working with `publicOnly` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10041,6 +10041,34 @@ Defaults to `true`.
 The following patterns are considered problems:
 
 ````js
+/** This is comment */
+export interface Foo {
+  bar(): string;
+}
+// Options: [{"contexts":["TSInterfaceDeclaration","TSMethodSignature","TSPropertySignature"],"publicOnly":{"ancestorsOnly":true}}]
+// Message: Missing JSDoc comment.
+
+/** This is comment */
+export interface Foo {
+  bar: string;
+}
+// Options: [{"contexts":["TSInterfaceDeclaration","TSMethodSignature","TSPropertySignature"],"publicOnly":{"ancestorsOnly":true,"esm":true}}]
+// Message: Missing JSDoc comment.
+
+/**
+ * Foo interface documentation.
+ */
+export interface Foo extends Bar {
+  /**
+   * baz method documentation.
+   */
+  baz(): void;
+
+  meow(): void;
+}
+// Options: [{"contexts":["TSMethodSignature"],"publicOnly":{"ancestorsOnly":true}}]
+// Message: Missing JSDoc comment.
+
 function quux (foo) {
 
 }

--- a/src/exportParser.js
+++ b/src/exportParser.js
@@ -439,11 +439,24 @@ const parse = function (ast, node, opt) {
   };
 };
 
+const tsNotInAstExportedType = new Set([
+  'TSPropertySignature',
+  'TSMethodSignature',
+]);
+
 const isUncommentedExport = function (node, sourceCode, opt, settings) {
   // Optimize with ancestor check for esm
   if (opt.esm) {
     const exportNode = getExportAncestor(node);
     if (exportNode && !findJSDocComment(exportNode, sourceCode, settings)) {
+      return true;
+    }
+
+    /** Some typescript types are not in AST, but inherit exported (interface property and method)*/
+    if (
+      tsNotInAstExportedType.has(node.type) &&
+      !findJSDocComment(node, sourceCode, settings)
+    ) {
       return true;
     }
   }

--- a/src/exportParser.js
+++ b/src/exportParser.js
@@ -359,6 +359,40 @@ const getExportAncestor = function (nde) {
   return false;
 };
 
+const canExportedByAncestorType = new Set([
+  'TSPropertySignature',
+  'TSMethodSignature',
+  'ClassProperty',
+  'Method',
+]);
+
+const canExportChildrenType = new Set([
+  'TSInterfaceBody',
+  'TSInterfaceDeclaration',
+  'ClassDefinition',
+  'ClassExpression',
+  'Program',
+]);
+
+const isExportByAncestor = function (nde) {
+  if (!canExportedByAncestorType.has(nde.type)) {
+    return false;
+  }
+  let node = nde.parent;
+  while (node) {
+    if (exportTypes.has(node.type)) {
+      return node;
+    }
+
+    if (!canExportChildrenType.has(node.type)) {
+      return false;
+    }
+    node = node.parent;
+  }
+
+  return false;
+};
+
 const findExportedNode = function (block, node, cache) {
   /* istanbul ignore next */
   if (block === null) {
@@ -439,22 +473,20 @@ const parse = function (ast, node, opt) {
   };
 };
 
-const tsNotInAstExportedType = new Set([
-  'TSPropertySignature',
-  'TSMethodSignature',
-]);
-
 const isUncommentedExport = function (node, sourceCode, opt, settings) {
+  // console.log({node});
   // Optimize with ancestor check for esm
   if (opt.esm) {
     const exportNode = getExportAncestor(node);
+
+    // Is export node comment
     if (exportNode && !findJSDocComment(exportNode, sourceCode, settings)) {
       return true;
     }
 
-    /** Some typescript types are not in AST, but inherit exported (interface property and method)*/
+    /** Some typescript types are not in variable map, but inherit exported (interface property and method)*/
     if (
-      tsNotInAstExportedType.has(node.type) &&
+      isExportByAncestor(node) &&
       !findJSDocComment(node, sourceCode, settings)
     ) {
       return true;

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -8,6 +8,96 @@ export default {
       code: `
           /** This is comment */
           export interface Foo {
+            /** This is comment x2 */
+            tom: string;
+            catchJerry(): boolean;
+          }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc comment.',
+          type: 'TSMethodSignature',
+        },
+      ],
+      options: [
+        {
+          contexts: [
+            'TSInterfaceDeclaration',
+            'TSMethodSignature',
+            'TSPropertySignature',
+          ],
+          publicOnly: {
+            ancestorsOnly: true,
+          },
+          require: {
+            ClassDeclaration: true,
+            ClassExpression: true,
+            MethodDefinition: true,
+          },
+        },
+      ],
+      output: `
+          /** This is comment */
+          export interface Foo {
+            /** This is comment x2 */
+            tom: string;
+            /**
+             *
+             */
+            catchJerry(): boolean;
+          }
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+          /** This is comment */
+          export interface Foo {
+            /** This is comment x2 */
+            tom: string;
+            jerry: number;
+          }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc comment.',
+          type: 'TSPropertySignature',
+        },
+      ],
+      options: [
+        {
+          contexts: [
+            'TSInterfaceDeclaration',
+            'TSMethodSignature',
+            'TSPropertySignature',
+          ],
+          publicOnly: {
+            ancestorsOnly: true,
+          },
+          require: {
+            ClassDeclaration: true,
+            ClassExpression: true,
+            MethodDefinition: true,
+          },
+        },
+      ],
+      output: `
+          /** This is comment */
+          export interface Foo {
+            /** This is comment x2 */
+            tom: string;
+            /**
+             *
+             */
+            jerry: number;
+          }
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+          /** This is comment */
+          export interface Foo {
             bar(): string;
           }
       `,
@@ -2873,6 +2963,114 @@ function quux (foo) {
     },
   ],
   valid: [{
+    code: `
+      interface FooBar {
+        fooBar: string;
+      }
+    `,
+    options: [
+      {
+        contexts: [
+          'TSInterfaceDeclaration',
+          'TSMethodSignature',
+          'TSPropertySignature',
+        ],
+        publicOnly: {
+          ancestorsOnly: true,
+        },
+      },
+    ],
+    parser: require.resolve('@typescript-eslint/parser'),
+  }, {
+    code: `
+      /** This is comment */
+      interface FooBar {
+        fooBar: string;
+      }
+    `,
+    options: [
+      {
+        contexts: [
+          'TSInterfaceDeclaration',
+          'TSMethodSignature',
+          'TSPropertySignature',
+        ],
+        publicOnly: {
+          ancestorsOnly: true,
+        },
+      },
+    ],
+    parser: require.resolve('@typescript-eslint/parser'),
+  }, {
+    code: `
+        /** This is comment */
+        export class Foo {
+          someMethod() {
+            interface FooBar {
+              fooBar: string;
+            }
+          }
+        }
+    `,
+    options: [
+      {
+        contexts: [
+          'TSInterfaceDeclaration',
+          'TSMethodSignature',
+          'TSPropertySignature',
+        ],
+        publicOnly: {
+          ancestorsOnly: true,
+        },
+      },
+    ],
+    parser: require.resolve('@typescript-eslint/parser'),
+  }, {
+    code: `
+        /** This is comment */
+        function someFunciton() {
+          interface FooBar {
+            fooBar: string;
+          }
+        }
+
+    `,
+    options: [
+      {
+        contexts: [
+          'TSInterfaceDeclaration',
+          'TSMethodSignature',
+          'TSPropertySignature',
+        ],
+        publicOnly: {
+          ancestorsOnly: true,
+        },
+      },
+    ],
+    parser: require.resolve('@typescript-eslint/parser'),
+  }, {
+    code: `
+        /** This is comment */
+        export function foo() {
+          interface bar {
+            fooBar: string;
+          }
+        }
+    `,
+    options: [
+      {
+        contexts: [
+          'TSInterfaceDeclaration',
+          'TSMethodSignature',
+          'TSPropertySignature',
+        ],
+        publicOnly: {
+          ancestorsOnly: true,
+        },
+      },
+    ],
+    parser: require.resolve('@typescript-eslint/parser'),
+  }, {
     code: `
         /**
          *

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -6,6 +6,124 @@ export default {
   invalid: [
     {
       code: `
+          /** This is comment */
+          export interface Foo {
+            bar(): string;
+          }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc comment.',
+          type: 'TSMethodSignature',
+        },
+      ],
+      options: [
+        {
+          contexts: [
+            'TSInterfaceDeclaration',
+            'TSMethodSignature',
+            'TSPropertySignature',
+          ],
+          publicOnly: {
+            ancestorsOnly: true,
+          },
+        },
+      ],
+      output: `
+          /** This is comment */
+          export interface Foo {
+            /**
+             *
+             */
+            bar(): string;
+          }
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+          /** This is comment */
+          export interface Foo {
+            bar: string;
+          }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc comment.',
+          type: 'TSPropertySignature',
+        },
+      ],
+      options: [
+        {
+          contexts: [
+            'TSInterfaceDeclaration',
+            'TSMethodSignature',
+            'TSPropertySignature',
+          ],
+          publicOnly: {
+            ancestorsOnly: true,
+            esm: true,
+          },
+        },
+      ],
+      output: `
+          /** This is comment */
+          export interface Foo {
+            /**
+             *
+             */
+            bar: string;
+          }
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+      /**
+       * Foo interface documentation.
+       */
+      export interface Foo extends Bar {
+        /**
+         * baz method documentation.
+         */
+        baz(): void;
+
+        meow(): void;
+      }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc comment.',
+        },
+      ],
+      options: [{
+        contexts: [
+          'TSMethodSignature',
+        ],
+        publicOnly: {
+          ancestorsOnly: true,
+        },
+      }],
+      output: `
+      /**
+       * Foo interface documentation.
+       */
+      export interface Foo extends Bar {
+        /**
+         * baz method documentation.
+         */
+        baz(): void;
+
+        /**
+         *
+         */
+        meow(): void;
+      }
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
 function quux (foo) {
 
 }`,


### PR DESCRIPTION
In typescript, when interface is export, property and method is also exposed. but unlike class method and property, they are not retrievable from AST, so they failed on both esm and AST check of public, in this PR I fix this issue.

more detail can be find in tests