### PR TITLE
feat(`check-indentation`): ensure masking through decorators within tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1949,6 +1949,18 @@ function MyDecorator(options: { myOptions: number }) {
   return (Base: Function) => {};
 }
 // "jsdoc/check-indentation": ["error"|"warn", {"excludeTags":["example","MyDecorator"]}]
+
+/**
+ * @example ```
+ * @MyDecorator({
+ *   myOptions: 42
+ * })
+ * export class MyClass {}
+ * ```
+ */
+function MyDecorator(options: { myOptions: number }) {
+  return (Base: Function) => {};
+}
 ````
 
 

--- a/src/rules/checkIndentation.js
+++ b/src/rules/checkIndentation.js
@@ -1,7 +1,7 @@
 import iterateJsdoc from '../iterateJsdoc';
 
 const maskExcludedContent = (str, excludeTags) => {
-  const regContent = new RegExp(`([ \\t]+\\*)[ \\t]@(?:${excludeTags.join('|')})(?=[ \\n])([\\w|\\W]*?\\n)(?=[ \\t]*\\*(?:[ \\t]*@|\\/))`, 'gu');
+  const regContent = new RegExp(`([ \\t]+\\*)[ \\t]@(?:${excludeTags.join('|')})(?=[ \\n])([\\w|\\W]*?\\n)(?=[ \\t]*\\*(?:[ \\t]*@\\w+\\s|\\/))`, 'gu');
 
   return str.replace(regContent, (_match, margin, code) => {
     return (margin + '\n').repeat(code.match(/\n/gu).length);

--- a/test/rules/assertions/checkIndentation.js
+++ b/test/rules/assertions/checkIndentation.js
@@ -311,5 +311,21 @@ export default {
       ],
       parser: require.resolve('@typescript-eslint/parser'),
     },
+    {
+      code: `
+      /**
+       * @example \`\`\`
+       * @MyDecorator({
+       *   myOptions: 42
+       * })
+       * export class MyClass {}
+       * \`\`\`
+       */
+      function MyDecorator(options: { myOptions: number }) {
+        return (Base: Function) => {};
+      }
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
   ],
 };


### PR DESCRIPTION
feat(`check-indentation`): ensure masking through decorators within tags (fixes #789)
