### PR TITLE
fix(`check-line-alignment`): Fix line alignment when no types are present

### DIFF
--- a/README.md
+++ b/README.md
@@ -2697,6 +2697,79 @@ const fn = ( lorem, sit ) => {};
  */
 const fn2 = () => {}
 // "jsdoc/check-line-alignment": ["error"|"warn", "always"]
+
+/**
+ * Function description.
+ *
+ * @param lorem Description.
+ * @param sit   Description multi words.
+ * @return      Return description.
+ */
+const fn = ( lorem, sit ) => {};
+
+/**
+ * Function description.
+ *
+ * @param lorem Description.
+ * @param sit   Description multi words.
+ * @returns     Return description.
+ */
+const fn2 = ( lorem, sit ) => {};
+
+/**
+ * Function description.
+ *
+ * @param a Description.
+ * @param b Description multi words.
+ * @returns Return description.
+ */
+const fn3 = ( a, b ) => {};
+// "jsdoc/check-line-alignment": ["error"|"warn", "always"]
+
+/**
+ * Function description.
+ *
+ * @argument lorem Description.
+ * @return         Return description.
+ */
+const fn = ( lorem ) => {};
+
+/**
+ * Function description.
+ *
+ * @argument lorem Description.
+ * @returns        Return description.
+ */
+const fn2 = ( lorem ) => {};
+// "jsdoc/check-line-alignment": ["error"|"warn", "always"]
+
+/**
+ * Function description.
+ *
+ * @arg a   Description.
+ * @returns Return description.
+ */
+const fn = ( a ) => {};
+// "jsdoc/check-line-alignment": ["error"|"warn", "always"]
+
+/**
+ * Function description.
+ *
+ * @arg   lorem Description.
+ * @param sit   Return description.
+ */
+const fn = ( lorem, sit ) => {};
+// "jsdoc/check-line-alignment": ["error"|"warn", "always"]
+
+/**
+ * Function description.
+ *
+ * @arg      a Description.
+ * @argument b Second description.
+ * @returns    Return description.
+ */
+const fn = ( a, b ) => {};
+// "jsdoc/check-line-alignment": ["error"|"warn", "always"]
 ````
 
 

--- a/test/rules/assertions/checkLineAlignment.js
+++ b/test/rules/assertions/checkLineAlignment.js
@@ -1577,5 +1577,103 @@ export default {
         'always',
       ],
     },
+    {
+      code: `
+      /**
+       * Function description.
+       *
+       * @param lorem Description.
+       * @param sit   Description multi words.
+       * @return      Return description.
+       */
+      const fn = ( lorem, sit ) => {};
+
+      /**
+       * Function description.
+       *
+       * @param lorem Description.
+       * @param sit   Description multi words.
+       * @returns     Return description.
+       */
+      const fn2 = ( lorem, sit ) => {};
+
+      /**
+       * Function description.
+       *
+       * @param a Description.
+       * @param b Description multi words.
+       * @returns Return description.
+       */
+      const fn3 = ( a, b ) => {};
+      `,
+      options: [
+        'always',
+      ],
+    },
+    {
+      code: `
+      /**
+       * Function description.
+       *
+       * @argument lorem Description.
+       * @return         Return description.
+       */
+      const fn = ( lorem ) => {};
+
+      /**
+       * Function description.
+       *
+       * @argument lorem Description.
+       * @returns        Return description.
+       */
+      const fn2 = ( lorem ) => {};
+      `,
+      options: [
+        'always',
+      ],
+    },
+    {
+      code: `
+      /**
+       * Function description.
+       *
+       * @arg a   Description.
+       * @returns Return description.
+       */
+      const fn = ( a ) => {};
+      `,
+      options: [
+        'always',
+      ],
+    },
+    {
+      code: `
+      /**
+       * Function description.
+       *
+       * @arg   lorem Description.
+       * @param sit   Return description.
+       */
+      const fn = ( lorem, sit ) => {};
+      `,
+      options: [
+        'always',
+      ],
+    },
+    {
+      code: `
+      /**
+       * Function description.
+       *
+       * @arg      a Description.
+       * @argument b Second description.
+       * @returns    Return description.
+       */
+      const fn = ( a, b ) => {};
+      `,
+      options: [
+        'always',
+      ],
+    },
   ],
 };


### PR DESCRIPTION
This fixes #894, along with a few additional edge cases I discovered along the way.

I tried to keep my fix structured similar to how the [initial change works](https://github.com/gajus/eslint-plugin-jsdoc/commit/26e7357171ee1abd73dc16191725a786e7108cf0). It does still kind of seem like a hack, so let me know if there is a different approach I should take.

If I made an incorrect assumption when creating the test cases and any of them should actually be invalid, let me know. I am willing to make changes to this pr.