### PR TITLE
feat(`tag-lines`): add `dropEndLines` option; fixes #847

### DIFF
--- a/.README/rules/match-description.md
+++ b/.README/rules/match-description.md
@@ -6,7 +6,7 @@ The default is this basic expression to match English sentences (Support
 for Unicode upper case may be added in a future version when it can be handled
 by our supported Node versions):
 
-``^([A-Z]|[`\\d_])[\\s\\S]*[.?!`]$``
+``^([A-Z]|[`\\d_])[\\s\\S]*[.?!`]\\s*$``
 
 Applies to the jsdoc block description and `@description` (or `@desc`)
 by default but the `tags` option (see below) may be used to match other tags.

--- a/.README/rules/tag-lines.md
+++ b/.README/rules/tag-lines.md
@@ -8,7 +8,7 @@ The first option is a single string set to "always", "never", or "any"
 (defaults to "never").
 
 "any" is only useful with `tags` (allowing non-enforcement of lines except
-for particular tags).
+for particular tags) or with `dropEndLines`.
 
 The second option is an object with the following optional properties.
 
@@ -20,6 +20,10 @@ Use with "always" to indicate the number of lines to require be present.
 
 Use with "always" to indicate the normal lines to be added after tags should
 not be added after the final tag.
+
+##### `dropEndLines` (defaults to `false`)
+
+If defined, will drop end lines for the final tag only.
 
 ##### `tags` (default to empty object)
 

--- a/README.md
+++ b/README.md
@@ -6608,7 +6608,7 @@ The default is this basic expression to match English sentences (Support
 for Unicode upper case may be added in a future version when it can be handled
 by our supported Node versions):
 
-``^([A-Z]|[`\\d_])[\\s\\S]*[.?!`]$``
+``^([A-Z]|[`\\d_])[\\s\\S]*[.?!`]\\s*$``
 
 Applies to the jsdoc block description and `@description` (or `@desc`)
 by default but the `tags` option (see below) may be used to match other tags.
@@ -6960,7 +6960,7 @@ function quux (foo) {
 function quux (foo) {
 
 }
-// "jsdoc/match-description": ["error"|"warn", {"mainDescription":"^[a-zA-Z]*$","tags":{"param":true}}]
+// "jsdoc/match-description": ["error"|"warn", {"mainDescription":"^[a-zA-Z]*\\s*$","tags":{"param":true}}]
 // Message: JSDoc description does not satisfy the regex pattern.
 
 /**
@@ -6971,7 +6971,7 @@ function quux (foo) {
 function quux (foo) {
 
 }
-// "jsdoc/match-description": ["error"|"warn", {"mainDescription":{"match":"^[a-zA-Z]*$","message":"Letters only"},"tags":{"param":{"match":true,"message":"Needs to begin with a capital letter and end with a period."}}}]
+// "jsdoc/match-description": ["error"|"warn", {"mainDescription":{"match":"^[a-zA-Z]*\\s*$","message":"Letters only"},"tags":{"param":{"match":true,"message":"Needs to begin with a capital letter and end with a period."}}}]
 // Message: Needs to begin with a capital letter and end with a period.
 
 /**
@@ -7150,6 +7150,16 @@ function quux (foo) {
 
 }
 // Settings: {"jsdoc":{"tagNamePreference":{"description":false}}}
+// Message: JSDoc description does not satisfy the regex pattern.
+
+/**
+ * Description with extra new line
+ *
+ */
+function quux () {
+
+}
+// "jsdoc/match-description": ["error"|"warn", {"matchDescription":"[\\s\\S]*\\S$"}]
 // Message: JSDoc description does not satisfy the regex pattern.
 ````
 

--- a/README.md
+++ b/README.md
@@ -20695,7 +20695,7 @@ The first option is a single string set to "always", "never", or "any"
 (defaults to "never").
 
 "any" is only useful with `tags` (allowing non-enforcement of lines except
-for particular tags).
+for particular tags) or with `dropEndLines`.
 
 The second option is an object with the following optional properties.
 
@@ -20711,6 +20711,12 @@ Use with "always" to indicate the number of lines to require be present.
 
 Use with "always" to indicate the normal lines to be added after tags should
 not be added after the final tag.
+
+<a name="user-content-eslint-plugin-jsdoc-rules-tag-lines-options-41-dropendlines-defaults-to-false"></a>
+<a name="eslint-plugin-jsdoc-rules-tag-lines-options-41-dropendlines-defaults-to-false"></a>
+##### <code>dropEndLines</code> (defaults to <code>false</code>)
+
+If defined, will drop end lines for the final tag only.
 
 <a name="user-content-eslint-plugin-jsdoc-rules-tag-lines-options-41-tags-default-to-empty-object"></a>
 <a name="eslint-plugin-jsdoc-rules-tag-lines-options-41-tags-default-to-empty-object"></a>
@@ -20869,6 +20875,20 @@ The following patterns are considered problems:
  */
 // "jsdoc/tag-lines": ["error"|"warn", "always"]
 // Message: Expected 1 line between tags but found 0
+
+/**
+ * Some description
+ * @param {string} a
+ * @param {string} b
+ *
+ * @returns {SomeType} An extended
+ * description.
+ *
+ * This is still part of `@returns`.
+ *
+ */
+// "jsdoc/tag-lines": ["error"|"warn", "any",{"dropEndLines":true}]
+// Message: Expected no trailing lines
 ````
 
 The following patterns are not considered problems:
@@ -21026,6 +21046,18 @@ The following patterns are not considered problems:
  *
  */
 // "jsdoc/tag-lines": ["error"|"warn", "always"]
+
+/**
+ * Some description
+ * @param {string} a
+ * @param {string} b
+ *
+ * @returns {SomeType} An extended
+ * description.
+ *
+ * This is still part of `@returns`.
+ */
+// "jsdoc/tag-lines": ["error"|"warn", "any",{"dropEndLines":true}]
 ````
 
 

--- a/src/rules/matchDescription.js
+++ b/src/rules/matchDescription.js
@@ -2,7 +2,7 @@ import iterateJsdoc from '../iterateJsdoc';
 
 // If supporting Node >= 10, we could loosen the default to this for the
 //   initial letter: \\p{Upper}
-const matchDescriptionDefault = '^[A-Z`\\d_][\\s\\S]*[.?!`]$';
+const matchDescriptionDefault = '^[A-Z`\\d_][\\s\\S]*[.?!`]\\s*$';
 
 const stringOrDefault = (value, userDefault) => {
   return typeof value === 'string' ?
@@ -68,9 +68,7 @@ export default iterateJsdoc(({
     const {
       description,
     } = utils.getDescription();
-    validateDescription(
-      description.replace(/\s+$/u, ''),
-    );
+    validateDescription(description);
   }
 
   if (!tags || !Object.keys(tags).length) {

--- a/test/rules/assertions/matchDescription.js
+++ b/test/rules/assertions/matchDescription.js
@@ -446,7 +446,7 @@ export default {
       ],
       options: [
         {
-          mainDescription: '^[a-zA-Z]*$',
+          mainDescription: '^[a-zA-Z]*\\s*$',
           tags: {
             param: true,
           },
@@ -473,7 +473,7 @@ export default {
       options: [
         {
           mainDescription: {
-            match: '^[a-zA-Z]*$',
+            match: '^[a-zA-Z]*\\s*$',
             message: 'Letters only',
           },
           tags: {
@@ -911,6 +911,28 @@ export default {
           },
         },
       },
+    },
+    {
+      code: `
+          /**
+           * Description with extra new line
+           *
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'JSDoc description does not satisfy the regex pattern.',
+        },
+      ],
+      options: [
+        {
+          matchDescription: '[\\s\\S]*\\S$',
+        },
+      ],
     },
   ],
   valid: [

--- a/test/rules/assertions/tagLines.js
+++ b/test/rules/assertions/tagLines.js
@@ -460,6 +460,45 @@ export default {
        */
       `,
     },
+    {
+      code: `
+      /**
+       * Some description
+       * @param {string} a
+       * @param {string} b
+       *
+       * @returns {SomeType} An extended
+       * description.
+       *
+       * This is still part of \`@returns\`.
+       *
+       */
+      `,
+      errors: [
+        {
+          line: 11,
+          message: 'Expected no trailing lines',
+        },
+      ],
+      options: [
+        'any',
+        {
+          dropEndLines: true,
+        },
+      ],
+      output: `
+      /**
+       * Some description
+       * @param {string} a
+       * @param {string} b
+       *
+       * @returns {SomeType} An extended
+       * description.
+       *
+       * This is still part of \`@returns\`.
+       */
+      `,
+    },
   ],
   valid: [
     {
@@ -764,6 +803,26 @@ export default {
       `,
       options: [
         'always',
+      ],
+    },
+    {
+      code: `
+      /**
+       * Some description
+       * @param {string} a
+       * @param {string} b
+       *
+       * @returns {SomeType} An extended
+       * description.
+       *
+       * This is still part of \`@returns\`.
+       */
+      `,
+      options: [
+        'any',
+        {
+          dropEndLines: true,
+        },
       ],
     },
   ],


### PR DESCRIPTION
- feat(`tag-lines`): add `dropEndLines` option; fixes #847
- fix(`match-description`): adjust default to allow for trailing whitespace but do check for such WS now

BREAKING CHANGE:

Regular expressions now need to take account for trailing whitespace

I've put these two together as they both related to allowing for trimming trailing lines