### PR TITLE
build(.npmignore): add `CONTRIBUTING.md`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ src
 test
 .*
 *.log
+CONTRIBUTING.md


### PR DESCRIPTION
Other development related files are removed before publishing, so this can probably go also.