### PR TITLE
feat(`multiline-blocks`): add `noFinalLineText` option

### DIFF
--- a/.README/rules/multiline-blocks.md
+++ b/.README/rules/multiline-blocks.md
@@ -7,6 +7,8 @@ Note that if you set `noSingleLineBlocks` and `noMultilineBlocks` to `true`
 and configure them in a certain manner, you might effectively be prohibiting
 all jsdoc blocks!
 
+Also allows for preventing text at the very beginning or very end of blocks.
+
 #### Options
 
 A single options object with the following properties.
@@ -15,6 +17,13 @@ A single options object with the following properties.
 
 For multiline blocks, any non-whitespace text immediately after the `/**` and
 space will be reported. (Text after a newline is not reported.)
+
+`noMultilineBlocks` will have priority over this rule if it applies.
+
+##### `noFinalLineText` (defaults to `true`)
+
+For multiline blocks, any non-whitespace text preceding the `*/` on the final
+line will be reported. (Text preceding a newline is not reported.)
 
 `noMultilineBlocks` will have priority over this rule if it applies.
 
@@ -79,6 +88,6 @@ cannot be reliably added after the tag either).
 |Tags|Any (though `singleLineTags` and `multilineTags` control the application)|
 |Recommended|true|
 |Settings||
-|Options|`noZeroLineText`, `noSingleLineBlocks`, `singleLineTags`, `noMultilineBlocks`, `minimumLengthForMultiline`, `multilineTags`, `allowMultipleTags`|
+|Options|`noZeroLineText`, `noSingleLineBlocks`, `singleLineTags`, `noMultilineBlocks`, `minimumLengthForMultiline`, `multilineTags`, `allowMultipleTags`, `noFinalLineText`|
 
 <!-- assertions multilineBlocks -->

--- a/README.md
+++ b/README.md
@@ -7138,6 +7138,8 @@ Note that if you set `noSingleLineBlocks` and `noMultilineBlocks` to `true`
 and configure them in a certain manner, you might effectively be prohibiting
 all jsdoc blocks!
 
+Also allows for preventing text at the very beginning or very end of blocks.
+
 <a name="eslint-plugin-jsdoc-rules-multiline-blocks-options-12"></a>
 #### Options
 
@@ -7148,6 +7150,14 @@ A single options object with the following properties.
 
 For multiline blocks, any non-whitespace text immediately after the `/**` and
 space will be reported. (Text after a newline is not reported.)
+
+`noMultilineBlocks` will have priority over this rule if it applies.
+
+<a name="eslint-plugin-jsdoc-rules-multiline-blocks-options-12-nofinallinetext-defaults-to-true"></a>
+##### <code>noFinalLineText</code> (defaults to <code>true</code>)
+
+For multiline blocks, any non-whitespace text preceding the `*/` on the final
+line will be reported. (Text preceding a newline is not reported.)
 
 `noMultilineBlocks` will have priority over this rule if it applies.
 
@@ -7218,7 +7228,7 @@ cannot be reliably added after the tag either).
 |Tags|Any (though `singleLineTags` and `multilineTags` control the application)|
 |Recommended|true|
 |Settings||
-|Options|`noZeroLineText`, `noSingleLineBlocks`, `singleLineTags`, `noMultilineBlocks`, `minimumLengthForMultiline`, `multilineTags`, `allowMultipleTags`|
+|Options|`noZeroLineText`, `noSingleLineBlocks`, `singleLineTags`, `noMultilineBlocks`, `minimumLengthForMultiline`, `multilineTags`, `allowMultipleTags`, `noFinalLineText`|
 
 The following patterns are considered problems:
 
@@ -7367,6 +7377,16 @@ The following patterns are considered problems:
  * line. */
 // "jsdoc/multiline-blocks": ["error"|"warn", {"multilineTags":[],"noMultilineBlocks":true}]
 // Message: Multiline jsdoc blocks are prohibited by your configuration.
+
+/**
+ * @someTag {aType} with Description */
+// "jsdoc/multiline-blocks": ["error"|"warn", {"noFinalLineBlocks":true}]
+// Message: Should have no text on the final line (before the `*/`).
+
+/**
+ * Description */
+// "jsdoc/multiline-blocks": ["error"|"warn", {"noFinalLineBlocks":true}]
+// Message: Should have no text on the final line (before the `*/`).
 ````
 
 The following patterns are not considered problems:
@@ -7469,6 +7489,9 @@ The following patterns are not considered problems:
  * @oneTag
  */
 // "jsdoc/multiline-blocks": ["error"|"warn", {"allowMultipleTags":false,"multilineTags":["oneTag"],"noMultilineBlocks":true}]
+
+/** @someTag with Description */
+// "jsdoc/multiline-blocks": ["error"|"warn", {"noFinalLineBlocks":true}]
 ````
 
 
@@ -8292,6 +8315,14 @@ The following patterns are considered problems:
 // Message: Should be no multiple asterisks on end lines.
 
 /** abc * */
+// Message: Should be no multiple asterisks on end lines.
+
+/**
+ * Preserve user's whitespace when fixing (though one may also
+ *   use an align rule)
+ *
+ * */
+// "jsdoc/no-multi-asterisks": ["error"|"warn", {"preventAtEnd":true}]
 // Message: Should be no multiple asterisks on end lines.
 ````
 

--- a/test/rules/assertions/multilineBlocks.js
+++ b/test/rules/assertions/multilineBlocks.js
@@ -467,6 +467,42 @@ export default {
         /** @lends This can be safely fixed to a single line. */
       `,
     },
+    {
+      code: `
+        /**
+         * @someTag {aType} with Description */
+      `,
+      errors: [{
+        line: 2,
+        message: 'Should have no text on the final line (before the `*/`).',
+      }],
+      options: [{
+        noFinalLineBlocks: true,
+      }],
+      output: `
+        /**
+         * @someTag {aType} with Description
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * Description */
+      `,
+      errors: [{
+        line: 2,
+        message: 'Should have no text on the final line (before the `*/`).',
+      }],
+      options: [{
+        noFinalLineBlocks: true,
+      }],
+      output: `
+        /**
+         * Description
+         */
+      `,
+    },
   ],
   valid: [
     {
@@ -683,6 +719,14 @@ export default {
         allowMultipleTags: false,
         multilineTags: ['oneTag'],
         noMultilineBlocks: true,
+      }],
+    },
+    {
+      code: `
+        /** @someTag with Description */
+      `,
+      options: [{
+        noFinalLineBlocks: true,
       }],
     },
   ],

--- a/test/rules/assertions/noMultiAsterisks.js
+++ b/test/rules/assertions/noMultiAsterisks.js
@@ -215,6 +215,29 @@ export default {
       /** abc */
       `,
     },
+    {
+      code: `
+      /**
+       * Preserve user's whitespace when fixing (though one may also
+       *   use an align rule)
+       *
+       * */
+      `,
+      errors: [{
+        line: 6,
+        message: 'Should be no multiple asterisks on end lines.',
+      }],
+      options: [{
+        preventAtEnd: true,
+      }],
+      output: `
+      /**
+       * Preserve user's whitespace when fixing (though one may also
+       *   use an align rule)
+       *
+        */
+      `,
+    },
   ],
   valid: [
     {


### PR DESCRIPTION
feat(`multiline-blocks`): add `noFinalLineText` option; fixes #738