### PR TITLE
ci: Add GitHub Action for linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v2
+
+      - name: ⎔ Setup node for problem matcher
+        if: github.event.pull_request
+        uses: actions/setup-node@v2
+
+      - name: 📥 Download deps
+        run: npm install
+
+      - name: 🧪 Run lint
+        run: npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_script: >
     npm install --no-save "eslint@${ESLINT}" eslint-config-canonical@24.4.4
   else
     npm install --no-save "eslint@${ESLINT}"
-    npm run lint
   fi
 
 notifications:


### PR DESCRIPTION
GitHub Actions have built-in problem matchers for ESLint from setup-node to show warnings/errors on the PR file tab