### PR TITLE
fix(valid-types): parse name paths as permissive.

### DIFF
--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -17,13 +17,9 @@ export default iterateJsdoc(({
   } = context.options[0] || {};
   const {mode} = settings;
 
-  const tryParseIgnoreError = (path) => {
+  const tryParsePathIgnoreError = (path) => {
     try {
-      if (mode === 'permissive') {
-        tryParse(path);
-      } else {
-        parse(path, mode);
-      }
+      tryParse(path);
 
       return true;
     } catch {
@@ -36,7 +32,7 @@ export default iterateJsdoc(({
   // eslint-disable-next-line complexity
   jsdoc.tags.forEach((tag) => {
     const validNamepathParsing = function (namepath, tagName) {
-      if (tryParseIgnoreError(namepath)) {
+      if (tryParsePathIgnoreError(namepath)) {
         return true;
       }
       let handled = false;
@@ -45,21 +41,21 @@ export default iterateJsdoc(({
         switch (tagName) {
         case 'module': {
           if (!namepath.startsWith('module:')) {
-            handled = tryParseIgnoreError(`module:${namepath}`);
+            handled = tryParsePathIgnoreError(`module:${namepath}`);
           }
           break;
         }
         case 'memberof': case 'memberof!': {
           const endChar = namepath.slice(-1);
           if (['#', '.', '~'].includes(endChar)) {
-            handled = tryParseIgnoreError(namepath.slice(0, -1));
+            handled = tryParsePathIgnoreError(namepath.slice(0, -1));
           }
           break;
         }
         case 'borrows': {
           const startChar = namepath.charAt();
           if (['#', '.', '~'].includes(startChar)) {
-            handled = tryParseIgnoreError(namepath.slice(1));
+            handled = tryParsePathIgnoreError(namepath.slice(1));
           }
         }
         }

--- a/test/rules/assertions/validTypes.js
+++ b/test/rules/assertions/validTypes.js
@@ -1247,5 +1247,22 @@ export default {
        */
       `,
     },
+    {
+      code: `
+      /**
+       * Foo.
+       *
+       * @fires Foo#bar
+       */
+      export default class Foo {
+
+      }
+      `,
+      ignoreReadme: true,
+      parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: {
+        sourceType: 'module',
+      },
+    },
   ],
 };


### PR DESCRIPTION
This parses name paths in permissive mode. It might be better that `jsdoc-type-pratt-parser` allows a specific name path parsing mode or name parsing mode so this can only be a name path or a type in the specified mode.

This is somewhat more permissive than before but fixes the false positives. This now allows all names of tags that are scanned for namepaths to also be in jsdoc mode.

I will introduce the name parsing mode in `jsdoc-type-pratt-parser` but it will take some time (weeks) as I do not have very much free time at hands at the moment.

Fixes #750 