### PR TITLE
feat(`check-types`): check `settings.jsdoc.structuredTags` for an array of permissible types

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -428,6 +428,7 @@ values are objects with the following optional properties:
         might use this with `@throws` to suggest that only free form text
         is being input or with `@augments` (for jsdoc mode) to disallow
         Closure-style bracketed usage along with a required namepath.
+      - (An array of strings) - A list of permissible types.
   - `required` - Array of one of the following (defaults to an empty array,
       meaning none are required):
     - One or both of the following strings (if both are included, then both

--- a/.README/rules/check-types.md
+++ b/.README/rules/check-types.md
@@ -122,7 +122,8 @@ String | **string** | **string** | `("test") instanceof String` -> **`false`**
 
 If you define your own tags and don't wish their bracketed portions checked
 for types, you can use `settings.jsdoc.structuredTags` with a tag `type` of
-`false`.
+`false`. If you set their `type` to an array, only those values will be
+permitted.
 
 |||
 |---|---|

--- a/.README/rules/no-undefined-types.md
+++ b/.README/rules/no-undefined-types.md
@@ -40,7 +40,8 @@ the `valid-types` rule to report parsing errors.
 If you define your own tags, you can use `settings.jsdoc.structuredTags`
 to indicate that a tag's `name` is "namepath-defining" (and should prevent
 reporting on use of that namepath elsewhere) and/or that a tag's `type` is
-`false` (and should not be checked for types).
+`false` (and should not be checked for types). If the `type` is an array, that
+array's items will be considered as defined for the purposes of that tag.
 
 #### Options
 

--- a/README.md
+++ b/README.md
@@ -7446,7 +7446,8 @@ the `valid-types` rule to report parsing errors.
 If you define your own tags, you can use `settings.jsdoc.structuredTags`
 to indicate that a tag's `name` is "namepath-defining" (and should prevent
 reporting on use of that namepath elsewhere) and/or that a tag's `type` is
-`false` (and should not be checked for types).
+`false` (and should not be checked for types). If the `type` is an array, that
+array's items will be considered as defined for the purposes of that tag.
 
 <a name="eslint-plugin-jsdoc-rules-no-undefined-types-options-16"></a>
 #### Options
@@ -7616,6 +7617,13 @@ function quux () {}
  */
 function quux () {}
 // Settings: {"jsdoc":{"structuredTags":{"aCustomTag":{"type":true}}}}
+// Message: The type 'SomeType' is undefined.
+
+/**
+ * @aCustomTag {SomeType}
+ */
+function quux () {}
+// Settings: {"jsdoc":{"structuredTags":{"aCustomTag":{"type":["aType","anotherType"]}}}}
 // Message: The type 'SomeType' is undefined.
 
 /**
@@ -7963,6 +7971,12 @@ exports.resolve1 = function resolve1(value) {
  */
 function quux () {}
 // Settings: {"jsdoc":{"structuredTags":{"aCustomTag":{"type":false}}}}
+
+/**
+ * @aCustomTag {SomeType}
+ */
+function quux () {}
+// Settings: {"jsdoc":{"structuredTags":{"aCustomTag":{"type":["aType","SomeType"]}}}}
 
 /**
  * @namepathDefiner SomeType

--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ values are objects with the following optional properties:
         might use this with `@throws` to suggest that only free form text
         is being input or with `@augments` (for jsdoc mode) to disallow
         Closure-style bracketed usage along with a required namepath.
+      - (An array of strings) - A list of permissible types.
   - `required` - Array of one of the following (defaults to an empty array,
       meaning none are required):
     - One or both of the following strings (if both are included, then both
@@ -4449,7 +4450,8 @@ String | **string** | **string** | `("test") instanceof String` -> **`false`**
 
 If you define your own tags and don't wish their bracketed portions checked
 for types, you can use `settings.jsdoc.structuredTags` with a tag `type` of
-`false`.
+`false`. If you set their `type` to an array, only those values will be
+permitted.
 
 |||
 |---|---|
@@ -5039,6 +5041,12 @@ function b () {}
  */
 // Settings: {"jsdoc":{"structuredTags":{"aCustomTag":{"type":true}}}}
 // Message: Invalid JSDoc @aCustomTag "foo" type "Number"; prefer: "number".
