### PR TITLE
`minLineCount` option to avoid reporting short functions/contexts

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -473,8 +473,8 @@ While at their simplest, these can be an array of string selectors, one can
 also supply an object with `context` (in place of the string) and one of two
 properties:
 
-1. For `require-jsdoc`, there is also an `inlineCommentBlock` property. See
-    that rule for details.
+1. For `require-jsdoc`, there are also `inlineCommentBlock` and
+    `minLineCount` properties. See that rule for details.
 1. For `no-missing-syntax` and `no-restricted-syntax`, there is also a
     `message` property which allows customization of the message to be shown
     when the rule is triggered.

--- a/.README/rules/require-jsdoc.md
+++ b/.README/rules/require-jsdoc.md
@@ -41,7 +41,8 @@ contexts where you wish the rule to be applied (e.g., `Property` for
 properties). If specified as an object, it should have a `context` property
 and can have an `inlineCommentBlock` property which, if set to `true`, will
 add an inline `/** */` instead of the regular, multi-line, indented jsdoc
-block which will otherwise be added. Defaults to an empty array.
+block which will otherwise be added. Defaults to an empty array. Contexts
+may also have their own `minLineCount` property.
 
 Note that you may need to disable `require` items (e.g., `MethodDefinition`)
 if you are specifying a more precise form in `contexts` (e.g., `MethodDefinition:not([accessibility="private"] > FunctionExpression`).
@@ -95,7 +96,8 @@ Defaults to `true`.
 ##### `minLineCount`
 
 An integer to indicate a minimum number of lines expected for a node in order
-for it to require documentation. Defaults to 0.
+for it to require documentation. Defaults to `undefined`. This option will
+apply to any context; see `contexts` for line counts per context.
 
 |||
 |---|---|

--- a/.README/rules/require-jsdoc.md
+++ b/.README/rules/require-jsdoc.md
@@ -92,11 +92,16 @@ if one only wishes documentation on one of the two accessors. Defaults to
 A boolean on whether to enable the fixer (which adds an empty jsdoc block).
 Defaults to `true`.
 
