### PR TITLE
feat: new rule `tag-line`; fixes #93

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -581,4 +581,5 @@ selector).
 {"gitdown": "include", "file": "./rules/require-throws.md"}
 {"gitdown": "include", "file": "./rules/require-yields.md"}
 {"gitdown": "include", "file": "./rules/require-yields-check.md"}
+{"gitdown": "include", "file": "./rules/tag-lines.md"}
 {"gitdown": "include", "file": "./rules/valid-types.md"}

--- a/.README/rules/tag-lines.md
+++ b/.README/rules/tag-lines.md
@@ -13,7 +13,7 @@ The second option is an object with the following optional properties.
 
 Use with "always" to indicate the number of lines to require be present.
 
-##### `noEndLine` (defaults to `false`)
+##### `noEndLines` (defaults to `false`)
 
 Use with "always" to indicate the normal lines after tags should not be
 added after the final tag.
@@ -24,6 +24,6 @@ added after the final tag.
 |Tags|Any|
 |Recommended|false|
 |Settings|N/A|
-|Options|(a string matching `"always" or "never"` and optional object with `count` and `noEndLine`)|
+|Options|(a string matching `"always" or "never"` and optional object with `count` and `noEndLines`)|
 
 <!-- assertions tagLines -->

--- a/.README/rules/tag-lines.md
+++ b/.README/rules/tag-lines.md
@@ -1,0 +1,28 @@
+### `tag-lines`
+
+Enforces lines (or no lines) between tags.
+
+#### Options
+
+The first option is a single string set to "always" or "never" (defaults to
+"never").
+
+The second option is an object with the following optional properties.
+
+##### `count` (defaults to 1)
+
+Use with "always" to indicate the number of lines to require be present.
+
+##### `noEndLine` (defaults to `false`)
+
+Use with "always" to indicate tag lines should not be added at the end.
+
+|||
+|---|---|
+|Context|everywhere|
+|Tags|Any|
+|Recommended|false|
+|Settings|N/A|
+|Options|(a string matching `"always" or "never"` and optional object with `count` and `noEndLine`)|
+
+<!-- assertions tagLines -->

--- a/.README/rules/tag-lines.md
+++ b/.README/rules/tag-lines.md
@@ -15,7 +15,8 @@ Use with "always" to indicate the number of lines to require be present.
 
 ##### `noEndLine` (defaults to `false`)
 
-Use with "always" to indicate tag lines should not be added at the end.
+Use with "always" to indicate the normal lines after tags should not be
+added after the final tag.
 
 |||
 |---|---|

--- a/.README/rules/tag-lines.md
+++ b/.README/rules/tag-lines.md
@@ -15,8 +15,8 @@ Use with "always" to indicate the number of lines to require be present.
 
 ##### `noEndLines` (defaults to `false`)
 
-Use with "always" to indicate the normal lines after tags should not be
-added after the final tag.
+Use with "always" to indicate the normal lines to be added after tags should
+not be added after the final tag.
 
 |||
 |---|---|

--- a/.README/rules/tag-lines.md
+++ b/.README/rules/tag-lines.md
@@ -22,7 +22,7 @@ not be added after the final tag.
 |---|---|
 |Context|everywhere|
 |Tags|Any|
-|Recommended|false|
+|Recommended|true|
 |Settings|N/A|
 |Options|(a string matching `"always" or "never"` and optional object with `count` and `noEndLines`)|
 

--- a/README.md
+++ b/README.md
@@ -18301,7 +18301,8 @@ Use with "always" to indicate the number of lines to require be present.
 <a name="eslint-plugin-jsdoc-rules-tag-lines-options-37-noendline-defaults-to-false"></a>
 ##### <code>noEndLine</code> (defaults to <code>false</code>)
 
-Use with "always" to indicate tag lines should not be added at the end.
+Use with "always" to indicate the normal lines after tags should not be
+added after the final tag.
 
 |||
 |---|---|

--- a/README.md
+++ b/README.md
@@ -18298,8 +18298,8 @@ The second option is an object with the following optional properties.
 
 Use with "always" to indicate the number of lines to require be present.
 
-<a name="eslint-plugin-jsdoc-rules-tag-lines-options-37-noendline-defaults-to-false"></a>
-##### <code>noEndLine</code> (defaults to <code>false</code>)
+<a name="eslint-plugin-jsdoc-rules-tag-lines-options-37-noendlines-defaults-to-false"></a>
+##### <code>noEndLines</code> (defaults to <code>false</code>)
 
 Use with "always" to indicate the normal lines after tags should not be
 added after the final tag.