+
+/**
+ * @aCustomTag {Number} foo
+ */
+// Settings: {"jsdoc":{"structuredTags":{"aCustomTag":{"type":["otherType","anotherType"]}}}}
+// Message: Invalid JSDoc @aCustomTag "foo" type "Number"; prefer: ["otherType","anotherType"].
 ````
 
 The following patterns are not considered problems:
@@ -5308,6 +5316,16 @@ function b () {}
  * @aCustomTag {Number} foo
  */
 // Settings: {"jsdoc":{"structuredTags":{"aCustomTag":{"type":false}}}}
+
+/**
+ * @aCustomTag {otherType} foo
+ */
+// Settings: {"jsdoc":{"structuredTags":{"aCustomTag":{"type":["otherType","anotherType"]}}}}
+
+/**
+ * @aCustomTag {anotherType|otherType} foo
+ */
+// Settings: {"jsdoc":{"structuredTags":{"aCustomTag":{"type":["otherType","anotherType"]}}}}
 ````
 
 

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -37,7 +37,7 @@ export default iterateJsdoc(({
   const {definedTypes = []} = context.options[0] || {};
 
   let definedPreferredTypes = [];
-  const {preferredTypes, mode} = settings;
+  const {preferredTypes, structuredTags, mode} = settings;
   if (Object.keys(preferredTypes).length) {
     definedPreferredTypes = Object.values(preferredTypes).map((preferredType) => {
       if (typeof preferredType === 'string') {
@@ -154,7 +154,10 @@ export default iterateJsdoc(({
 
     traverse(parsedType, ({type, name}) => {
       if (type === 'NAME') {
-        if (!allDefinedTypes.has(name)) {
+        const structuredTypes = structuredTags[tag.tag]?.type;
+        if (!allDefinedTypes.has(name) &&
+          (!Array.isArray(structuredTypes) || !structuredTypes.includes(name))
+        ) {
           report(`The type '${name}' is undefined.`, null, tag);
         } else if (!extraTypes.includes(name)) {
           context.markVariableAsUsed(name);

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -1989,6 +1989,28 @@ export default {
         },
       },
     },
+    {
+      code: `
+          /**
+           * @aCustomTag {Number} foo
+           */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @aCustomTag "foo" type "Number"; prefer: ["otherType","anotherType"].',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            aCustomTag: {
+              type: ['otherType', 'anotherType'],
+            },
+          },
+        },
+      },
+    },
   ],
   valid: [
     {
@@ -2521,6 +2543,38 @@ export default {
           structuredTags: {
             aCustomTag: {
               type: false,
+            },
+          },
+        },
+      },
+    },
+    {
+      code: `
+          /**
+           * @aCustomTag {otherType} foo
+           */
+      `,
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            aCustomTag: {
+              type: ['otherType', 'anotherType'],
+            },
+          },
+        },
+      },
+    },
+    {
+      code: `
+          /**
+           * @aCustomTag {anotherType|otherType} foo
+           */
+      `,
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            aCustomTag: {
+              type: ['otherType', 'anotherType'],
             },
           },
         },

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -340,6 +340,29 @@ export default {
     {
       code: `
       /**
+       * @aCustomTag {SomeType}
+       */
+      function quux () {}
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'The type \'SomeType\' is undefined.',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            aCustomTag: {
+              type: ['aType', 'anotherType'],
+            },
+          },
+        },
+      },
+    },
+    {
+      code: `
+      /**
        * @namepathDefiner SomeType
        */
       /**
@@ -914,6 +937,23 @@ export default {
           structuredTags: {
             aCustomTag: {
               type: false,
+            },
+          },
+        },
+      },
+    },
+    {
+      code: `
+      /**
+       * @aCustomTag {SomeType}
+       */
+      function quux () {}
+      `,
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            aCustomTag: {
+              type: ['aType', 'SomeType'],
             },
           },
         },


### PR DESCRIPTION
- feat(`check-types`): check `settings.jsdoc.structuredTags` for an array of permissible types, reporting if not present; fixes #695
- feat(`no-undefined-types`): allow `structuredTags` types to be auto-defined

This does not completely replace the `exemptTagContexts` option since `settings.jsdoc.structuredTags` does not provide a way to permit even invalid types.

I've included two features as they both tie in to `structuredTags` settings.