### PR TITLE
Add line alignment tags support when using `always`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2167,6 +2167,15 @@ const fn = ( lorem, sit ) => {}
 // Message: Expected JSDoc block lines to be aligned.
 
 /**
+ * Only return doc.
+ *
+ * @return {boolean}  Return description.
+ */
+const fn = ( lorem, sit ) => {}
+// "jsdoc/check-line-alignment": ["error"|"warn", "always"]
+// Message: Expected JSDoc block lines to be aligned.
+
+/**
  * Creates OS based shortcuts for files, folders, and applications.
  *
  * @param  {object}  options  Options object for each OS.
@@ -2378,6 +2387,14 @@ const fn = ( lorem ) => {}
  *
  * @param  {object}  options Options object for each OS.
  * @return {boolean}
+ */
+ function quux () {}
+// "jsdoc/check-line-alignment": ["error"|"warn", "always"]
+
+/**
+ * Only return doc.
+ *
+ * @return {boolean} Return description.
  */
  function quux () {}
 // "jsdoc/check-line-alignment": ["error"|"warn", "always"]

--- a/README.md
+++ b/README.md
@@ -1960,6 +1960,16 @@ const fn = ( lorem, sit ) => {}
 // Message: Expected JSDoc block lines to be aligned.
 
 /**
+ * With tabs.
+ *
+ * @param {string} lorem Description.
+ * @param {int} sit Description multi words.
+ */
+    const fn = ( lorem, sit ) => {}
+// "jsdoc/check-line-alignment": ["error"|"warn", "always"]
+// Message: Expected JSDoc block lines to be aligned.
+
+/**
  * Function description.
  *
  * @param {string} lorem - Description.
@@ -2249,6 +2259,15 @@ The following patterns are not considered problems:
  * @param {int}    sit   Description multi words.
  */
 const fn = ( lorem, sit ) => {}
+// "jsdoc/check-line-alignment": ["error"|"warn", "always"]
+
+/**
+ * With tabs.
+ *
+ * @param {string} lorem Description.
+ * @param {int}    sit   Description multi words.
+ */
+    const fn = ( lorem, sit ) => {}
 // "jsdoc/check-line-alignment": ["error"|"warn", "always"]
 
 /**

--- a/README.md
+++ b/README.md
@@ -2091,6 +2091,19 @@ const config = {
 // Message: Expected JSDoc block lines to be aligned.
 
 /**
+ * My object.
+ *
+ * @typedef {Object} MyObject
+ *
+ * @property {{a: number, b: string, c}} lorem Description.
+ * @property {Object.<string, Class>} sit Description multi words.
+ * @property {Object.<string, Class>} amet Description} weird {multi} {{words}}.
+ * @property {Object.<string, Class>} dolor
+ */
+// "jsdoc/check-line-alignment": ["error"|"warn", "always",{"tags":["typedef","property"]}]
+// Message: Expected JSDoc block lines to be aligned.
+
+/**
  * My function.
  *
  * @param {string} lorem  Description.
@@ -2128,6 +2141,30 @@ const fn = ( lorem, sit ) => {}
  */
 const fn = ( lorem, sit ) => {}
 // Message: Expected JSDoc block lines to not be aligned.
