### PR TITLE
Allow the use of jsx annotations

### DIFF
--- a/.README/rules/check-tag-names.md
+++ b/.README/rules/check-tag-names.md
@@ -187,6 +187,20 @@ The format is as follows:
 }
 ```
 
+#### `jsxTags`
+
+If this is set to `true`, all of the following tags used to control JSX output are allowed:
+
+```
+jsx
+jsxFrag
+jsxImportSource
+jsxRuntime
+```
+
+For more information, see the [babel documentation](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx).
+
+
 |||
 |---|---|
 |Context|everywhere|

--- a/README.md
+++ b/README.md
@@ -3702,6 +3702,21 @@ The format is as follows:
 }
 ```
 
+<a name="eslint-plugin-jsdoc-rules-check-tag-names-jsxtags"></a>
+#### <code>jsxTags</code>
+
+If this is set to `true`, all of the following tags used to control JSX output are allowed:
+
+```
+jsx
+jsxFrag
+jsxImportSource
+jsxRuntime
+```
+
+For more information, see the [babel documentation](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx).
+
+
 |||
 |---|---|
 |Context|everywhere|
@@ -4048,6 +4063,12 @@ function quux (foo) {}
  */
 function quux (foo) {}
 // Message: Invalid JSDoc tag name "externs".
+
+/** @jsx h */
+/** @jsxFrag Fragment */
+/** @jsxImportSource preact */
+/** @jsxRuntime automatic */
+// Message: Invalid JSDoc tag name "jsx".
 ````
 
 The following patterns are not considered problems:
@@ -4320,6 +4341,12 @@ class Foo { }
 export function transient<T>(target?: T): T {
   // ...
 }
+
+/** @jsx h */
+/** @jsxFrag Fragment */
+/** @jsxImportSource preact */
+/** @jsxRuntime automatic */
+// "jsdoc/check-tag-names": ["error"|"warn", {"jsxTags":true}]
 ````
 
 

--- a/src/rules/checkTagNames.js
+++ b/src/rules/checkTagNames.js
@@ -1,6 +1,14 @@
 import _ from 'lodash';
 import iterateJsdoc from '../iterateJsdoc';
 
+// https://babeljs.io/docs/en/babel-plugin-transform-react-jsx/
+const jsxTagNames = new Set([
+  'jsx',
+  'jsxFrag',
+  'jsxImportSource',
+  'jsxRuntime',
+]);
+
 export default iterateJsdoc(({
   sourceCode,
   jsdoc,
@@ -10,7 +18,7 @@ export default iterateJsdoc(({
   settings,
   jsdocNode,
 }) => {
-  const {definedTags = []} = context.options[0] || {};
+  const {definedTags = [], jsxTags} = context.options[0] || {};
 
   let definedPreferredTags = [];
   const {tagNamePreference, structuredTags} = settings;
@@ -39,6 +47,9 @@ export default iterateJsdoc(({
 
   jsdoc.tags.forEach((jsdocTag) => {
     const tagName = jsdocTag.tag;
+    if (jsxTags && jsxTagNames.has(tagName)) {
+      return;
+    }
     if (utils.isValidTag(tagName, [
       ...definedTags, ...definedPreferredTags, ...definedNonPreferredTags,
       ...definedStructuredTags,
@@ -91,6 +102,9 @@ export default iterateJsdoc(({
               type: 'string',
             },
             type: 'array',
+          },
+          jsxTags: {
+            type: 'boolean',
           },
         },
         type: 'object',

--- a/src/tagNames.js
+++ b/src/tagNames.js
@@ -5,17 +5,8 @@ const jsdocTagsUndocumented = {
   modifies: [],
 };
 
-// https://babeljs.io/docs/en/babel-plugin-transform-react-jsx/
-const jsxTags = {
-  jsx: [],
-  jsxFrag: [],
-  jsxImportSource: [],
-  jsxRuntime: [],
-};
-
 const jsdocTags = {
   ...jsdocTagsUndocumented,
-  ...jsxTags,
   abstract: [
     'virtual',
   ],

--- a/src/tagNames.js
+++ b/src/tagNames.js
@@ -5,8 +5,17 @@ const jsdocTagsUndocumented = {
   modifies: [],
 };
 
+// https://babeljs.io/docs/en/babel-plugin-transform-react-jsx/
+const jsxTags = {
+  jsx: [],
+  jsxFrag: [],
+  jsxImportSource: [],
+  jsxRuntime: [],
+};
+
 const jsdocTags = {
   ...jsdocTagsUndocumented,
+  ...jsxTags,
   abstract: [
     'virtual',
   ],

--- a/test/rules/assertions/checkTagNames.js
+++ b/test/rules/assertions/checkTagNames.js
@@ -581,6 +581,20 @@ export default {
         },
       ],
     },
+    {
+      code: `
+        /** @jsx h */
+        /** @jsxFrag Fragment */
+        /** @jsxImportSource preact */
+        /** @jsxRuntime automatic */
+      `,
+      errors: [
+        {message: 'Invalid JSDoc tag name "jsx".'},
+        {message: 'Invalid JSDoc tag name "jsxFrag".'},
+        {message: 'Invalid JSDoc tag name "jsxImportSource".'},
+        {message: 'Invalid JSDoc tag name "jsxRuntime".'},
+      ],
+    },
   ],
   valid: [
     {
@@ -809,6 +823,15 @@ export default {
       parserOptions: {
         sourceType: 'module',
       },
+    },
+    {
+      code: `
+        /** @jsx h */
+        /** @jsxFrag Fragment */
+        /** @jsxImportSource preact */
+        /** @jsxRuntime automatic */
+      `,
+      options: [{jsxTags: true}],
     },
   ],
 };


### PR DESCRIPTION
These tags may be used to tweak how JSX is converted by Babel or TypeScript.

See https://babeljs.io/docs/en/babel-plugin-transform-react-jsx