### PR TITLE
build: add Node 18 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: xenial
+dist: focal
 language: node_js
 node_js:
   - "14.17.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - "14.17.0"
   - "16"
   - "17"
+  - "18"
 install:
   - npm install --legacy-peer-deps
 before_script: >

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typescript": "^4.6.3"
   },
   "engines": {
-    "node": "^14 || ^16 || ^17"
+    "node": "^14 || ^16 || ^17 || ^18"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
Node 18 is out. This adds it to the CI and package.json.

Node 18 requires newer versions of GLIBC which are included in Ubuntu 20.04 LTS (focal), but not Ubuntu 16.04 LTS (xenial)

Relates to https://github.com/es-joy/jsdoccomment/pull/7