### PR TITLE
fix(`require-param-type`): report column=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14868,6 +14868,13 @@ function quux (foo) {
 // Message: Missing JSDoc @param "foo" type.
 
 /**
+ * @param {a xxx
+ */
+function quux () {
+}
+// Message: Missing JSDoc @param "" type.
+
+/**
  * @param foo
  */
 function quux (foo) {

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -844,9 +844,11 @@ const makeReport = (context, commentNode) => {
 
       loc = {
         end: {
+          column: 0,
           line: lineNumber,
         },
         start: {
+          column: 0,
           line: lineNumber,
         },
       };
@@ -858,9 +860,6 @@ const makeReport = (context, commentNode) => {
 
         loc.end.column = colNumber;
         loc.start.column = colNumber;
-      } else {
-        loc.end.column = 0;
-        loc.start.column = 0;
       }
     }
 

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -858,6 +858,9 @@ const makeReport = (context, commentNode) => {
 
         loc.end.column = colNumber;
         loc.start.column = colNumber;
+      } else {
+        loc.end.column = 0;
+        loc.start.column = 0;
       }
     }
 

--- a/test/rules/assertions/requireParamType.js
+++ b/test/rules/assertions/requireParamType.js
@@ -19,6 +19,22 @@ export default {
     },
     {
       code: `
+      /**
+       * @param {a xxx
+       */
+      function quux () {
+      }
+      `,
+      errors: [
+        {
+          column: 1,
+          line: 3,
+          message: 'Missing JSDoc @param "" type.',
+        },
+      ],
+    },
+    {
+      code: `
           /**
            * @param foo
            */

--- a/test/rules/assertions/requireParamType.js
+++ b/test/rules/assertions/requireParamType.js
@@ -11,6 +11,7 @@ export default {
       `,
       errors: [
         {
+          column: 1,
           line: 3,
           message: 'Missing JSDoc @param "foo" type.',
         },
@@ -27,6 +28,7 @@ export default {
       `,
       errors: [
         {
+          column: 1,
           line: 3,
           message: 'Missing JSDoc @param "foo" type.',
         },
@@ -48,6 +50,7 @@ export default {
       `,
       errors: [
         {
+          column: 1,
           line: 4,
           message: 'Missing JSDoc @param "foo" type.',
         },
@@ -69,6 +72,7 @@ export default {
       `,
       errors: [
         {
+          column: 1,
           line: 4,
           message: 'Missing JSDoc @param "foo" type.',
         },
@@ -92,6 +96,7 @@ export default {
       `,
       errors: [
         {
+          column: 1,
           line: 3,
           message: 'Missing JSDoc @arg "foo" type.',
         },
@@ -115,6 +120,7 @@ export default {
       `,
       errors: [
         {
+          column: 1,
           line: 3,
           message: 'Unexpected tag `@param`',
         },


### PR DESCRIPTION
Hello, I've been dealing with an annoying bug using NeoVim + LSP + eslint. If I'm typing a function parameter from scratch, like `/** @param {nu`, this plugin rightfully reports an error (`require-param-type`) since I haven't finished typing the type.

But it reports column number = 0 which causes NeoVim's LSP client to crash, interrupting my typing.

Presumably it would be impossible to error on an empty line, so I'm hoping adding column = 1 when the upstream parser doesn't report a column number is okay as a quick fix. I'm sure there is a better way to get the real column number but I don't have time to dig any deeper right now.

Not sure if other rules are affected or not, this is the only one I ran into.

Thanks!

---

`x.js`
```js
/**
 * @param {a xxx
 */
```

`yarn eslint x.js` before commit
```
2:0   error  Missing JSDoc @param "" type     jsdoc/require-param-type
```

`yarn eslint x.js` after commit
```
2:1   error  Missing JSDoc @param "" type     jsdoc/require-param-type
```