### PR TITLE
test: move Mocha and NYC config from CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_script: >
     if [ ${node_version:1:2} = "16" ]; then
       npm install --engine-strict --no-save "eslint@${ESLINT}"
       npm run lint
+      npm run build
     else
       npm install --legacy-peer-deps --no-save "eslint@${ESLINT}" eslint-config-canonical@32.1.0 eslint-plugin-mocha@9
     fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ can use `npm run test-index`.
 To test specific rules, you can supply a comma-separated list with the `--rule`
 flag passed to `test-index`, e.g., for `check-examples` and `require-example`:
 
-`npm run --rule=check-examples,require-example test-index`.
+`npm run test-index --rule=check-examples,require-example`.
 
 You can further limit this by providing `--invalid` and/or `--valid` flags
 with a comma-separated list of 0-based indexes that you wish to include (also

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "nyc": {
     "branches": 100,
-    "check-coverage": false,
+    "check-coverage": true,
     "exclude": [
       "src/rules/checkExamples.js"
     ],

--- a/package.json
+++ b/package.json
@@ -61,6 +61,14 @@
   },
   "main": "./dist/index.js",
   "name": "eslint-plugin-jsdoc",
+  "mocha": {
+    "require": [
+      "@babel/register"
+    ],
+    "reporter": "dot",
+    "recursive": true,
+    "timeout": 12000
+  },
   "nyc": {
     "branches": 100,
     "check-coverage": false,
@@ -73,6 +81,7 @@
     ],
     "instrument": false,
     "lines": 100,
+    "reporter": "text-summary",
     "require": [
       "@babel/register"
     ],
@@ -99,10 +108,10 @@
     "lint-arg": "eslint --report-unused-disable-directives",
     "lint-fix": "npm run lint-arg -- --fix .",
     "prepare": "husky install",
-    "test": "cross-env BABEL_ENV=test nyc --reporter text-summary mocha --reporter dot --recursive --require @babel/register --timeout 12000",
-    "test-cov": "cross-env BABEL_ENV=test TIMING=1 nyc mocha --reporter dot --recursive --require @babel/register --timeout 12000",
-    "test-index": "cross-env BABEL_ENV=test mocha --recursive --require @babel/register --reporter progress --timeout 12000 test/rules/index.js",
-    "test-no-cov": "cross-env BABEL_ENV=test mocha --reporter dot --recursive --require @babel/register --timeout 12000"
+    "test-no-cov": "cross-env BABEL_ENV=test mocha",
+    "test": "nyc npm run test-no-cov",
+    "test-cov": "cross-env TIMING=1 nyc --reporter text npm run test-no-cov",
+    "test-index": "npm run test-no-cov -- test/rules/index.js"
   },
   "version": "1.0.0"
 }


### PR DESCRIPTION
Cleans up the scripts so all the CLI arguments are in the config sections in package.json. This allows the CLI to be overloaded while calling the scripts if needed.
Also allows IDEs to hook into with the debugger, since the config is loaded by Mocha.