### PR TITLE
[tag-lines] Schema fix for tags

### DIFF
--- a/src/rules/tagLines.js
+++ b/src/rules/tagLines.js
@@ -129,18 +129,16 @@ export default iterateJsdoc(({
             type: 'boolean',
           },
           tags: {
-            properties: {
-              patternProperties: {
-                '.*': {
-                  additionalProperties: false,
-                  properties: {
-                    count: {
-                      type: 'integer',
-                    },
-                    lines: {
-                      enum: ['always', 'never', 'any'],
-                      type: 'string',
-                    },
+            patternProperties: {
+              '.*': {
+                additionalProperties: false,
+                properties: {
+                  count: {
+                    type: 'integer',
+                  },
+                  lines: {
+                    enum: ['always', 'never', 'any'],
+                    type: 'string',
                   },
                 },
               },


### PR DESCRIPTION
The current schema of `tag-lines` for the property tags is incorrect as `patternProperties` is inside `properties` instead of only `patternProperties`.
As such only `tags.patternProperties` is checked and not as wanted `tags.*`.