### PR TITLE
Prefer TypeScript compatibility

### DIFF
--- a/.README/rules/check-types.md
+++ b/.README/rules/check-types.md
@@ -107,11 +107,12 @@ as a lone type. However, one additional complexity is that TypeScript allows and
 actually [currently requires](https://github.com/microsoft/TypeScript/issues/20555)
 `Object` (with the initial upper-case) if used in the syntax
 `Object.<keyType, valueType>` or `Object<keyType, valueType`, perhaps to
-adhere to what [JSDoc documents](https://jsdoc.app/tags-type.html).
+adhere to that which [JSDoc documents](https://jsdoc.app/tags-type.html).
 
 So, for optimal compatibility with TypeScript (especially since TypeScript
-tools can be used on plain JavaScript with JSDoc), we are now allowing this
-TypeScript approach by default.
+tools can be used on plain JavaScript with JSDoc), we are now requiring this
+TypeScript approach by default (if you set `object` type `preferredTypes` in
+TypeScript mode, the defaults will not apply).
 
 Basically, for primitives, we want to define the type as a primitive, because
 that's what we use in 99.9% of cases. For everything else, we use the type

--- a/README.md
+++ b/README.md
@@ -4883,11 +4883,12 @@ as a lone type. However, one additional complexity is that TypeScript allows and
 actually [currently requires](https://github.com/microsoft/TypeScript/issues/20555)
 `Object` (with the initial upper-case) if used in the syntax
 `Object.<keyType, valueType>` or `Object<keyType, valueType`, perhaps to
-adhere to what [JSDoc documents](https://jsdoc.app/tags-type.html).
+adhere to that which [JSDoc documents](https://jsdoc.app/tags-type.html).
 
 So, for optimal compatibility with TypeScript (especially since TypeScript
-tools can be used on plain JavaScript with JSDoc), we are now allowing this
-TypeScript approach by default.
+tools can be used on plain JavaScript with JSDoc), we are now requiring this
+TypeScript approach by default (if you set `object` type `preferredTypes` in
+TypeScript mode, the defaults will not apply).
 
 Basically, for primitives, we want to define the type as a primitive, because
 that's what we use in 99.9% of cases. For everything else, we use the type
@@ -5491,7 +5492,7 @@ function quux (foo) {
 function a () {}
 
 /**
- * @typedef {Object} foo
+ * @typedef {Object<string>} foo
  */
 function b () {}
 // Settings: {"jsdoc":{"mode":"typescript","preferredTypes":{"object":"Object"}}}
@@ -5549,6 +5550,24 @@ function quux (foo) {
 function quux (foo) {
 }
 // Settings: {"jsdoc":{"mode":"typescript","preferredTypes":{"Object":"object","object.<>":"Object<>","Object.<>":"Object<>","object<>":"Object<>"}}}
+// Message: Invalid JSDoc @param "foo" type "object"; prefer: "Object<>".
+
+/**
+ * @param {object.<string>} foo
+ */
+function quux (foo) {
+
+}
+// Settings: {"jsdoc":{"mode":"typescript","preferredTypes":{"Object":"object","object.<>":"Object<>","Object.<>":"Object<>","object<>":"Object<>"}}}
+// Message: Invalid JSDoc @param "foo" type "object"; prefer: "Object<>".
+
+/**
+ * @param {object.<string>} foo
+ */
+function quux (foo) {
+
+}
+// Settings: {"jsdoc":{"mode":"typescript"}}
 // Message: Invalid JSDoc @param "foo" type "object"; prefer: "Object<>".
 ````
 
@@ -5810,7 +5829,7 @@ function b () {}
 function a () {}
 
 /**
- * @typedef {Object} foo
+ * @typedef {Object<string>} foo
  */
 function b () {}
 // Settings: {"jsdoc":{"mode":"typescript"}}
@@ -5839,7 +5858,7 @@ function quux (foo) {
 }
 
 /**
- * @param {Object.<string>} foo
+ * @param {Object<string>} foo
  */
 function quux (foo) {
 

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -2048,7 +2048,7 @@ export default {
         function a () {}
 
         /**
-         * @typedef {Object} foo
+         * @typedef {Object<string>} foo
          */
         function b () {}
       `,
@@ -2065,7 +2065,7 @@ export default {
         function a () {}
 
         /**
-         * @typedef {Object} foo
+         * @typedef {Object<string>} foo
          */
         function b () {}
       `,
@@ -2289,6 +2289,70 @@ export default {
             'Object.<>': 'Object<>',
             'object<>': 'Object<>',
           },
+        },
+      },
+    },
+    {
+      code: `
+        /**
+         * @param {object.<string>} foo
+         */
+        function quux (foo) {
+
+        }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "Object<>".',
+        },
+      ],
+      output: `
+        /**
+         * @param {Object<string>} foo
+         */
+        function quux (foo) {
+
+        }
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'typescript',
+          preferredTypes: {
+            Object: 'object',
+            'object.<>': 'Object<>',
+            'Object.<>': 'Object<>',
+            'object<>': 'Object<>',
+          },
+        },
+      },
+    },
+    {
+      code: `
+        /**
+         * @param {object.<string>} foo
+         */
+        function quux (foo) {
+
+        }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "Object<>".',
+        },
+      ],
+      output: `
+        /**
+         * @param {Object<string>} foo
+         */
+        function quux (foo) {
+
+        }
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'typescript',
         },
       },
     },
@@ -2815,7 +2879,7 @@ export default {
         function a () {}
 
         /**
-         * @typedef {Object} foo
+         * @typedef {Object<string>} foo
          */
         function b () {}
       `,
@@ -2891,7 +2955,7 @@ export default {
     {
       code: `
       /**
-       * @param {Object.<string>} foo
+       * @param {Object<string>} foo
        */
       function quux (foo) {
 


### PR DESCRIPTION
feat: unless the user supplies their own `object` type `preferredTypes`, prefer `object` for plain objects and otherwise prefer `Object<>`; fixes #800

I'm not yet convinced we're ready for #834 , but in anticipation of a likely future change, I think we should go ahead and enforce the best compatibility with TypeScript now even for plain jsdoc users.

Now admittedly, TypeScript has an issue to change things to [support equivalent behavior for either form](https://github.com/microsoft/TypeScript/issues/20555) when within JSDoc, but regardless, it seems that it is better for us to enforce operating in a manner closer to how TypeScript is to behave (that `Object` is discouraged in plain form and `object` is the more basic type allowing for `Object.create(null)) and how it makes sense to behave (if one JSDoc type is allowed then `Object` seems more like a generic-friendly form).