### PR TITLE
feat: target Node 14 in builds now that using it

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -7,7 +7,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": 12
+          "node": 14
         }
       }
     ]


### PR DESCRIPTION
I think this is more of a fix in some ways, and really part of the intent of requiring Node 14 in 39.0.0, but thought I'd submit here, if nothing else than to confirm that it works on our test environments.