### PR TITLE
chore: require engines Node 12+

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -9,7 +9,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": 10
+          "node": 12
         }
       }
     ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ os: linux
 dist: xenial
 language: node_js
 node_js:
+  - 16
   - 14
   - 12
-  - 10
 
 before_install:
   - npm config set depth 0

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "gitdown": "^3.1.4",
     "glob": "^7.1.7",
     "husky": "^6.0.0",
-    "lint-staged": "^10.5.4",
+    "lint-staged": "^11.0.0",
     "mocha": "^8.4.0",
     "nyc": "^15.1.0",
     "rimraf": "^3.0.2",
@@ -44,7 +44,7 @@
     "typescript": "^4.2.4"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "lint-staged": {
     ".eslintignore": "npm run lint",

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -325,10 +325,7 @@ const isValidTag = (
 ) : boolean => {
   const tagNames = getTagNamesForMode(mode, context);
 
-  // Todo[engine:node@>=12]: Switch to flatten
-
-  // eslint-disable-next-line unicorn/prefer-array-flat -- Not yet supported
-  const validTagNames = Object.keys(tagNames).concat(_.flatten(Object.values(tagNames)));
+  const validTagNames = Object.keys(tagNames).concat(Object.values(tagNames).flat());
   const additionalTags = definedTags;
   const allTags = validTagNames.concat(additionalTags);
 


### PR DESCRIPTION
BREAKING CHANGE:

Also:
- Build: Switch to Node 12 target
- Linting: Use `flat` API
- Travis: Add Node 16, remove Node 10
- npm: Update devDep.