### PR TITLE
removed regextra library to reduce dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ os: linux
 dist: xenial
 language: node_js
 node_js:
-  - "12.22.0"
   - "14.17.0"
   - "16"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: node_js
 node_js:
   - "14.17.0"
   - "16"
+  - "17"
 install:
   - npm install --legacy-peer-deps
 before_script: >

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "^4.6.3"
   },
   "engines": {
-    "node": "^12 || ^14 || ^16 || ^17"
+    "node": "^14 || ^16 || ^17"
   },
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "debug": "^4.3.4",
     "escape-string-regexp": "^4.0.0",
     "esquery": "^1.4.0",
-    "regextras": "^0.8.0",
     "semver": "^7.3.6",
     "spdx-expression-parse": "^3.0.1"
   },

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -22,16 +22,9 @@ const extractSentences = (text, abbreviationsRegex) => {
     // Remove custom abbreviations
     .replace(abbreviationsRegex, '');
 
-  const sentenceEndGrouping = /([.?!])(?:\s+|$)/u;
+  const sentenceEndGrouping = /([.?!])(?:\s+|$)/ug;
 
-  const puncts = [];
-  let matches;
-  let n0;
-  let index = 0;
-  while ((matches = sentenceEndGrouping.exec(txt)) !== null) {
-    n0 = matches.splice(0, 1);
-    puncts.push(matches.concat(index++, n0));
-  }
+  const puncts = txt.matchAll(sentenceEndGrouping);
 
   return txt
 

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -1,7 +1,4 @@
 import escapeStringRegexp from 'escape-string-regexp';
-import {
-  RegExtras,
-} from 'regextras/dist/main-umd';
 import iterateJsdoc from '../iterateJsdoc';
 
 const otherDescriptiveTags = new Set([
@@ -27,10 +24,14 @@ const extractSentences = (text, abbreviationsRegex) => {
 
   const sentenceEndGrouping = /([.?!])(?:\s+|$)/u;
 
-  // eslint-disable-next-line unicorn/no-array-method-this-argument
-  const puncts = new RegExtras(sentenceEndGrouping).map(txt, (punct) => {
-    return punct;
-  });
+  const puncts = [];
+  let matches;
+  let n0;
+  let index = 0;
+  while ((matches = sentenceEndGrouping.exec(txt)) !== null) {
+    n0 = matches.splice(0, 1);
+    puncts.push(matches.concat(index++, n0));
+  }
 
   return txt
 


### PR DESCRIPTION
We currently have three seperate security advisories for this package due to the sub packages of regextras. I noticed that there is only one use of the regextras package and it could be replaced with only a few lines and would signifigantly reduce the size of the package and the impact of the downstream dependencies.