### PR TITLE
feat: `match-name` rule; fixes #509

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -557,6 +557,7 @@ selector).
 {"gitdown": "include", "file": "./rules/empty-tags.md"}
 {"gitdown": "include", "file": "./rules/implements-on-classes.md"}
 {"gitdown": "include", "file": "./rules/match-description.md"}
+{"gitdown": "include", "file": "./rules/match-name.md"}
 {"gitdown": "include", "file": "./rules/multiline-blocks.md"}
 {"gitdown": "include", "file": "./rules/newline-after-description.md"}
 {"gitdown": "include", "file": "./rules/no-bad-blocks.md"}

--- a/.README/rules/match-name.md
+++ b/.README/rules/match-name.md
@@ -1,0 +1,61 @@
+### `match-name`
+
+Reports the name portion of a JSDoc tag if matching or not matching
+a given regular expression.
+
+Note that some tags do not possess names and anything appearing to be a
+name will actually be part of the description (e.g., for
+`@returns {type} notAName`). If you are defining your own tags, see the
+`structuredTags` setting (if `name: false`, this rule will not apply to
+that tag).
+
+#### Options
+
+A single options object with the following properties:
+
+##### `match`
+
+`match` is a required option containing an array of objects which determine
+the conditions whereby a name is reported as being problematic.
+
+These objects can have any combination of the following groups of optional
+properties, all of which act to confine one another:
+
+- `tags` - This array should include tag names or `*` to indicate the
+  match will apply for all tags (except as confined by any context
+  properties). If `*` is not used, then these rules will only apply to
+  the specified tags. If `tags` is omitted, then `*` is assumed.
+
+- `allowName` - Indicates which names are allowed for the given tag (or `*`).
+    Accepts a string regular expression (optionally wrapped between two
+    `/` delimiters followed by optional flags) used to match the name.
+- `disallowName` - As with `allowName` but indicates names that are not
+    allowed.
+- `replacement` - If `disallowName` is supplied and this value is present, it
+    will replace the matched `disallowName` text.
+
+- `context` - AST to confine the allowing or disallowing to jsdoc blocks
+    associated with a particular context. See the
+    ["AST and Selectors"](#eslint-plugin-jsdoc-advanced-ast-and-selectors)
+    section of our README for more on the expected format.
+- `comment` - As with `context` but AST for the JSDoc block comment and types
+
+- `message` - An optional custom message to use when there is a match.
+
+Note that `comment`, even if targeting a specific tag, is used to match the
+whole block. So if a `comment` finds its specific tag, it may still apply
+fixes found by the likes of `disallowName` even when a different tag has the
+disallowed name. An alternative is to ensure that `comment` finds the specific
+tag of the desired tag and/or name and no `disallowName` (or `allowName`) is
+supplied. In such a case, only one error will be reported, but no fixer will
+be applied, however.
+
+|||
+|---|---|
+|Context|everywhere|
+|Tags|(The tags specifie by `tags`, including any tag if `*` is set)|
+|Recommended|false|
+|Settings|`structuredTags`|
+|Options|`match`|
+
+<!-- assertions matchName -->

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import checkValues from './rules/checkValues';
 import emptyTags from './rules/emptyTags';
 import implementsOnClasses from './rules/implementsOnClasses';
 import matchDescription from './rules/matchDescription';
+import matchName from './rules/matchName';
 import multilineBlocks from './rules/multilineBlocks';
 import newlineAfterDescription from './rules/newlineAfterDescription';
 import noBadBlocks from './rules/noBadBlocks';
@@ -65,6 +66,7 @@ export default {
         'jsdoc/empty-tags': 'warn',
         'jsdoc/implements-on-classes': 'warn',
         'jsdoc/match-description': 'off',
+        'jsdoc/match-name': 'off',
         'jsdoc/multiline-blocks': 'warn',
         'jsdoc/newline-after-description': 'warn',
         'jsdoc/no-bad-blocks': 'off',
@@ -116,6 +118,7 @@ export default {
     'empty-tags': emptyTags,
     'implements-on-classes': implementsOnClasses,
     'match-description': matchDescription,
+    'match-name': matchName,
     'multiline-blocks': multilineBlocks,
     'newline-after-description': newlineAfterDescription,
     'no-bad-blocks': noBadBlocks,

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -1093,9 +1093,10 @@ const enforcedContexts = (context, defaultContexts) => {
 const getContextObject = (contexts, checkJsdoc, handler) => {
   const properties = {};
 
-  contexts.forEach((prop) => {
+  contexts.forEach((prop, idx) => {
     if (typeof prop === 'object') {
       const selInfo = {
+        lastIndex: idx,
         selector: prop.context,
       };
       if (prop.comment) {
@@ -1110,6 +1111,7 @@ const getContextObject = (contexts, checkJsdoc, handler) => {
       }
     } else {
       const selInfo = {
+        lastIndex: idx,
         selector: prop,
       };
       properties[prop] = checkJsdoc.bind(null, selInfo, null);

--- a/src/rules/matchName.js
+++ b/src/rules/matchName.js
@@ -1,0 +1,130 @@
+import iterateJsdoc from '../iterateJsdoc';
+
+export default iterateJsdoc(({
+  context,
+  jsdoc,
+  report,
+  info: {lastIndex},
+  utils,
+}) => {
+  const {match} = context.options[0] || {};
+  if (!match) {
+    report('Rule `no-restricted-syntax` is missing a `match` option.');
+
+    return;
+  }
+
+  const {
+    allowName,
+    disallowName,
+    replacement,
+    tags = ['*'],
+  } = match[lastIndex];
+
+  const allowNameRegex = allowName && utils.getRegexFromString(allowName);
+  const disallowNameRegex = disallowName && utils.getRegexFromString(disallowName);
+
+  let applicableTags = jsdoc.tags;
+  if (!tags.includes('*')) {
+    applicableTags = utils.getPresentTags(tags);
+  }
+
+  let reported = false;
+  applicableTags.forEach((tag) => {
+    const allowed = !allowNameRegex || allowNameRegex.test(tag.name);
+    const disallowed = disallowNameRegex && disallowNameRegex.test(tag.name);
+    const hasRegex = allowNameRegex || disallowNameRegex;
+    if (hasRegex && allowed && !disallowed) {
+      return;
+    }
+    if (!hasRegex && reported) {
+      return;
+    }
+
+    const fixer = () => {
+      tag.source[0].tokens.name = tag.source[0].tokens.name.replace(
+        disallowNameRegex, replacement,
+      );
+    };
+
+    let {message} = match[lastIndex];
+    if (!message) {
+      if (hasRegex) {
+        message = disallowed ?
+          `Only allowing names not matching \`${disallowNameRegex}\` but found "${tag.name}".` :
+          `Only allowing names matching \`${allowNameRegex}\` but found "${tag.name}".`;
+      } else {
+        message = `Prohibited context for "${tag.name}".`;
+      }
+    }
+
+    utils.reportJSDoc(
+      message,
+      hasRegex ? tag : null,
+
+      // We could match up
+      disallowNameRegex && replacement !== undefined ?
+        fixer :
+        null,
+      false,
+      {
+        // Could also supply `context`, `comment`, `tags`
+        allowName,
+        disallowName,
+        name: tag.name,
+      },
+    );
+    if (!hasRegex) {
+      reported = true;
+    }
+  });
+}, {
+  matchContext: true,
+  meta: {
+    docs: {
+      description: 'Reports the name portion of a JSDoc tag if matching or not matching a given regular expression.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-match-name',
+    },
+    fixable: 'code',
+    schema: [
+      {
+        additionalProperies: false,
+        properties: {
+          match: {
+            additionalProperies: false,
+            items: {
+              properties: {
+                allowName: {
+                  type: 'string',
+                },
+                comment: {
+                  type: 'string',
+                },
+                context: {
+                  type: 'string',
+                },
+                disallowName: {
+                  type: 'string',
+                },
+                message: {
+                  type: 'string',
+                },
+                tags: {
+                  items: {
+                    type: 'string',
+                  },
+                  type: 'array',
+                },
+              },
+              type: 'object',
+            },
+            type: 'array',
+          },
+        },
+        required: ['match'],
+        type: 'object',
+      },
+    ],
+    type: 'suggestion',
+  },
+});

--- a/test/rules/assertions/matchName.js
+++ b/test/rules/assertions/matchName.js
@@ -1,0 +1,418 @@
+export default {
+  invalid: [
+    {
+      code: `
+        /**
+         * @param opt_a
+         * @param opt_b
+         */
+      `,
+      errors: [{
+        line: 3,
+        message: 'Only allowing names not matching `/^opt_/i` but found "opt_a".',
+      }, {
+        line: 4,
+        message: 'Only allowing names not matching `/^opt_/i` but found "opt_b".',
+      }],
+      options: [{
+        match: [
+          {
+            disallowName: '/^opt_/i',
+          },
+        ],
+      }],
+    },
+    {
+      code: `
+        /**
+         * @param opt_a
+         * @param opt_b
+         */
+      `,
+      errors: [{
+        line: 3,
+        message: 'Only allowing names not matching `/^opt_/i` but found "opt_a".',
+      }, {
+        line: 4,
+        message: 'Only allowing names not matching `/^opt_/i` but found "opt_b".',
+      }],
+      options: [{
+        match: [
+          {
+            disallowName: '/^opt_/i',
+            replacement: '',
+          },
+        ],
+      }],
+      output: `
+        /**
+         * @param a
+         * @param opt_b
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @param a
+         * @param opt_b
+         */
+      `,
+      errors: [{
+        line: 4,
+        message: 'Only allowing names matching `/^[a-z]+$/i` but ' +
+          'found "opt_b".',
+      }],
+      options: [{
+        match: [
+          {
+            allowName: '/^[a-z]+$/i',
+          },
+        ],
+      }],
+    },
+    {
+      code: `
+        /**
+         * @param arg
+         * @param opt_b
+         */
+      `,
+      errors: [{
+        line: 3,
+        message: 'Only allowing names not matching `/^arg/i` but ' +
+          'found "arg".',
+      }, {
+        line: 4,
+        message: 'Only allowing names matching `/^[a-z]+$/i` but ' +
+          'found "opt_b".',
+      }],
+      options: [{
+        match: [
+          {
+            allowName: '/^[a-z]+$/i',
+            disallowName: '/^arg/i',
+          },
+        ],
+      }],
+    },
+    {
+      code: `
+        /**
+         * @param opt_a
+         * @param arg
+         */
+      `,
+      errors: [{
+        line: 3,
+        message: 'Only allowing names not matching `/^opt_/i` but ' +
+          'found "opt_a".',
+      }, {
+        line: 4,
+        message: 'Only allowing names not matching `/^arg$/i` but ' +
+          'found "arg".',
+      }],
+      options: [{
+        match: [
+          {
+            disallowName: '/^arg$/i',
+          },
+          {
+            disallowName: '/^opt_/i',
+          },
+        ],
+      }],
+    },
+    {
+      code: `
+        /**
+         * @property opt_a
+         * @param opt_b
+         */
+      `,
+      errors: [{
+        line: 4,
+        message: 'Only allowing names not matching `/^opt_/i` but found "opt_b".',
+      }],
+      options: [{
+        match: [
+          {
+            disallowName: '/^opt_/i',
+            tags: ['param'],
+          },
+        ],
+      }],
+    },
+    {
+      code: `
+        /**
+         * @someTag opt_a
+         * @param opt_b
+         */
+      `,
+      errors: [{
+        line: 4,
+        message: 'Only allowing names not matching `/^opt_/i` but found "opt_b".',
+      }],
+      options: [{
+        match: [
+          {
+            disallowName: '/^opt_/i',
+            tags: ['param'],
+          },
+        ],
+      }],
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            someTag: {
+              name: 'namepath-defining',
+            },
+          },
+        },
+      },
+    },
+    {
+      code: `
+        /**
+         * @property opt_a
+         * @param opt_b
+         */
+      `,
+      errors: [{
+        line: 3,
+        message: 'Only allowing names not matching `/^opt_/i` but found "opt_a".',
+      }, {
+        line: 4,
+        message: 'Only allowing names not matching `/^opt_/i` but found "opt_b".',
+      }],
+      options: [{
+        match: [
+          {
+            disallowName: '/^opt_/i',
+            tags: ['*'],
+          },
+        ],
+      }],
+    },
+    {
+      code: `
+        /**
+         * @param opt_a
+         * @param opt_b
+         */
+        function quux () {
+        }
+      `,
+      errors: [{
+        line: 3,
+        message: 'Only allowing names not matching `/^opt_/i` but found "opt_a".',
+      }, {
+        line: 4,
+        message: 'Only allowing names not matching `/^opt_/i` but found "opt_b".',
+      }],
+      options: [{
+        match: [
+          {
+            context: 'FunctionDeclaration',
+            disallowName: '/^opt_/i',
+          },
+        ],
+      }],
+    },
+    {
+      code: `
+        /**
+         * @property opt_a
+         * @param {Bar|Foo} opt_b
+         */
+      `,
+      errors: [{
+        line: 2,
+        message: 'Prohibited context for "opt_a".',
+      }],
+      options: [{
+        match: [
+          {
+            comment: 'JSDocBlock:has(JSDocTag[tag="param"][name=/opt_/] > JSDocTypeUnion:has(JsdocTypeName[value="Bar"]:nth-child(1)))',
+          },
+        ],
+      }],
+    },
+    {
+      code: `
+        /**
+         * @property opt_a
+         * @param {Bar|Foo} opt_b
+         */
+      `,
+      errors: [{
+        line: 2,
+        message: 'Don\'t use `opt_` prefixes with Bar|...',
+      }],
+      options: [{
+        match: [
+          {
+            comment: 'JSDocBlock:has(JSDocTag[tag="param"][name=/opt_/] > JSDocTypeUnion:has(JsdocTypeName[value="Bar"]:nth-child(1)))',
+            message: 'Don\'t use `opt_` prefixes with Bar|...',
+          },
+        ],
+      }],
+    },
+    {
+      code: `
+      /**
+       * @param opt_a
+       * @param opt_b
+       */
+      function quux () {}
+      `,
+      errors: [{
+        line: 2,
+        message: 'Rule `no-restricted-syntax` is missing a `match` option.',
+      }],
+      options: [],
+    },
+  ],
+  valid: [
+    {
+      code: `
+        /**
+         * @param opt_a
+         * @param opt_b
+         */
+      `,
+      options: [{
+        match: [
+          {
+            disallowName: '/^arg/i',
+          },
+        ],
+      }],
+    },
+    {
+      code: `
+        /**
+         * @param a
+         * @param opt_b
+         */
+      `,
+      options: [{
+        match: [
+          {
+            allowName: '/^[a-z_]+$/i',
+          },
+        ],
+      }],
+    },
+    {
+      code: `
+        /**
+         * @param someArg
+         * @param anotherArg
+         */
+      `,
+      options: [{
+        match: [
+          {
+            allowName: '/^[a-z]+$/i',
+            disallowName: '/^arg/i',
+          },
+        ],
+      }],
+    },
+    {
+      code: `
+        /**
+         * @param elem1
+         * @param elem2
+         */
+      `,
+      options: [{
+        match: [
+          {
+            disallowName: '/^arg$/i',
+          },
+          {
+            disallowName: '/^opt_/i',
+          },
+        ],
+      }],
+    },
+    {
+      code: `
+        /**
+         * @someTag opt_a
+         * @param opt_b
+         */
+      `,
+      options: [{
+        match: [
+          {
+            disallowName: '/^opt_/i',
+            tags: ['property'],
+          },
+        ],
+      }],
+      settings: {
+        jsdoc: {
+          structuredTags: {
+            someTag: {
+              name: 'namepath-defining',
+            },
+          },
+        },
+      },
+    },
+    {
+      code: `
+        /**
+         * @property opt_a
+         * @param opt_b
+         */
+      `,
+      options: [{
+        match: [
+          {
+            disallowName: '/^arg/i',
+            tags: ['*'],
+          },
+        ],
+      }],
+    },
+    {
+      code: `
+        /**
+         * @param opt_a
+         * @param opt_b
+         */
+        class A {
+        }
+      `,
+      options: [{
+        match: [
+          {
+            context: 'FunctionDeclaration',
+            disallowName: '/^opt_/i',
+          },
+        ],
+      }],
+    },
+    {
+      code: `
+        /**
+         * @property opt_a
+         * @param {Foo|Bar} opt_b
+         */
+      `,
+      options: [{
+        match: [
+          {
+            comment: 'JSDocBlock > JSDocTag[tag="param"] > JSDocTypeUnion[left.name="Bar"]',
+            disallowName: '/^opt_/i',
+          },
+        ],
+      }],
+    },
+  ],
+};

--- a/test/rules/ruleNames.json
+++ b/test/rules/ruleNames.json
@@ -13,6 +13,7 @@
   "empty-tags",
   "implements-on-classes",
   "match-description",
+  "match-name",
   "multiline-blocks",
   "newline-after-description",
   "no-bad-blocks",


### PR DESCRIPTION
Allows reporting and in some cases fixing portions of the name (e.g., `@tag name`, based on context or the presence of other tags.