@@ -18310,7 +18310,7 @@ added after the final tag.
 |Tags|Any|
 |Recommended|false|
 |Settings|N/A|
-|Options|(a string matching `"always" or "never"` and optional object with `count` and `noEndLine`)|
+|Options|(a string matching `"always" or "never"` and optional object with `count` and `noEndLines`)|
 
 The following patterns are considered problems:
 
@@ -18345,7 +18345,7 @@ The following patterns are considered problems:
  * @param {string} a
  * @param {number} b
  */
-// "jsdoc/tag-lines": ["error"|"warn", "always",{"noEndLine":true}]
+// "jsdoc/tag-lines": ["error"|"warn", "always",{"noEndLines":true}]
 // Message: Expected 1 line between tags but found 0
 
 /**
@@ -18399,15 +18399,15 @@ The following patterns are not considered problems:
  *
  * @param {string} a
  */
-// "jsdoc/tag-lines": ["error"|"warn", "always",{"noEndLine":true}]
+// "jsdoc/tag-lines": ["error"|"warn", "always",{"noEndLines":true}]
 
 /**
  * @param {string} a
  */
-// "jsdoc/tag-lines": ["error"|"warn", "never",{"noEndLine":true}]
+// "jsdoc/tag-lines": ["error"|"warn", "never",{"noEndLines":true}]
 
 /** @param {number} b */
-// "jsdoc/tag-lines": ["error"|"warn", "never",{"noEndLine":true}]
+// "jsdoc/tag-lines": ["error"|"warn", "never",{"noEndLines":true}]
 
 /**
  * Some description

--- a/README.md
+++ b/README.md
@@ -18301,8 +18301,8 @@ Use with "always" to indicate the number of lines to require be present.
 <a name="eslint-plugin-jsdoc-rules-tag-lines-options-37-noendlines-defaults-to-false"></a>
 ##### <code>noEndLines</code> (defaults to <code>false</code>)
 
-Use with "always" to indicate the normal lines after tags should not be
-added after the final tag.
+Use with "always" to indicate the normal lines to be added after tags should
+not be added after the final tag.
 
 |||
 |---|---|

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ JSDoc linting rules for ESLint.
         * [`require-throws`](#eslint-plugin-jsdoc-rules-require-throws)
         * [`require-yields`](#eslint-plugin-jsdoc-rules-require-yields)
         * [`require-yields-check`](#eslint-plugin-jsdoc-rules-require-yields-check)
+        * [`tag-lines`](#eslint-plugin-jsdoc-rules-tag-lines)
         * [`valid-types`](#eslint-plugin-jsdoc-rules-valid-types)
 
 
@@ -18279,6 +18280,156 @@ function * quux (foo) {
 ````
 
 
+<a name="eslint-plugin-jsdoc-rules-tag-lines"></a>
+### <code>tag-lines</code>
+
+Enforces lines (or no lines) between tags.
+
+<a name="eslint-plugin-jsdoc-rules-tag-lines-options-37"></a>
+#### Options
+
+The first option is a single string set to "always" or "never" (defaults to
+"never").
+
+The second option is an object with the following optional properties.
+
+<a name="eslint-plugin-jsdoc-rules-tag-lines-options-37-count-defaults-to-1"></a>
+##### <code>count</code> (defaults to 1)
+
+Use with "always" to indicate the number of lines to require be present.
+
+<a name="eslint-plugin-jsdoc-rules-tag-lines-options-37-noendline-defaults-to-false"></a>
+##### <code>noEndLine</code> (defaults to <code>false</code>)
+
+Use with "always" to indicate tag lines should not be added at the end.
+
+|||
+|---|---|
+|Context|everywhere|
+|Tags|Any|
+|Recommended|false|
+|Settings|N/A|
+|Options|(a string matching `"always" or "never"` and optional object with `count` and `noEndLine`)|
+
+The following patterns are considered problems:
+
+````js
+/**
+ * Some description
+ * @param {string} a
+ * @param {number} b
+ */
+// "jsdoc/tag-lines": ["error"|"warn", "always"]
+// Message: Expected 1 line between tags but found 0
+
+/**
+ * Some description
+ * @param {string} a
+ * @param {number} b
+ */
+// "jsdoc/tag-lines": ["error"|"warn", "always",{"count":2}]
+// Message: Expected 2 lines between tags but found 0
+
+/**
+ * Some description
+ * @param {string} a
+ *
+ * @param {number} b
+ */
+// "jsdoc/tag-lines": ["error"|"warn", "always",{"count":2}]
+// Message: Expected 2 lines between tags but found 1
+
+/**
+ * Some description
+ * @param {string} a
+ * @param {number} b
+ */
+// "jsdoc/tag-lines": ["error"|"warn", "always",{"noEndLine":true}]
+// Message: Expected 1 line between tags but found 0
+
+/**
+ * Some description
+ * @param {string} a
+ *
+ * @param {number} b
+ *
+ */
+// "jsdoc/tag-lines": ["error"|"warn", "never"]
+// Message: Expected no lines between tags
+
+/**
+ * Some description
+ * @param {string} a
+ *
+ * @param {number} b
+ *
+ */
+// Message: Expected no lines between tags
+
+/**
+ * Some description
+ * @param {string} a
+ *
+ * @param {number} b
+ * @param {number} c
+ */
+// "jsdoc/tag-lines": ["error"|"warn", "always"]
+// Message: Expected 1 line between tags but found 0
+````
+
+The following patterns are not considered problems:
+
+````js
+/**
+ * Some description
+ * @param {string} a
+ * @param {number} b
+ */
+
+/**
+ * Some description
+ * @param {string} a
+ * @param {number} b
+ */
+// "jsdoc/tag-lines": ["error"|"warn", "never"]
+
+/**
+ * @param {string} a
+ *
+ * @param {string} a
+ */
+// "jsdoc/tag-lines": ["error"|"warn", "always",{"noEndLine":true}]
+
+/**
+ * @param {string} a
+ */
+// "jsdoc/tag-lines": ["error"|"warn", "never",{"noEndLine":true}]
+
+/** @param {number} b */
+// "jsdoc/tag-lines": ["error"|"warn", "never",{"noEndLine":true}]
+
+/**
+ * Some description
+ * @param {string} a
+ *
+ * @param {number} b
+ *
+ */
+// "jsdoc/tag-lines": ["error"|"warn", "always"]
+
+/**
+ * Some description
+ * @param {string} a
+ *
+ *
+ * @param {number} b
+ *
+ *
+ */
+// "jsdoc/tag-lines": ["error"|"warn", "always",{"count":2}]
+````
+
+
 <a name="eslint-plugin-jsdoc-rules-valid-types"></a>
 ### <code>valid-types</code>
 
