### PR TITLE
fix(`check-line-alignment`): preserve carriage returns; fixes #745

### DIFF
--- a/README.md
+++ b/README.md
@@ -2345,6 +2345,8 @@ const fn = ( lorem, sit ) => {}
         *
         * @param {string} lorem Description.
         * @param {int} sit Description multi words.
+        * @param {string} sth   Multi
+        *                       line description.
         */
        const fn = ( lorem, sit ) => {}
 // "jsdoc/check-line-alignment": ["error"|"warn", "always"]
@@ -2611,6 +2613,8 @@ const fn = ({ids}) => {}
         *
         * @param {string} lorem Description.
         * @param {int}    sit   Description multi words.
+        * @param {string} sth   Multi
+        *                       line description.
         */
        const fn = ( lorem, sit ) => {}
 // "jsdoc/check-line-alignment": ["error"|"warn", "always"]

--- a/README.md
+++ b/README.md
@@ -2338,6 +2338,17 @@ const fn = ( lorem, sit ) => {}
 const fn = ( lorem, sit ) => {}
 // "jsdoc/check-line-alignment": ["error"|"warn", "never",{"customSpacings":{"postName":3}}]
 // Message: Expected JSDoc block lines to not be aligned.
+
+
+       /**
+        * Function description.
+        *
+        * @param {string} lorem Description.
+        * @param {int} sit Description multi words.
+        */
+       const fn = ( lorem, sit ) => {}
+// "jsdoc/check-line-alignment": ["error"|"warn", "always"]
+// Message: Expected JSDoc block lines to be aligned.
 ````
 
 The following patterns are not considered problems:
@@ -2592,6 +2603,16 @@ const fn = ( lorem, sit ) => {}
  *        }}            params
  */
 const fn = ({ids}) => {}
+// "jsdoc/check-line-alignment": ["error"|"warn", "always"]
+
+
+       /**
+        * Function description.
+        *
+        * @param {string} lorem Description.
+        * @param {int}    sit   Description multi words.
+        */
+       const fn = ( lorem, sit ) => {}
 // "jsdoc/check-line-alignment": ["error"|"warn", "always"]
 ````
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "url": "http://gajus.com"
   },
   "dependencies": {
-    "@es-joy/jsdoccomment": "^0.8.0",
-    "comment-parser": "1.1.5",
+    "@es-joy/jsdoccomment": "^0.9.0-alpha.1",
+    "comment-parser": "1.1.6-beta.0",
     "debug": "^4.3.2",
     "esquery": "^1.4.0",
     "jsdoc-type-pratt-parser": "^1.0.4",

--- a/src/alignTransform.js
+++ b/src/alignTransform.js
@@ -169,7 +169,7 @@ const alignTransform = ({
 
     if (!intoTags) {
       if (tokens.description === '') {
-        tokens.postDelimiter = '';
+        tokens.postDelimiter = tokens.postDelimiter === '\r' ? '\r' : '';
       } else if (!preserveMainDescriptionPostDelimiter) {
         tokens.postDelimiter = ' ';
       }

--- a/test/rules/assertions/checkLineAlignment.js
+++ b/test/rules/assertions/checkLineAlignment.js
@@ -1057,6 +1057,36 @@ export default {
       const fn = ( lorem, sit ) => {}
       `,
     },
+    {
+      code: `\r
+        /**\r
+         * Function description.\r
+         *\r
+         * @param {string} lorem Description.\r
+         * @param {int} sit Description multi words.\r
+         */\r
+        const fn = ( lorem, sit ) => {}\r
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Expected JSDoc block lines to be aligned.',
+          type: 'Block',
+        },
+      ],
+      options: [
+        'always',
+      ],
+      output: `\r
+        /**\r
+         * Function description.\r
+         *\r
+         * @param {string} lorem Description.\r
+         * @param {int}    sit   Description multi words.\r
+         */\r
+        const fn = ( lorem, sit ) => {}\r
+      `,
+    },
   ],
   valid: [
     {
@@ -1443,6 +1473,18 @@ export default {
          *        }}            params
          */
         const fn = ({ids}) => {}
+      `,
+      options: ['always'],
+    },
+    {
+      code: `\r
+        /**\r
+         * Function description.\r
+         *\r
+         * @param {string} lorem Description.\r
+         * @param {int}    sit   Description multi words.\r
+         */\r
+        const fn = ( lorem, sit ) => {}\r
       `,
       options: ['always'],
     },

--- a/test/rules/assertions/checkLineAlignment.js
+++ b/test/rules/assertions/checkLineAlignment.js
@@ -1064,6 +1064,8 @@ export default {
          *\r
          * @param {string} lorem Description.\r
          * @param {int} sit Description multi words.\r
+         * @param {string} sth   Multi\r
+         *                       line description.\r
          */\r
         const fn = ( lorem, sit ) => {}\r
       `,
@@ -1083,6 +1085,8 @@ export default {
          *\r
          * @param {string} lorem Description.\r
          * @param {int}    sit   Description multi words.\r
+         * @param {string} sth   Multi\r
+         *                       line description.\r
          */\r
         const fn = ( lorem, sit ) => {}\r
       `,
@@ -1483,6 +1487,8 @@ export default {
          *\r
          * @param {string} lorem Description.\r
          * @param {int}    sit   Description multi words.\r
+         * @param {string} sth   Multi\r
+         *                       line description.\r
          */\r
         const fn = ( lorem, sit ) => {}\r
       `,


### PR DESCRIPTION
Fixes #745.

Waiting on feedback on https://github.com/syavorsky/comment-parser/pull/132 (and possibly to use a stable update to `comment-parser` if also ready).

@renatho : You might want to see my [comment](https://github.com/syavorsky/comment-parser/pull/132#issuecomment-876814403) there. In particular, if the `delim`-setting code is unreachable, then I imagine we don't really need to expand on this line:

```js
    tokens.postDelimiter = nothingAfter.delim ? '' : space(spacings.postDelimiter);
```
to this:
```js
    tokens.postDelimiter = nothingAfter.delim ? (tokens.postDelimiter === '\r' ? '\r' : '') : space(spacings.postDelimiter);
```