+##### `minLineCount`
+
+An integer to indicate a minimum number of lines expected for a node in order
+for it to require documentation. Defaults to 0.
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `ClassDeclaration`, `ClassExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|N/A|
 |Recommended|true|
-|Options|`publicOnly`, `require`, `contexts`, `exemptEmptyConstructors`, `exemptEmptyFunctions`, `enableFixer`|
+|Options|`publicOnly`, `require`, `contexts`, `exemptEmptyConstructors`, `exemptEmptyFunctions`, `enableFixer`, `minLineCount`|
 
 <!-- assertions requireJsdoc -->

--- a/README.md
+++ b/README.md
@@ -569,8 +569,8 @@ While at their simplest, these can be an array of string selectors, one can
 also supply an object with `context` (in place of the string) and one of two
 properties:
 
-1. For `require-jsdoc`, there is also an `inlineCommentBlock` property. See
-    that rule for details.
+1. For `require-jsdoc`, there are also `inlineCommentBlock` and
+    `minLineCount` properties. See that rule for details.
 1. For `no-missing-syntax` and `no-restricted-syntax`, there is also a
     `message` property which allows customization of the message to be shown
     when the rule is triggered.
@@ -12821,7 +12821,8 @@ contexts where you wish the rule to be applied (e.g., `Property` for
 properties). If specified as an object, it should have a `context` property
 and can have an `inlineCommentBlock` property which, if set to `true`, will
 add an inline `/** */` instead of the regular, multi-line, indented jsdoc
-block which will otherwise be added. Defaults to an empty array.
+block which will otherwise be added. Defaults to an empty array. Contexts
+may also have their own `minLineCount` property.
 
 Note that you may need to disable `require` items (e.g., `MethodDefinition`)
 if you are specifying a more precise form in `contexts` (e.g., `MethodDefinition:not([accessibility="private"] > FunctionExpression`).
@@ -12889,7 +12890,8 @@ Defaults to `true`.
 ##### <code>minLineCount</code>
 
 An integer to indicate a minimum number of lines expected for a node in order
-for it to require documentation. Defaults to 0.
+for it to require documentation. Defaults to `undefined`. This option will
+apply to any context; see `contexts` for line counts per context.
 
 |||
 |---|---|
@@ -13690,6 +13692,33 @@ function quux () {
 
 function b () {}
 // "jsdoc/require-jsdoc": ["error"|"warn", {"minLineCount":2}]
+// Message: Missing JSDoc comment.
+
+function quux () {
+  return 3;
+}
+
+var a = {};
+// "jsdoc/require-jsdoc": ["error"|"warn", {"contexts":[{"context":"FunctionDeclaration","minLineCount":2},{"context":"VariableDeclaration","minLineCount":2}],"require":{"FunctionDeclaration":false}}]
+// Message: Missing JSDoc comment.
+
+function quux () {
+  return 3;
+}
+
+var a = {
+  b: 1,
+  c: 2
+};
+// "jsdoc/require-jsdoc": ["error"|"warn", {"contexts":[{"context":"FunctionDeclaration","minLineCount":4},{"context":"VariableDeclaration","minLineCount":2}],"require":{"FunctionDeclaration":false}}]
+// Message: Missing JSDoc comment.
+
+class A {
+  setId(newId: number): void {
+    this.id = id;
+  }
+}
+// "jsdoc/require-jsdoc": ["error"|"warn", {"contexts":[{"context":"MethodDefinition","minLineCount":3}],"require":{"ClassDeclaration":false,"FunctionExpression":false,"MethodDefinition":false}}]
 // Message: Missing JSDoc comment.
 ````
 
@@ -14511,6 +14540,23 @@ export class User {
 
 function b () {}
 // "jsdoc/require-jsdoc": ["error"|"warn", {"minLineCount":4}]
+
+function quux () {
+  return 3;
+}
+
+var a = {
+  b: 1,
+  c: 2
+};
+// "jsdoc/require-jsdoc": ["error"|"warn", {"contexts":[{"context":"FunctionDeclaration","minLineCount":4},{"context":"VariableDeclaration","minLineCount":5}],"require":{"FunctionDeclaration":false}}]
+
+class A {
+  setId(newId: number): void {
+    this.id = id;
+  }
+}
+// "jsdoc/require-jsdoc": ["error"|"warn", {"contexts":[{"context":"MethodDefinition","minLineCount":4}],"require":{"ClassDeclaration":false,"FunctionExpression":false,"MethodDefinition":false}}]
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -12884,12 +12884,19 @@ if one only wishes documentation on one of the two accessors. Defaults to
 A boolean on whether to enable the fixer (which adds an empty jsdoc block).
 Defaults to `true`.
 
+<a name="user-content-eslint-plugin-jsdoc-rules-require-jsdoc-options-28-minlinecount"></a>
+<a name="eslint-plugin-jsdoc-rules-require-jsdoc-options-28-minlinecount"></a>
+##### <code>minLineCount</code>
+
+An integer to indicate a minimum number of lines expected for a node in order
+for it to require documentation. Defaults to 0.
+
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `ClassDeclaration`, `ClassExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|N/A|
 |Recommended|true|
-|Options|`publicOnly`, `require`, `contexts`, `exemptEmptyConstructors`, `exemptEmptyFunctions`, `enableFixer`|
+|Options|`publicOnly`, `require`, `contexts`, `exemptEmptyConstructors`, `exemptEmptyFunctions`, `enableFixer`, `minLineCount`|
 
 The following patterns are considered problems:
 
@@ -13675,6 +13682,14 @@ module.exports = class Utility {
   }
 };
 // "jsdoc/require-jsdoc": ["error"|"warn", {"enableFixer":false,"publicOnly":true,"require":{"ArrowFunctionExpression":true,"ClassDeclaration":true,"ClassExpression":true,"FunctionDeclaration":true,"FunctionExpression":true,"MethodDefinition":true}}]
+// Message: Missing JSDoc comment.
+
+function quux () {
+  return 3;
+}
+
+function b () {}
+// "jsdoc/require-jsdoc": ["error"|"warn", {"minLineCount":2}]
 // Message: Missing JSDoc comment.
 ````
 
@@ -14489,6 +14504,13 @@ export class UserSettingsState { }
 export class User {
 }
 // "jsdoc/require-jsdoc": ["error"|"warn", {"contexts":["Decorator"],"require":{"FunctionDeclaration":false}}]
+
+  function quux () {
+  return 3;
+}
+
+function b () {}
+// "jsdoc/require-jsdoc": ["error"|"warn", {"minLineCount":4}]
 ````
 
 

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -271,7 +271,7 @@ const getFunctionParameterNames = (
     throw new Error(`Unsupported function signature format: \`${param.type}\`.`);
   };
 
