### PR TITLE
`no-bad-blocks`: add `preventAllMultiasteriskBlocks`  option

### DIFF
--- a/.README/rules/no-bad-blocks.md
+++ b/.README/rules/no-bad-blocks.md
@@ -1,8 +1,8 @@
 ### `no-bad-blocks`
 
 This rule checks for multi-line-style comments which fail to meet the
-criteria of a jsdoc block, namely that it should begin with two asterisks,
-but which appear to be intended as jsdoc blocks due to the presence
+criteria of a jsdoc block, namely that it should begin with two and only two
+asterisks, but which appear to be intended as jsdoc blocks due to the presence
 of whitespace followed by whitespace or asterisks, and
 an at-sign (`@`) and some non-whitespace (as with a jsdoc block tag).
 
@@ -18,11 +18,16 @@ a multi-comment block and at-sign `/* @`.
 Defaults to `['ts-check', 'ts-expect-error', 'ts-ignore', 'ts-nocheck']`
 (some directives [used by TypeScript](https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html#ts-check)).
 
+##### `preventAllMultiAsteriskBlocks`
+
+A boolean (defaulting to `false`) which if `true` will prevent all
+multi-asterisked blocks even those without apparent tag content.
+
 |||
 |---|---|
 |Context|Everywhere|
 |Tags|N/A|
 |Recommended|false|
-|Options|`ignore`|
+|Options|`ignore`, `preventAllMultiAsteriskBlocks`|
 
 <!-- assertions noBadBlocks -->

--- a/README.md
+++ b/README.md
@@ -7215,8 +7215,8 @@ function example() {
 ### <code>no-bad-blocks</code>
 
 This rule checks for multi-line-style comments which fail to meet the
-criteria of a jsdoc block, namely that it should begin with two asterisks,
-but which appear to be intended as jsdoc blocks due to the presence
+criteria of a jsdoc block, namely that it should begin with two and only two
+asterisks, but which appear to be intended as jsdoc blocks due to the presence
 of whitespace followed by whitespace or asterisks, and
 an at-sign (`@`) and some non-whitespace (as with a jsdoc block tag).
 
@@ -7234,12 +7234,18 @@ a multi-comment block and at-sign `/* @`.
 Defaults to `['ts-check', 'ts-expect-error', 'ts-ignore', 'ts-nocheck']`
 (some directives [used by TypeScript](https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html#ts-check)).
 
+<a name="eslint-plugin-jsdoc-rules-no-bad-blocks-options-13-preventallmultiasteriskblocks"></a>
+##### <code>preventAllMultiAsteriskBlocks</code>
+
+A boolean (defaulting to `false`) which if `true` will prevent all
+multi-asterisked blocks even those without apparent tag content.
+
 |||
 |---|---|
 |Context|Everywhere|
 |Tags|N/A|
 |Recommended|false|
-|Options|`ignore`|
+|Options|`ignore`, `preventAllMultiAsteriskBlocks`|
 
 The following patterns are considered problems:
 
@@ -7283,6 +7289,15 @@ function echo() {
 function quux (foo) {
 
 }
+// Message: Expected JSDoc-like comment to begin with two asterisks.
+
+/***
+ *
+ */
+function quux (foo) {
+
+}
+// "jsdoc/no-bad-blocks": ["error"|"warn", {"preventAllMultiAsteriskBlocks":true}]
 // Message: Expected JSDoc-like comment to begin with two asterisks.
 ````
 
@@ -7328,6 +7343,13 @@ function quux () {
 
 /* @custom */
 // "jsdoc/no-bad-blocks": ["error"|"warn", {"ignore":["custom"]}]
+
+/***
+ *
+ */
+function quux (foo) {
+
+}
 ````
 
 

--- a/src/rules/noBadBlocks.js
+++ b/src/rules/noBadBlocks.js
@@ -22,6 +22,7 @@ export default iterateJsdoc(({
         'ts-ignore',
         'ts-nocheck',
       ],
+      preventAllMultiAsteriskBlocks = false,
     } = {},
   ] = context.options;
 
@@ -36,6 +37,9 @@ export default iterateJsdoc(({
       }
       sliceIndex = multiline.length;
       extraAsterisks = true;
+      if (preventAllMultiAsteriskBlocks) {
+        return true;
+      }
     }
 
     const [{tags = {}} = {}] = commentParser(
@@ -83,6 +87,9 @@ export default iterateJsdoc(({
               type: 'string',
             },
             type: 'array',
+          },
+          preventAllMultiAsteriskBlocks: {
+            type: 'boolean',
           },
         },
         type: 'object',

--- a/test/rules/assertions/noBadBlocks.js
+++ b/test/rules/assertions/noBadBlocks.js
@@ -124,6 +124,33 @@ export default {
           }
       `,
     },
+    {
+      code: `
+          /***
+           *
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Expected JSDoc-like comment to begin with two asterisks.',
+        },
+      ],
+      options: [{
+        preventAllMultiAsteriskBlocks: true,
+      }],
+      output: `
+          /**
+           *
+           */
+          function quux (foo) {
+
+          }
+      `,
+    },
   ],
   valid: [
     {
@@ -186,6 +213,16 @@ export default {
     {
       code: '/* @custom */',
       options: [{ignore: ['custom']}],
+    },
+    {
+      code: `
+          /***
+           *
+           */
+          function quux (foo) {
+
+          }
+      `,
     },
   ],
 };


### PR DESCRIPTION
feat(`no-bad-blocks`): add `preventAllMultiasteriskBlocks` boolean option to allow reporting of any multi-asterisked multiline comments