@@ -18359,7 +18510,7 @@ for valid types (based on the tag's `type` value), and either portion checked
 for presence (based on `false` `name` or `type` values or their `required`
 value). See the setting for more details.
 
-<a name="eslint-plugin-jsdoc-rules-valid-types-options-37"></a>
+<a name="eslint-plugin-jsdoc-rules-valid-types-options-38"></a>
 #### Options
 
 - `allowEmptyNamepaths` (default: true) - Set to `false` to bulk disallow

--- a/README.md
+++ b/README.md
@@ -18308,7 +18308,7 @@ not be added after the final tag.
 |---|---|
 |Context|everywhere|
 |Tags|Any|
-|Recommended|false|
+|Recommended|true|
 |Settings|N/A|
 |Options|(a string matching `"always" or "never"` and optional object with `count` and `noEndLines`)|
 

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ import requireReturnsType from './rules/requireReturnsType';
 import requireThrows from './rules/requireThrows';
 import requireYields from './rules/requireYields';
 import requireYieldsCheck from './rules/requireYieldsCheck';
+import tagLines from './rules/tagLines';
 import validTypes from './rules/validTypes';
 
 export default {
@@ -91,6 +92,7 @@ export default {
         'jsdoc/require-throws': 'off',
         'jsdoc/require-yields': 'warn',
         'jsdoc/require-yields-check': 'warn',
+        'jsdoc/tag-lines': 'warn',
         'jsdoc/valid-types': 'warn',
       },
     },
@@ -139,6 +141,7 @@ export default {
     'require-throws': requireThrows,
     'require-yields': requireYields,
     'require-yields-check': requireYieldsCheck,
+    'tag-lines': tagLines,
     'valid-types': validTypes,
   },
 };