-  return (functionNode.params || functionNode.value.params).map((param) => {
+  return functionNode.params.map((param) => {
     return getParamName(param);
   });
 };

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -82,6 +82,10 @@ const OPTIONS_SCHEMA = {
       default: '',
       type: 'string',
     },
+    minLineCount: {
+      default: 0,
+      type: 'integer',
+    },
     publicOnly: {
       oneOf: [
         {
@@ -164,6 +168,7 @@ const getOptions = (context) => {
     exemptEmptyFunctions = false,
     enableFixer = true,
     fixerMessage = '',
+    minLineCount = 0,
   } = context.options[0] || {};
 
   return {
@@ -172,6 +177,7 @@ const getOptions = (context) => {
     exemptEmptyConstructors,
     exemptEmptyFunctions,
     fixerMessage,
+    minLineCount,
     publicOnly: ((baseObj) => {
       if (!publicOnly) {
         return false;
@@ -213,9 +219,18 @@ export default {
       exemptEmptyConstructors,
       enableFixer,
       fixerMessage,
+      minLineCount,
     } = getOptions(context);
 
     const checkJsDoc = (info, handler, node) => {
+      if (
+        // Optimize
+        minLineCount &&
+        (sourceCode.getText(node).match(/\n/gu)?.length ?? 0) < minLineCount
+      ) {
+        return;
+      }
+
       const jsDocNode = getJSDocComment(sourceCode, node, settings);
 
       if (jsDocNode) {

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -3816,7 +3816,6 @@ function quux (foo) {
       `,
       parser: require.resolve('@typescript-eslint/parser'),
     },
-
     {
       code: `
          class Utility {
@@ -3882,6 +3881,36 @@ function quux (foo) {
           },
         },
       ],
+    },
+    {
+      code: `
+        function quux () {
+          return 3;
+        }
+
+        function b () {}
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc comment.',
+        },
+      ],
+      options: [
+        {
+          minLineCount: 2,
+        },
+      ],
+      output: `
+        /**
+         *
+         */
+        function quux () {
+          return 3;
+        }
+
+        function b () {}
+      `,
     },
   ],
   valid: [
@@ -5828,6 +5857,20 @@ function quux (foo) {
             FunctionExpression: true,
             MethodDefinition: true,
           },
+        },
+      ],
+    },
+    {
+      code: `
+          function quux () {
+          return 3;
+        }
+
+        function b () {}
+      `,
+      options: [
+        {
+          minLineCount: 4,
         },
       ],
     },

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -3912,6 +3912,137 @@ function quux (foo) {
         function b () {}
       `,
     },
+    {
+      code: `
+        function quux () {
+          return 3;
+        }
+
+        var a = {};
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc comment.',
+        },
+      ],
+      options: [
+        {
+          contexts: [
+            {
+              context: 'FunctionDeclaration',
+              minLineCount: 2,
+            },
+            {
+              context: 'VariableDeclaration',
+              minLineCount: 2,
+            },
+          ],
+          require: {
+            FunctionDeclaration: false,
+          },
+        },
+      ],
+      output: `
+        /**
+         *
+         */
+        function quux () {
+          return 3;
+        }
+
+        var a = {};
+      `,
+    },
+    {
+      code: `
+        function quux () {
+          return 3;
+        }
+
+        var a = {
+          b: 1,
+          c: 2
+        };
+      `,
+      errors: [
+        {
+          line: 6,
+          message: 'Missing JSDoc comment.',
+        },
+      ],
+      options: [
+        {
+          contexts: [
+            {
+              context: 'FunctionDeclaration',
+              minLineCount: 4,
+            },
+            {
+              context: 'VariableDeclaration',
+              minLineCount: 2,
+            },
+          ],
+          require: {
+            FunctionDeclaration: false,
+          },
+        },
+      ],
+      output: `
+        function quux () {
+          return 3;
+        }
+
+        /**
+         *
+         */
+        var a = {
+          b: 1,
+          c: 2
+        };
+      `,
+    },
+    {
+      code: `
+        class A {
+          setId(newId: number): void {
+            this.id = id;
+          }
+        }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing JSDoc comment.',
+        },
+      ],
+      options: [
+        {
+          contexts: [
+            {
+              context: 'MethodDefinition',
+              minLineCount: 3,
+            },
+          ],
+          require: {
+            ClassDeclaration: false,
+            FunctionExpression: false,
+            MethodDefinition: false,
+          },
+        },
+      ],
+      output: `
+        class A {
+          /**
+           *
+           */
+          setId(newId: number): void {
+            this.id = id;
+          }
+        }
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
   ],
   valid: [
     {
@@ -5873,6 +6004,60 @@ function quux (foo) {
           minLineCount: 4,
         },
       ],
+    },
+    {
+      code: `
+        function quux () {
+          return 3;
+        }
+
+        var a = {
+          b: 1,
+          c: 2
+        };
+      `,
+      options: [
+        {
+          contexts: [
+            {
+              context: 'FunctionDeclaration',
+              minLineCount: 4,
+            },
+            {
+              context: 'VariableDeclaration',
+              minLineCount: 5,
+            },
+          ],
+          require: {
+            FunctionDeclaration: false,
+          },
+        },
+      ],
+    },
+    {
+      code: `
+        class A {
+          setId(newId: number): void {
+            this.id = id;
+          }
+        }
+      `,
+      options: [
+        {
+          contexts: [
+            {
+              context: 'MethodDefinition',
+              minLineCount: 4,
+            },
+          ],
+          require: {
+            ClassDeclaration: false,
+            FunctionExpression: false,
+            MethodDefinition: false,
+          },
+        },
+      ],
+      parser: require.resolve('@typescript-eslint/parser'),
     },
   ],
 };


### PR DESCRIPTION
feat(`require-jsdoc`): add `minLineCount` option (including on `contexts`) to avoid reporting short functions/contexts; fixes #870