### PR TITLE
fix(`check-tag-names`): work with the constructor tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4500,6 +4500,15 @@ function quux (foo) {}
 /** @jsxImportSource preact */
 /** @jsxRuntime automatic */
 // Message: Invalid JSDoc tag name "jsx".
+
+/**
+ * @constructor
+ */
+function Test() {
+  this.works = false;
+}
+// Settings: {"jsdoc":{"tagNamePreference":{"returns":"return"}}}
+// Message: Invalid JSDoc tag (preference). Replace "constructor" JSDoc tag with "class".
 ````
 
 The following patterns are not considered problems:

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -396,7 +396,7 @@ const getPreferredTagName = (
       }),
   );
 
-  if (name in tagPreferenceFixed) {
+  if (Object.prototype.hasOwnProperty.call(tagPreferenceFixed, name)) {
     return tagPreferenceFixed[name];
   }
 

--- a/test/jsdocUtils.js
+++ b/test/jsdocUtils.js
@@ -10,6 +10,12 @@ describe('jsdocUtils', () => {
         it('returns the primary tag name', () => {
           expect(jsdocUtils.getPreferredTagName({}, 'jsdoc', 'return')).to.equal('returns');
         });
+        it('works with the constructor tag', () => {
+          expect(jsdocUtils.getPreferredTagName({}, 'jsdoc', 'constructor')).to.equal('class');
+        });
+      });
+      it('works with tags that clash with prototype properties', () => {
+        expect(jsdocUtils.getPreferredTagName({}, 'jsdoc', 'toString')).to.equal('toString');
       });
       it('returns the primary tag name', () => {
         expect(jsdocUtils.getPreferredTagName({}, 'jsdoc', 'returns')).to.equal('returns');

--- a/test/rules/assertions/checkTagNames.js
+++ b/test/rules/assertions/checkTagNames.js
@@ -641,6 +641,37 @@ export default {
         },
       ],
     },
+    {
+      code: `
+      /**
+       * @constructor
+       */
+      function Test() {
+        this.works = false;
+      }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc tag (preference). Replace "constructor" JSDoc tag with "class".',
+        },
+      ],
+      output: `
+      /**
+       * @class
+       */
+      function Test() {
+        this.works = false;
+      }
+      `,
+      settings: {
+        jsdoc: {
+          tagNamePreference: {
+            returns: 'return',
+          },
+        },
+      },
+    },
   ],
   valid: [
     {


### PR DESCRIPTION
This makes it so the `check-tag-names` rule works when JSDoc tag names match `Object.prototype` properties (like `@constructor`).

Fixes #898.

