### PR TITLE
Add `preserveMainDescriptionPostDelimiter` option to `check-line-alignment` rule

### DIFF
--- a/src/alignTransform.js
+++ b/src/alignTransform.js
@@ -58,7 +58,7 @@ const space = (len) => {
   return ''.padStart(len, ' ');
 };
 
-const alignTransform = (tags, indent) => {
+const alignTransform = (tags, indent, preserveMainDescriptionPostDelimiter) => {
   let intoTags = false;
   let width;
 
@@ -145,7 +145,11 @@ const alignTransform = (tags, indent) => {
     /* eslint-enable */
 
     if (!intoTags) {
-      tokens.postDelimiter = tokens.description === '' ? '' : ' ';
+      if (tokens.description === '') {
+        tokens.postDelimiter = '';
+      } else if (!preserveMainDescriptionPostDelimiter) {
+        tokens.postDelimiter = ' ';
+      }
 
       return {
         ...line,

--- a/src/rules/checkLineAlignment.js
+++ b/src/rules/checkLineAlignment.js
@@ -100,11 +100,12 @@ const checkAlignment = ({
   indent,
   jsdoc,
   jsdocNode,
+  preserveMainDescriptionPostDelimiter,
   report,
   tags,
   utils,
 }) => {
-  const transform = commentFlow(alignTransform(tags, indent));
+  const transform = commentFlow(alignTransform(tags, indent, preserveMainDescriptionPostDelimiter));
   const transformedJsdoc = transform(jsdoc);
 
   const comment = '/*' + jsdocNode.value + '*/';
@@ -131,6 +132,7 @@ export default iterateJsdoc(({
 }) => {
   const {
     tags: applicableTags = ['param', 'arg', 'argument', 'property', 'prop', 'returns', 'return'],
+    preserveMainDescriptionPostDelimiter,
   } = context.options[1] || {};
 
   if (context.options[0] === 'always') {
@@ -143,6 +145,7 @@ export default iterateJsdoc(({
       indent,
       jsdoc,
       jsdocNode,
+      preserveMainDescriptionPostDelimiter,
       report,
       tags: applicableTags,
       utils,
@@ -171,6 +174,10 @@ export default iterateJsdoc(({
       {
         additionalProperties: false,
         properties: {
+          preserveMainDescriptionPostDelimiter: {
+            default: false,
+            type: 'boolean',
+          },
           tags: {
             items: {
               type: 'string',

--- a/test/rules/assertions/checkLineAlignment.js
+++ b/test/rules/assertions/checkLineAlignment.js
@@ -860,6 +860,35 @@ export default {
       function quux () {}
       `,
     },
+    {
+      code: `
+      /**
+       * Function description
+       *           description with post delimiter.
+       *
+       * @param {string} lorem Description.
+       * @param {int}    sit   Description multi words.
+       */
+      const fn = ( lorem, sit ) => {}
+      `,
+      errors: [
+        {
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      options: ['always'],
+      output: `
+      /**
+       * Function description
+       * description with post delimiter.
+       *
+       * @param {string} lorem Description.
+       * @param {int}    sit   Description multi words.
+       */
+      const fn = ( lorem, sit ) => {}
+      `,
+    },
   ],
   valid: [
     {
@@ -1182,6 +1211,21 @@ export default {
 
       }
       `,
+    },
+    {
+      code: `
+        /**
+         * Function description
+         *           description with post delimiter.
+         *
+         * @param {string} lorem Description.
+         * @param {int}    sit   Description multi words.
+         */
+        const fn = ( lorem, sit ) => {}
+      `,
+      options: ['always', {
+        preserveMainDescriptionPostDelimiter: true,
+      }],
     },
   ],
 };


### PR DESCRIPTION
This introduces the new option `preserveMainDescriptionPostDelimiter ` for the `check-line-alignment` rule.

This new option will preserve the post delimiter (spacings after the `*`) in the main description when using the `always` option.

```js
      /**
       * Function description
       *           description with post delimiter.
       *
       * @param {string} lorem Description.
       * @param {int}    sit   Description multi words.
       */
```

Notice that it just applies to `always` because the `never` always preserves the spacing. I thought about doing it as default to `always` too, but since we already released it in that way, I added a new option to avoid breaking changes.