+
+/**
+ * Function description.
+ *
+ * @param {string} lorem Description.
+ * @param {int} sit Description multi
+   line without *.
+ */
+const fn = ( lorem, sit ) => {}
+// "jsdoc/check-line-alignment": ["error"|"warn", "always"]
+// Message: Expected JSDoc block lines to be aligned.
+
+/**
+ * My function.
+ *
+ * @param {string} lorem Description.
+ * @param   {int}    sit
+ *
+ * @return  {string}  Return description
+ *    with multi line, but don't touch.
+ */
+const fn = ( lorem, sit ) => {}
+// "jsdoc/check-line-alignment": ["error"|"warn", "always",{"tags":["param"]}]
+// Message: Expected JSDoc block lines to be aligned.
 
 /**
  * Creates OS based shortcuts for files, folders, and applications.
@@ -2279,8 +2316,8 @@ const fn = ( lorem, sit ) => {}
 
 /**
  * @namespace
- * @property  {object} defaults       Description.
- * @property  {int}    defaults.lorem Description multi words.
+ * @property {object} defaults       Description.
+ * @property {int}    defaults.lorem Description multi words.
  */
 const config = {
     defaults: {
@@ -2292,10 +2329,22 @@ const config = {
 /**
  * My object.
  *
- * @typedef  {Object} MyObject
+ * @typedef {Object} MyObject
  *
- * @property {string} lorem    Description.
- * @property {int}    sit      Description multi words.
+ * @property {string} lorem Description.
+ * @property {int}    sit   Description multi words.
+ */
+// "jsdoc/check-line-alignment": ["error"|"warn", "always"]
+
+/**
+ * My object.
+ *
+ * @typedef {Object} MyObject
+ *
+ * @property {{a: number, b: string, c}} lorem Description.
+ * @property {Object.<string, Class>}    sit   Description multi words.
+ * @property {Object.<string, Class>}    amet  Description} weird {multi} {{words}}.
+ * @property {Object.<string, Class>}    dolor
  */
 // "jsdoc/check-line-alignment": ["error"|"warn", "always"]
 
@@ -2309,7 +2358,7 @@ const config = {
  * @property {Object.<string, Class>}    amet     Description} weird {multi} {{words}}.
  * @property {Object.<string, Class>}    dolor
  */
-// "jsdoc/check-line-alignment": ["error"|"warn", "always"]
+// "jsdoc/check-line-alignment": ["error"|"warn", "always",{"tags":["typedef","property"]}]
 
 /** @param {number} lorem */
 const fn = ( lorem ) => {}
@@ -2320,6 +2369,15 @@ const fn = ( lorem ) => {}
  *
  * @param  {object}  options Options object for each OS.
  * @return {boolean}         True = success, false = failed to create the icon
+ */
+ function quux () {}
+// "jsdoc/check-line-alignment": ["error"|"warn", "always"]
+
+/**
+ * Creates OS based shortcuts for files, folders, and applications.
+ *
+ * @param  {object}  options Options object for each OS.
+ * @return {boolean}
  */
  function quux () {}
 // "jsdoc/check-line-alignment": ["error"|"warn", "always"]

--- a/README.md
+++ b/README.md
@@ -2388,6 +2388,18 @@ const config = {
  */
 // "jsdoc/check-line-alignment": ["error"|"warn", "always",{"tags":["typedef","property"]}]
 
+/**
+ * My object.
+ *
+ * @template                             T
+ * @template                             W,X,Y,Z
+ * @template {string}                    K               - K must be a string or string literal
+ * @template {{ serious(): string }}     Seriousalizable - must have a serious method
+ *
+ * @param    {{a: number, b: string, c}} lorem           Description.
+ */
+// "jsdoc/check-line-alignment": ["error"|"warn", "always",{"tags":["template","param"]}]
+
 /** @param {number} lorem */
 const fn = ( lorem ) => {}
 // "jsdoc/check-line-alignment": ["error"|"warn", "always"]

--- a/src/alignTransform.js
+++ b/src/alignTransform.js
@@ -136,6 +136,7 @@ const alignTransform = (tags) => {
           nothingAfter.tag = true;
           tokens.postTag = '';
 
+          /* istanbul ignore next: Never happens because the !intoTags return. But it's here for consistency wih the original align transform */
           if (tokens.tag === '') {
             nothingAfter.delim = true;
           }

--- a/src/alignTransform.js
+++ b/src/alignTransform.js
@@ -1,0 +1,175 @@
+import {
+  Markers,
+} from 'comment-parser/lib/primitives';
+import {
+  rewireSource,
+} from 'comment-parser/lib/util';
+
+const zeroWidth = {
+  name: 0,
+  start: 0,
+  tag: 0,
+  type: 0,
+};
+
+const shouldAlign = (tags, index, source) => {
+  const tag = source[index].tokens.tag.replace('@', '');
+  const includesTag = tags.includes(tag);
+
+  if (includesTag) {
+    return true;
+  }
+
+  if (tag !== '') {
+    return false;
+  }
+
+  for (let iterator = index; iterator >= 0; iterator--) {
+    const previousTag = source[iterator].tokens.tag.replace('@', '');
+
+    if (previousTag !== '') {
+      if (tags.includes(previousTag)) {
+        return true;
+      }
+
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const getWidth = (tags) => {
+  return (width, {tokens}, index, source) => {
+    if (!shouldAlign(tags, index, source)) {
+      return width;
+    }
+
+    return {
+      name: Math.max(width.name, tokens.name.length),
+      start: tokens.delimiter === Markers.start ? tokens.start.length : width.start,
+      tag: Math.max(width.tag, tokens.tag.length),
+      type: Math.max(width.type, tokens.type.length),
+    };
+  };
+};
+
+const space = (len) => {
+  return ''.padStart(len, ' ');
+};
+
+const alignTransform = (tags) => {
+// function align(tags) {
+  let intoTags = false;
+  let w;
+
+  const update = (line, index, source) => {
+    const tokens = {...line.tokens};
+    if (tokens.tag !== '') {
+      intoTags = true;
+    }
+
+    const isEmpty =
+      tokens.tag === '' &&
+      tokens.name === '' &&
+      tokens.type === '' &&
+      tokens.description === '';
+
+    // dangling '*/'
+    if (tokens.end === Markers.end && isEmpty) {
+      tokens.start = space(w.start + 1);
+
+      return {
+        ...line,
+        tokens,
+      };
+    }
+
+    /* eslint-disable indent */
+    switch (tokens.delimiter) {
+      case Markers.start:
+        tokens.start = space(w.start);
+        break;
+      case Markers.delim:
+        tokens.start = space(w.start + 1);
+        break;
+      default:
+        tokens.delimiter = '';
+
+        // compensate delimiter
+        tokens.start = space(w.start + 2);
+    }
+    /* eslint-enable */
+
+    if (!intoTags) {
+      tokens.postDelimiter = tokens.description === '' ? '' : ' ';
+
+      return {
+        ...line,
+        tokens,
+      };
+    }
+
+    // Not align.
+    if (!shouldAlign(tags, index, source)) {
+      return {
+        ...line,
+        tokens,
+      };
+    }
+
+    const nothingAfter = {
+      delim: false,
+      name: false,
+      tag: false,
+      type: false,
+    };
+
+    if (tokens.description === '') {
+      nothingAfter.name = true;
+      tokens.postName = '';
+
+      if (tokens.name === '') {
+        nothingAfter.type = true;
+        tokens.postType = '';
+
+        if (tokens.type === '') {
+          nothingAfter.tag = true;
+          tokens.postTag = '';
+
+          if (tokens.tag === '') {
+            nothingAfter.delim = true;
+          }
+        }
+      }
+    }
+
+    tokens.postDelimiter = nothingAfter.delim ? '' : ' ';
+
+    if (!nothingAfter.tag) {
+      tokens.postTag = space(w.tag - tokens.tag.length + 1);
+    }
+    if (!nothingAfter.type) {
+      tokens.postType = space(w.type - tokens.type.length + 1);
+    }
+    if (!nothingAfter.name) {
+      tokens.postName = space(w.name - tokens.name.length + 1);
+    }
+
+    return {
+      ...line,
+      tokens,
+    };
+  };
+
+  return ({source, ...fields}) => {
+    w = source.reduce(getWidth(tags), {...zeroWidth});
+
+    return rewireSource({
+      ...fields,
+      source: source.map(update),
+    });
+  };
+};
+
+export default alignTransform;

--- a/src/alignTransform.js
+++ b/src/alignTransform.js
@@ -62,6 +62,50 @@ const alignTransform = (tags) => {
   let intoTags = false;
   let width;
 
+  const alignTokens = (tokens) => {
+    const nothingAfter = {
+      delim: false,
+      name: false,
+      tag: false,
+      type: false,
+    };
+
+    if (tokens.description === '') {
+      nothingAfter.name = true;
+      tokens.postName = '';
+
+      if (tokens.name === '') {
+        nothingAfter.type = true;
+        tokens.postType = '';
+
+        if (tokens.type === '') {
+          nothingAfter.tag = true;
+          tokens.postTag = '';
+
+          /* istanbul ignore next: Never happens because the !intoTags return. But it's here for consistency with the original align transform */
+          if (tokens.tag === '') {
+            nothingAfter.delim = true;
+          }
+        }
+      }
+    }
+
+    tokens.postDelimiter = nothingAfter.delim ? '' : ' ';
+
+    if (!nothingAfter.tag) {
+      tokens.postTag = space(width.tag - tokens.tag.length + 1);
+    }
+    if (!nothingAfter.type) {
+      tokens.postType = space(width.type - tokens.type.length + 1);
+    }
+    if (!nothingAfter.name) {
+      // If post name is empty for all lines (name width 0), don't add post name spacing.
+      tokens.postName = width.name === 0 ? '' : space(width.name - tokens.name.length + 1);
+    }
+
+    return tokens;
+  };
+
   const update = (line, index, source) => {
     const tokens = {...line.tokens};
     if (tokens.tag !== '') {
@@ -117,48 +161,9 @@ const alignTransform = (tags) => {
       };
     }
 
-    const nothingAfter = {
-      delim: false,
-      name: false,
-      tag: false,
-      type: false,
-    };
-
-    if (tokens.description === '') {
-      nothingAfter.name = true;
-      tokens.postName = '';
-
-      if (tokens.name === '') {
-        nothingAfter.type = true;
-        tokens.postType = '';
-
-        if (tokens.type === '') {
-          nothingAfter.tag = true;
-          tokens.postTag = '';
-
-          /* istanbul ignore next: Never happens because the !intoTags return. But it's here for consistency with the original align transform */
-          if (tokens.tag === '') {
-            nothingAfter.delim = true;
-          }
-        }
-      }
-    }
-
-    tokens.postDelimiter = nothingAfter.delim ? '' : ' ';
-
-    if (!nothingAfter.tag) {
-      tokens.postTag = space(width.tag - tokens.tag.length + 1);
-    }
-    if (!nothingAfter.type) {
-      tokens.postType = space(width.type - tokens.type.length + 1);
-    }
-    if (!nothingAfter.name) {
-      tokens.postName = space(width.name - tokens.name.length + 1);
-    }
-
     return {
       ...line,
-      tokens,
+      tokens: alignTokens(tokens),
     };
   };
 

--- a/src/alignTransform.js
+++ b/src/alignTransform.js
@@ -59,9 +59,8 @@ const space = (len) => {
 };
 
 const alignTransform = (tags) => {
-// function align(tags) {
   let intoTags = false;
-  let w;
+  let width;
 
   const update = (line, index, source) => {
     const tokens = {...line.tokens};
@@ -77,7 +76,7 @@ const alignTransform = (tags) => {
 
     // dangling '*/'
     if (tokens.end === Markers.end && isEmpty) {
-      tokens.start = space(w.start + 1);
+      tokens.start = space(width.start + 1);
 
       return {
         ...line,
@@ -88,16 +87,16 @@ const alignTransform = (tags) => {
     /* eslint-disable indent */
     switch (tokens.delimiter) {
       case Markers.start:
-        tokens.start = space(w.start);
+        tokens.start = space(width.start);
         break;
       case Markers.delim:
-        tokens.start = space(w.start + 1);
+        tokens.start = space(width.start + 1);
         break;
       default:
         tokens.delimiter = '';
 
         // compensate delimiter
-        tokens.start = space(w.start + 2);
+        tokens.start = space(width.start + 2);
     }
     /* eslint-enable */
 
@@ -147,13 +146,13 @@ const alignTransform = (tags) => {
     tokens.postDelimiter = nothingAfter.delim ? '' : ' ';
 
     if (!nothingAfter.tag) {
-      tokens.postTag = space(w.tag - tokens.tag.length + 1);
+      tokens.postTag = space(width.tag - tokens.tag.length + 1);
     }
     if (!nothingAfter.type) {
-      tokens.postType = space(w.type - tokens.type.length + 1);
+      tokens.postType = space(width.type - tokens.type.length + 1);
     }
     if (!nothingAfter.name) {
-      tokens.postName = space(w.name - tokens.name.length + 1);
+      tokens.postName = space(width.name - tokens.name.length + 1);
     }
 
     return {
@@ -163,7 +162,7 @@ const alignTransform = (tags) => {
   };
 
   return ({source, ...fields}) => {
-    w = source.reduce(getWidth(tags), {...zeroWidth});
+    width = source.reduce(getWidth(tags), {...zeroWidth});
 
     return rewireSource({
       ...fields,

--- a/src/alignTransform.js
+++ b/src/alignTransform.js
@@ -136,7 +136,7 @@ const alignTransform = (tags) => {
           nothingAfter.tag = true;
           tokens.postTag = '';
 
-          /* istanbul ignore next: Never happens because the !intoTags return. But it's here for consistency wih the original align transform */
+          /* istanbul ignore next: Never happens because the !intoTags return. But it's here for consistency with the original align transform */
           if (tokens.tag === '') {
             nothingAfter.delim = true;
           }

--- a/src/alignTransform.js
+++ b/src/alignTransform.js
@@ -58,7 +58,7 @@ const space = (len) => {
   return ''.padStart(len, ' ');
 };
 
-const alignTransform = (tags) => {
+const alignTransform = (tags, indent) => {
   let intoTags = false;
   let width;
 
@@ -120,7 +120,7 @@ const alignTransform = (tags) => {
 
     // dangling '*/'
     if (tokens.end === Markers.end && isEmpty) {
-      tokens.start = space(width.start + 1);
+      tokens.start = indent + ' ';
 
       return {
         ...line,
@@ -131,16 +131,16 @@ const alignTransform = (tags) => {
     /* eslint-disable indent */
     switch (tokens.delimiter) {
       case Markers.start:
-        tokens.start = space(width.start);
+        tokens.start = indent;
         break;
       case Markers.delim:
-        tokens.start = space(width.start + 1);
+        tokens.start = indent + ' ';
         break;
       default:
         tokens.delimiter = '';
 
         // compensate delimiter
-        tokens.start = space(width.start + 2);
+        tokens.start = indent + '  ';
     }
     /* eslint-enable */
 

--- a/src/rules/checkLineAlignment.js
+++ b/src/rules/checkLineAlignment.js
@@ -6,7 +6,6 @@ import iterateJsdoc from '../iterateJsdoc';
 
 const {
   flow: commentFlow,
-  indent: commentIndent,
 } = transforms;
 
 const checkNotAlignedPerTag = (utils, tag) => {
@@ -105,7 +104,7 @@ const checkAlignment = ({
   tags,
   utils,
 }) => {
-  const transform = commentFlow(alignTransform(tags), commentIndent(indent.length));
+  const transform = commentFlow(alignTransform(tags, indent));
   const transformedJsdoc = transform(jsdoc);
 
   const comment = '/*' + jsdocNode.value + '*/';

--- a/src/rules/checkLineAlignment.js
+++ b/src/rules/checkLineAlignment.js
@@ -1,11 +1,11 @@
 import {
   transforms,
 } from 'comment-parser';
+import alignTransform from '../alignTransform';
 import iterateJsdoc from '../iterateJsdoc';
 
 const {
   flow: commentFlow,
-  align: commentAlign,
   indent: commentIndent,
 } = transforms;
 
@@ -102,9 +102,10 @@ const checkAlignment = ({
   jsdoc,
   jsdocNode,
   report,
+  tags,
   utils,
 }) => {
-  const transform = commentFlow(commentAlign(), commentIndent(indent.length));
+  const transform = commentFlow(alignTransform(tags), commentIndent(indent.length));
   const transformedJsdoc = transform(jsdoc);
 
   const comment = '/*' + jsdocNode.value + '*/';
@@ -144,6 +145,7 @@ export default iterateJsdoc(({
       jsdoc,
       jsdocNode,
       report,
+      tags: applicableTags,
       utils,
     });
 

--- a/test/rules/assertions/checkLineAlignment.js
+++ b/test/rules/assertions/checkLineAlignment.js
@@ -1077,6 +1077,23 @@ export default {
     },
     {
       code: `
+        /**
+         * My object.
+         *
+         * @template                             T,U,V
+         * @template                             W,X,Y,Z
+         * @template {string}                    K               - K must be a string or string literal
+         * @template {{ serious(): string }}     Seriousalizable - must have a serious method
+         *
+         * @param    {{a: number, b: string, c}} lorem           Description.
+         */
+      `,
+      options: ['always', {
+        tags: ['template', 'param'],
+      }],
+    },
+    {
+      code: `
         /** @param {number} lorem */
         const fn = ( lorem ) => {}
       `,

--- a/test/rules/assertions/checkLineAlignment.js
+++ b/test/rules/assertions/checkLineAlignment.js
@@ -323,8 +323,8 @@ export default {
       output: `
         /**
          * @namespace
-         * @property  {object} defaults       Description.
-         * @property  {int}    defaults.lorem Description multi words.
+         * @property {object} defaults       Description.
+         * @property {int}    defaults.lorem Description multi words.
          */
         const config = {
             defaults: {
@@ -357,10 +357,10 @@ export default {
         /**
          * My object.
          *
-         * @typedef  {Object} MyObject
+         * @typedef {Object} MyObject
          *
-         * @property {string} lorem    Description.
-         * @property {int}    sit      Description multi words.
+         * @property {string} lorem Description.
+         * @property {int}    sit   Description multi words.
          */
       `,
     },
@@ -386,6 +386,41 @@ export default {
       options: [
         'always',
       ],
+      output: `
+        /**
+         * My object.
+         *
+         * @typedef {Object} MyObject
+         *
+         * @property {{a: number, b: string, c}} lorem Description.
+         * @property {Object.<string, Class>}    sit   Description multi words.
+         * @property {Object.<string, Class>}    amet  Description} weird {multi} {{words}}.
+         * @property {Object.<string, Class>}    dolor
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * My object.
+         *
+         * @typedef {Object} MyObject
+         *
+         * @property {{a: number, b: string, c}} lorem Description.
+         * @property {Object.<string, Class>} sit Description multi words.
+         * @property {Object.<string, Class>} amet Description} weird {multi} {{words}}.
+         * @property {Object.<string, Class>} dolor
+         */
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      options: ['always', {
+        tags: ['typedef', 'property'],
+      }],
       output: `
         /**
          * My object.
@@ -512,6 +547,41 @@ export default {
          *
          * @param {string} lorem Description.
          * @param {int} sit
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+    },
+    {
+      code: `
+        /**
+         * My function.
+         *
+         * @param {string} lorem Description.
+         * @param   {int}    sit
+         *
+         * @return  {string}  Return description
+         *    with multi line, but don't touch.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      options: ['always', {
+        tags: ['param'],
+      }],
+      output: `
+        /**
+         * My function.
+         *
+         * @param {string} lorem Description.
+         * @param {int}    sit
+         *
+         * @return  {string}  Return description
+         *    with multi line, but don't touch.
          */
         const fn = ( lorem, sit ) => {}
       `,
@@ -840,8 +910,8 @@ export default {
       code: `
         /**
          * @namespace
-         * @property  {object} defaults       Description.
-         * @property  {int}    defaults.lorem Description multi words.
+         * @property {object} defaults       Description.
+         * @property {int}    defaults.lorem Description multi words.
          */
         const config = {
             defaults: {
@@ -858,10 +928,27 @@ export default {
         /**
          * My object.
          *
-         * @typedef  {Object} MyObject
+         * @typedef {Object} MyObject
          *
-         * @property {string} lorem    Description.
-         * @property {int}    sit      Description multi words.
+         * @property {string} lorem Description.
+         * @property {int}    sit   Description multi words.
+         */
+      `,
+      options: [
+        'always',
+      ],
+    },
+    {
+      code: `
+        /**
+         * My object.
+         *
+         * @typedef {Object} MyObject
+         *
+         * @property {{a: number, b: string, c}} lorem Description.
+         * @property {Object.<string, Class>}    sit   Description multi words.
+         * @property {Object.<string, Class>}    amet  Description} weird {multi} {{words}}.
+         * @property {Object.<string, Class>}    dolor
          */
       `,
       options: [
@@ -881,9 +968,9 @@ export default {
          * @property {Object.<string, Class>}    dolor
          */
       `,
-      options: [
-        'always',
-      ],
+      options: ['always', {
+        tags: ['typedef', 'property'],
+      }],
     },
     {
       code: `

--- a/test/rules/assertions/checkLineAlignment.js
+++ b/test/rules/assertions/checkLineAlignment.js
@@ -554,6 +554,37 @@ export default {
     {
       code: `
         /**
+         * Function description.
+         *
+         * @param {string} lorem Description.
+         * @param {int} sit Description multi
+           line without *.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      options: [
+        'always',
+      ],
+      output: `
+        /**
+         * Function description.
+         *
+         * @param {string} lorem Description.
+         * @param {int}    sit   Description multi
+                                 line without *.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+    },
+    {
+      code: `
+        /**
          * My function.
          *
          * @param {string} lorem Description.
@@ -988,6 +1019,18 @@ export default {
        *
        * @param  {object}  options Options object for each OS.
        * @return {boolean}         True = success, false = failed to create the icon
+       */
+       function quux () {}
+      `,
+      options: ['always'],
+    },
+    {
+      code: `
+      /**
+       * Creates OS based shortcuts for files, folders, and applications.
+       *
+       * @param  {object}  options Options object for each OS.
+       * @return {boolean}
        */
        function quux () {}
       `,

--- a/test/rules/assertions/checkLineAlignment.js
+++ b/test/rules/assertions/checkLineAlignment.js
@@ -1080,7 +1080,7 @@ export default {
         /**
          * My object.
          *
-         * @template                             T,U,V
+         * @template                             T
          * @template                             W,X,Y,Z
          * @template {string}                    K               - K must be a string or string literal
          * @template {{ serious(): string }}     Seriousalizable - must have a serious method

--- a/test/rules/assertions/checkLineAlignment.js
+++ b/test/rules/assertions/checkLineAlignment.js
@@ -619,6 +619,31 @@ export default {
     },
     {
       code: `
+        /**
+         * Only return doc.
+         *
+         * @return {boolean}  Return description.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      options: ['always'],
+      output: `
+        /**
+         * Only return doc.
+         *
+         * @return {boolean} Return description.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+    },
+    {
+      code: `
       /**
        * Creates OS based shortcuts for files, folders, and applications.
        *
@@ -1031,6 +1056,17 @@ export default {
        *
        * @param  {object}  options Options object for each OS.
        * @return {boolean}
+       */
+       function quux () {}
+      `,
+      options: ['always'],
+    },
+    {
+      code: `
+      /**
+       * Only return doc.
+       *
+       * @return {boolean} Return description.
        */
        function quux () {}
       `,

--- a/test/rules/assertions/checkLineAlignment.js
+++ b/test/rules/assertions/checkLineAlignment.js
@@ -29,6 +29,37 @@ export default {
         const fn = ( lorem, sit ) => {}
       `,
     },
+    /* eslint-disable no-tabs */
+    {
+      code: `
+				/**
+				 * With tabs.
+				 *
+				 * @param {string} lorem Description.
+				 * @param {int} sit Description multi words.
+				 */
+        const fn = ( lorem, sit ) => {}
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      options: [
+        'always',
+      ],
+      output: `
+				/**
+				 * With tabs.
+				 *
+				 * @param {string} lorem Description.
+				 * @param {int}    sit   Description multi words.
+				 */
+        const fn = ( lorem, sit ) => {}
+      `,
+    },
+    /* eslint-enable no-tabs */
     {
       code: `
         /**
@@ -845,6 +876,22 @@ export default {
         'always',
       ],
     },
+    /* eslint-disable no-tabs */
+    {
+      code: `
+				/**
+				 * With tabs.
+				 *
+				 * @param {string} lorem Description.
+				 * @param {int}    sit   Description multi words.
+				 */
+        const fn = ( lorem, sit ) => {}
+      `,
+      options: [
+        'always',
+      ],
+    },
+    /* eslint-enable no-tabs */
     {
       code: `
         /**


### PR DESCRIPTION
Part of #680
Close #689

This PR adds support to the `tags` option when using the `always` option.

The first PR for this feature was the https://github.com/gajus/eslint-plugin-jsdoc/pull/689, but the approach wasn't being enough, needing a lot of hacks. So I changed the approach, creating a new transform based on the original `align`, but adding support to custom tags.

It still reports the errors for the entire block, different than what was suggested in https://github.com/gajus/eslint-plugin-jsdoc/issues/680#issuecomment-770314024.

Another idea for a new feature in the future:

- We could add a new option to force the alignment similar to the `never` for the tags that aren't in the `tags` when using the `always`.