### PR TITLE
confirm that a "never" value is indeed present

### DIFF
--- a/README.md
+++ b/README.md
@@ -16507,6 +16507,22 @@ async function foo() {
 function quux () {}
 // "jsdoc/require-returns-check": ["error"|"warn", {"reportMissingReturnForUndefinedTypes":true}]
 // Message: JSDoc @returns declaration present but return expression not available in function.
+
+/**
+ * @returns {never} Foo.
+ */
+function quux () {
+  return undefined;
+}
+// Message: JSDoc @returns declaration set with "never" but return expression is present in function.
+
+/**
+ * @returns {never}
+ */
+function quux (foo) {
+  return foo;
+}
+// Message: JSDoc @returns declaration set with "never" but return expression is present in function.
 ````
 
 The following patterns are not considered problems:
@@ -16641,13 +16657,6 @@ function quux () {
  * @returns {never} Foo.
  */
 function quux () {
-}
-
-/**
- * @returns {never} Foo.
- */
-function quux () {
-  return undefined;
 }
 
 /**
@@ -18445,6 +18454,14 @@ const directThrowAfterArrow = (b) => {
   return a;
 };
 // Message: Missing JSDoc @throws declaration.
+
+/**
+ * @throws {never}
+ */
+function quux (foo) {
+  throw new Error('err')
+}
+// Message: JSDoc @throws declaration set to "never" but throw value found.
 ````
 
 The following patterns are not considered problems:
@@ -18464,6 +18481,13 @@ function quux (foo) {
   try {
     throw new Error('err')
   } catch(e) {}
+}
+
+/**
+ * @throws {object}
+ */
+function quux (foo) {
+  throw new Error('err')
 }
 
 /**
@@ -18508,6 +18532,12 @@ const nested = () => () => {throw new Error('oops');};
  */
 async function foo() {
   throw Error("bar");
+}
+
+/**
+ * @throws {never}
+ */
+function quux (foo) {
 }
 ````
 
@@ -19493,6 +19523,23 @@ async function * quux() {}
  */
 const quux = async function * () {}
 // Message: JSDoc @yields declaration present but yield expression not available in function.
+
+/**
+ * @yields {never} Foo.
+ */
+function * quux () {
+  yield 5;
+}
+// Message: JSDoc @yields declaration set with "never" but yield expression is present in function.
+
+/**
+ * @next {never}
+ */
+function * quux (foo) {
+  const a = yield;
+}
+// "jsdoc/require-yields-check": ["error"|"warn", {"next":true}]
+// Message: JSDoc @next declaration set with "never" but yield expression with return value is present in function.
 ````
 
 The following patterns are not considered problems:

--- a/src/rules/requireReturnsCheck.js
+++ b/src/rules/requireReturnsCheck.js
@@ -68,9 +68,17 @@ export default iterateJsdoc(({
 
   const [tag] = tags;
 
+  const returnNever = tag.type.trim() === 'never';
+
+  if (returnNever && utils.hasValueOrExecutorHasNonEmptyResolveValue(false)) {
+    report(`JSDoc @${tagName} declaration set with "never" but return expression is present in function.`);
+
+    return;
+  }
+
   // In case a return value is declared in JSDoc, we also expect one in the code.
   if (
-    tag.type.trim() !== 'never' &&
+    !returnNever &&
     (
       reportMissingReturnForUndefinedTypes ||
       utils.hasDefinedTypeTag(tag)

--- a/src/rules/requireThrows.js
+++ b/src/rules/requireThrows.js
@@ -47,6 +47,10 @@ export default iterateJsdoc(({
 
   const shouldReport = () => {
     if (!missingThrowsTag) {
+      if (tag.type.trim() === 'never' && iteratingFunction && utils.hasThrowValue()) {
+        report(`JSDoc @${tagName} declaration set to "never" but throw value found.`);
+      }
+
       return false;
     }
 

--- a/src/rules/requireYieldsCheck.js
+++ b/src/rules/requireYieldsCheck.js
@@ -72,6 +72,10 @@ export default iterateJsdoc(({
   if (preferredYieldTagName) {
     const shouldReportYields = () => {
       if (yieldTag.type.trim() === 'never') {
+        if (utils.hasYieldValue()) {
+          report(`JSDoc @${preferredYieldTagName} declaration set with "never" but yield expression is present in function.`);
+        }
+
         return false;
       }
 
@@ -95,6 +99,10 @@ export default iterateJsdoc(({
     if (preferredNextTagName) {
       const shouldReportNext = () => {
         if (nextTag.type.trim() === 'never') {
+          if (utils.hasYieldReturnValue()) {
+            report(`JSDoc @${preferredNextTagName} declaration set with "never" but yield expression with return value is present in function.`);
+          }
+
           return false;
         }
 

--- a/test/rules/assertions/requireReturnsCheck.js
+++ b/test/rules/assertions/requireReturnsCheck.js
@@ -325,6 +325,38 @@ export default {
         reportMissingReturnForUndefinedTypes: true,
       }],
     },
+    {
+      code: `
+          /**
+           * @returns {never} Foo.
+           */
+          function quux () {
+            return undefined;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'JSDoc @returns declaration set with "never" but return expression is present in function.',
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @returns {never}
+           */
+          function quux (foo) {
+            return foo;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'JSDoc @returns declaration set with "never" but return expression is present in function.',
+        },
+      ],
+    },
   ],
   valid: [
     {
@@ -525,16 +557,6 @@ export default {
            * @returns {never} Foo.
            */
           function quux () {
-          }
-      `,
-    },
-    {
-      code: `
-          /**
-           * @returns {never} Foo.
-           */
-          function quux () {
-            return undefined;
           }
       `,
     },

--- a/test/rules/assertions/requireThrows.js
+++ b/test/rules/assertions/requireThrows.js
@@ -334,6 +334,22 @@ export default {
         },
       ],
     },
+    {
+      code: `
+          /**
+           * @throws {never}
+           */
+          function quux (foo) {
+            throw new Error('err')
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'JSDoc @throws declaration set to "never" but throw value found.',
+        },
+      ],
+    },
   ],
   valid: [
     {
@@ -355,6 +371,16 @@ export default {
             try {
               throw new Error('err')
             } catch(e) {}
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @throws {object}
+           */
+          function quux (foo) {
+            throw new Error('err')
           }
       `,
     },
@@ -429,6 +455,15 @@ export default {
       parserOptions: {
         ecmaVersion: 8,
       },
+    },
+    {
+      code: `
+        /**
+         * @throws {never}
+         */
+        function quux (foo) {
+        }
+      `,
     },
   ],
 };

--- a/test/rules/assertions/requireYieldsCheck.js
+++ b/test/rules/assertions/requireYieldsCheck.js
@@ -297,6 +297,37 @@ export default {
         ecmaVersion: 2_018,
       },
     },
+    {
+      code: `
+          /**
+           * @yields {never} Foo.
+           */
+          function * quux () {
+            yield 5;
+          }
+      `,
+      errors: [{
+        line: 2,
+        message: 'JSDoc @yields declaration set with "never" but yield expression is present in function.',
+      }],
+    },
+    {
+      code: `
+          /**
+           * @next {never}
+           */
+          function * quux (foo) {
+            const a = yield;
+          }
+      `,
+      errors: [{
+        line: 2,
+        message: 'JSDoc @next declaration set with "never" but yield expression with return value is present in function.',
+      }],
+      options: [{
+        next: true,
+      }],
+    },
   ],
   valid: [
     {


### PR DESCRIPTION
feat(`require-returns-check`, `require-yields-check`, `require-throws`): confirm that a "never" value is indeed present

Inspired by and closes #817 .

Note that as we have no `require-throws-check` (which would be pretty useless since functions often call other functions that throw without having a throw statement themselves), I've added the "never" checking to `require-throws`.