--- a/src/rules/tagLines.js
+++ b/src/rules/tagLines.js
@@ -9,7 +9,7 @@ export default iterateJsdoc(({
     alwaysNever = 'never',
     {
       count = 1,
-      noEndLine = false,
+      noEndLines = false,
     } = {},
   ] = context.options;
 
@@ -37,7 +37,7 @@ export default iterateJsdoc(({
     return;
   }
 
-  (noEndLine ? jsdoc.tags.slice(0, -1) : jsdoc.tags).some((tg, tagIdx) => {
+  (noEndLines ? jsdoc.tags.slice(0, -1) : jsdoc.tags).some((tg, tagIdx) => {
     const lines = [];
 
     tg.source.forEach(({number, tokens: {tag, name, type, description, end}}, idx) => {
@@ -80,7 +80,7 @@ export default iterateJsdoc(({
           count: {
             type: 'integer',
           },
-          noEndLine: {
+          noEndLines: {
             type: 'boolean',
           },
         },

--- a/src/rules/tagLines.js
+++ b/src/rules/tagLines.js
@@ -1,0 +1,92 @@
+import iterateJsdoc from '../iterateJsdoc';
+
+export default iterateJsdoc(({
+  context,
+  jsdoc,
+  utils,
+}) => {
+  const [
+    alwaysNever = 'never',
+    {
+      count = 1,
+      noEndLine = false,
+    } = {},
+  ] = context.options;
+
+  if (alwaysNever === 'never') {
+    jsdoc.tags.some((tg, tagIdx) => {
+      return tg.source.some(({tokens: {tag, name, type, description, end}}, idx) => {
+        const fixer = () => {
+          utils.removeTagItem(tagIdx, idx);
+        };
+        if (!tag && !name && !type && !description && !end) {
+          utils.reportJSDoc(
+            'Expected no lines between tags',
+            {line: tg.source[0].number + 1},
+            fixer,
+            true,
+          );
+
+          return true;
+        }
+
+        return false;
+      });
+    });
+
+    return;
+  }
+
+  (noEndLine ? jsdoc.tags.slice(0, -1) : jsdoc.tags).some((tg, tagIdx) => {
+    const lines = [];
+
+    tg.source.forEach(({number, tokens: {tag, name, type, description, end}}, idx) => {
+      if (!tag && !name && !type && !description && !end) {
+        lines.push({idx, number});
+      }
+    });
+    if (lines.length < count) {
+      const fixer = () => {
+        utils.addLines(tagIdx, lines[lines.length - 1]?.idx || 1, count - lines.length);
+      };
+      utils.reportJSDoc(
+        `Expected ${count} line${count === 1 ? '' : 's'} between tags but found ${lines.length}`,
+        {line: lines[lines.length - 1]?.number || tg.source[0].number},
+        fixer,
+        true,
+      );
+
+      return true;
+    }
+
+    return false;
+  });
+}, {
+  iterateAllJsdocs: true,
+  meta: {
+    docs: {
+      description: 'Enforces lines (or no lines) between tags.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-tag-lines',
+    },
+    fixable: true,
+    schema: [
+      {
+        enum: ['always', 'never'],
+        type: 'string',
+      },
+      {
+        additionalProperies: false,
+        properties: {
+          count: {
+            type: 'integer',
+          },
+          noEndLine: {
+            type: 'boolean',
+          },
+        },
+        type: 'object',
+      },
+    ],
+    type: 'suggestion',
+  },
+});

--- a/src/rules/tagLines.js
+++ b/src/rules/tagLines.js
@@ -68,7 +68,7 @@ export default iterateJsdoc(({
       description: 'Enforces lines (or no lines) between tags.',
       url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-tag-lines',
     },
-    fixable: true,
+    fixable: 'code',
     schema: [
       {
         enum: ['always', 'never'],

--- a/test/rules/assertions/tagLines.js
+++ b/test/rules/assertions/tagLines.js
@@ -88,7 +88,7 @@ export default {
       options: [
         'always',
         {
-          noEndLine: true,
+          noEndLines: true,
         },
       ],
       output: `
@@ -203,7 +203,7 @@ export default {
        */
       `,
       options: ['always', {
-        noEndLine: true,
+        noEndLines: true,
       }],
     },
     {
@@ -213,7 +213,7 @@ export default {
        */
       `,
       options: ['never', {
-        noEndLine: true,
+        noEndLines: true,
       }],
     },
     {
@@ -221,7 +221,7 @@ export default {
       /** @param {number} b */
       `,
       options: ['never', {
-        noEndLine: true,
+        noEndLines: true,
       }],
     },
     {

--- a/test/rules/assertions/tagLines.js
+++ b/test/rules/assertions/tagLines.js
@@ -1,0 +1,256 @@
+export default {
+  invalid: [
+    {
+      code: `
+      /**
+       * Some description
+       * @param {string} a
+       * @param {number} b
+       */
+      `,
+      errors: [{
+        line: 4,
+        message: 'Expected 1 line between tags but found 0',
+      }],
+      options: ['always'],
+      output: `
+      /**
+       * Some description
+       * @param {string} a
+       *
+       * @param {number} b
+       */
+      `,
+    },
+    {
+      code: `
+      /**
+       * Some description
+       * @param {string} a
+       * @param {number} b
+       */
+      `,
+      errors: [{
+        line: 4,
+        message: 'Expected 2 lines between tags but found 0',
+      }],
+      options: ['always', {
+        count: 2,
+      }],
+      output: `
+      /**
+       * Some description
+       * @param {string} a
+       *
+       *
+       * @param {number} b
+       */
+      `,
+    },
+    {
+      code: `
+      /**
+       * Some description
+       * @param {string} a
+       *
+       * @param {number} b
+       */
+      `,
+      errors: [{
+        line: 5,
+        message: 'Expected 2 lines between tags but found 1',
+      }],
+      options: ['always', {
+        count: 2,
+      }],
+      output: `
+      /**
+       * Some description
+       * @param {string} a
+       *
+       *
+       * @param {number} b
+       */
+      `,
+    },
+    {
+      code: `
+      /**
+       * Some description
+       * @param {string} a
+       * @param {number} b
+       */
+      `,
+      errors: [{
+        line: 4,
+        message: 'Expected 1 line between tags but found 0',
+      }],
+      options: [
+        'always',
+        {
+          noEndLine: true,
+        },
+      ],
+      output: `
+      /**
+       * Some description
+       * @param {string} a
+       *
+       * @param {number} b
+       */
+      `,
+    },
+    {
+      code: `
+      /**
+       * Some description
+       * @param {string} a
+       *
+       * @param {number} b
+       *
+       */
+      `,
+      errors: [{
+        line: 5,
+        message: 'Expected no lines between tags',
+      }],
+      options: ['never'],
+      output: `
+      /**
+       * Some description
+       * @param {string} a
+       * @param {number} b
+       *
+       */
+      `,
+    },
+    {
+      code: `
+      /**
+       * Some description
+       * @param {string} a
+       *
+       * @param {number} b
+       *
+       */
+      `,
+      errors: [{
+        line: 5,
+        message: 'Expected no lines between tags',
+      }],
+      output: `
+      /**
+       * Some description
+       * @param {string} a
+       * @param {number} b
+       *
+       */
+      `,
+    },
+    {
+      code: `
+      /**
+       * Some description
+       * @param {string} a
+       *
+       * @param {number} b
+       * @param {number} c
+       */
+      `,
+      errors: [{
+        line: 6,
+        message: 'Expected 1 line between tags but found 0',
+      }],
+      options: ['always'],
+      output: `
+      /**
+       * Some description
+       * @param {string} a
+       *
+       * @param {number} b
+       *
+       * @param {number} c
+       */
+      `,
+    },
+  ],
+  valid: [
+    {
+      code: `
+      /**
+       * Some description
+       * @param {string} a
+       * @param {number} b
+       */
+      `,
+    },
+    {
+      code: `
+      /**
+       * Some description
+       * @param {string} a
+       * @param {number} b
+       */
+      `,
+      options: ['never'],
+    },
+    {
+      code: `
+      /**
+       * @param {string} a
+       *
+       * @param {string} a
+       */
+      `,
+      options: ['always', {
+        noEndLine: true,
+      }],
+    },
+    {
+      code: `
+      /**
+       * @param {string} a
+       */
+      `,
+      options: ['never', {
+        noEndLine: true,
+      }],
+    },
+    {
+      code: `
+      /** @param {number} b */
+      `,
+      options: ['never', {
+        noEndLine: true,
+      }],
+    },
+    {
+      code: `
+      /**
+       * Some description
+       * @param {string} a
+       *
+       * @param {number} b
+       *
+       */
+      `,
+      options: ['always'],
+    },
+    {
+      code: `
+      /**
+       * Some description
+       * @param {string} a
+       *
+       *
+       * @param {number} b
+       *
+       *
+       */
+      `,
+      options: ['always', {
+        count: 2,
+      }],
+    },
+  ],
+};

--- a/test/rules/ruleNames.json
+++ b/test/rules/ruleNames.json
@@ -42,5 +42,6 @@
   "require-throws",
   "require-yields",
   "require-yields-check",
+  "tag-lines",
   "valid-types"
 ]


### PR DESCRIPTION
Includes a `always` vs. `never` option as well as two special options for `always` (`count` and `noEndLine`). Fixes #93.