### PR TITLE
Fix README link in require-returns-type.md

### DIFF
--- a/.README/rules/require-returns-type.md
+++ b/.README/rules/require-returns-type.md
@@ -14,7 +14,7 @@ for finding function blocks not attached to a function declaration or
 expression, i.e., `@callback` or `@function` (or its aliases `@func` or
 `@method`) (including those associated with an `@interface`).
 
-See the ["AST and Selectors"](#eslint-plugin-jsdoc-advanced-ast-and-selectors)
+See the ["AST and Selectors"](../#ast-and-selectors)
 section of our README for more on the expected format.
 
 |||


### PR DESCRIPTION
The README link to "ASTs and Selectors" in rules/require-returns-type.md does not currently work.

This pull request updates the link to use the correct URL and anchor.