### PR TITLE
treat non-void `TSDeclareFunction` type annotations as having a return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -17382,6 +17382,41 @@ function quux (foo) {
   return foo;
 }
 // Message: JSDoc @returns declaration set with "never" but return expression is present in function.
+
+/**
+ * Reads a test fixture.
+ *
+ * @param path The path to resolve relative to the fixture base. It will be normalized for the
+ * operating system.
+ *
+ * @returns The file contents as buffer.
+ */
+export function readFixture(path: string): void;
+// Message: JSDoc @returns declaration present but return expression not available in function.
+
+/**
+ * Reads a test fixture.
+ *
+ * @param path The path to resolve relative to the fixture base. It will be normalized for the
+ * operating system.
+ *
+ * @returns The file contents as buffer.
+ */
+export function readFixture(path: string);
+// Message: JSDoc @returns declaration present but return expression not available in function.
+
+/**
+ * Reads a test fixture.
+ *
+ * @param path The path to resolve relative to the fixture base. It will be normalized for the
+ * operating system.
+ *
+ * @returns The file contents as buffer.
+ */
+export function readFixture(path: string): void {
+  return;
+};
+// Message: JSDoc @returns declaration present but return expression not available in function.
 ````
 
 The following patterns are not considered problems:
@@ -17766,6 +17801,38 @@ function * quux() {}
 function assertNumber(val) {
   assert(typeof val === 'number');
 }
+
+/**
+ * Reads a test fixture.
+ *
+ * @param path The path to resolve relative to the fixture base. It will be normalized for the
+ * operating system.
+ *
+ * @returns The file contents as buffer.
+ */
+export function readFixture(path: string): Promise<Buffer>;
+
+/**
+ * Reads a test fixture.
+ *
+ * @param path The path to resolve relative to the fixture base. It will be normalized for the
+ * operating system.
+ *
+ * @returns The file contents as buffer.
+ */
+export function readFixture(path: string): Promise<Buffer> {
+  return new Promise(() => {});
+}
+
+/**
+ * Reads a test fixture.
+ *
+ * @param path The path to resolve relative to the fixture base. It will be normalized for the
+ * operating system.
+ *
+ * @returns {void} The file contents as buffer.
+ */
+export function readFixture(path: string);
 ````
 
 
@@ -18640,6 +18707,26 @@ export const sleep = (ms: number) => {
   return new Promise<string>((res) => setTimeout(res, ms));
 };
 // Message: Missing JSDoc @returns declaration.
+
+/**
+ * Reads a test fixture.
+ */
+export function readFixture(path: string): Promise<Buffer>;
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ * Reads a test fixture.
+ */
+export function readFixture(path: string): void;
+// "jsdoc/require-returns": ["error"|"warn", {"forceRequireReturn":true}]
+// Message: Missing JSDoc @returns declaration.
+
+/**
+ * Reads a test fixture.
+ */
+export function readFixture(path: string);
+// "jsdoc/require-returns": ["error"|"warn", {"forceRequireReturn":true}]
+// Message: Missing JSDoc @returns declaration.
 ````
 
 The following patterns are not considered problems:
@@ -19143,6 +19230,30 @@ export const sleep = (ms: number) =>
 export const sleep = (ms: number) => {
   return new Promise<void>((res) => setTimeout(res, ms));
 };
+
+/**
+ * Reads a test fixture.
+ *
+ * @returns The file contents as buffer.
+ */
+export function readFixture(path: string): Promise<Buffer>;
+
+/**
+ * Reads a test fixture.
+ *
+ * @returns {void}.
+ */
+export function readFixture(path: string): void;
+
+/**
+ * Reads a test fixture.
+ */
+export function readFixture(path: string): void;
+
+/**
+ * Reads a test fixture.
+ */
+export function readFixture(path: string);
 ````
 
 

--- a/src/utils/hasReturnValue.js
+++ b/src/utils/hasReturnValue.js
@@ -15,6 +15,10 @@ const isVoidPromise = (node) => {
   return node?.typeParameters?.params?.[0]?.type === 'TSVoidKeyword';
 };
 
+const undefinedKeywords = new Set([
+  'TSVoidKeyword', 'TSUndefinedKeyword', 'TSNeverKeyword',
+]);
+
 /**
  * @callback PromiseFilter
  * @param {object} node
@@ -35,12 +39,13 @@ const hasReturnValue = (node, promFilter) => {
   }
 
   switch (node.type) {
+  case 'TSDeclareFunction':
   case 'TSFunctionType':
-  case 'TSMethodSignature':
-    return ![
-      'TSVoidKeyword',
-      'TSUndefinedKeyword',
-    ].includes(node?.returnType?.typeAnnotation?.type);
+  case 'TSMethodSignature': {
+    const type = node?.returnType?.typeAnnotation?.type;
+    return type && !undefinedKeywords.has(type);
+  }
+
   case 'MethodDefinition':
     return hasReturnValue(node.value, promFilter);
   case 'FunctionExpression':

--- a/test/rules/assertions/requireReturns.js
+++ b/test/rules/assertions/requireReturns.js
@@ -1671,6 +1671,61 @@ export default {
       ],
       parser: require.resolve('@typescript-eslint/parser'),
     },
+    {
+      code: `
+      /**
+       * Reads a test fixture.
+       */
+      export function readFixture(path: string): Promise<Buffer>;
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+      /**
+       * Reads a test fixture.
+       */
+      export function readFixture(path: string): void;
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      options: [
+        {
+          forceRequireReturn: true,
+        },
+      ],
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+      /**
+       * Reads a test fixture.
+       */
+      export function readFixture(path: string);
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @returns declaration.',
+        },
+      ],
+      options: [
+        {
+          forceRequireReturn: true,
+        },
+      ],
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
   ],
   valid: [
     {
@@ -2538,6 +2593,46 @@ export default {
         export const sleep = (ms: number) => {
           return new Promise<void>((res) => setTimeout(res, ms));
         };
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+      /**
+       * Reads a test fixture.
+       *
+       * @returns The file contents as buffer.
+       */
+      export function readFixture(path: string): Promise<Buffer>;
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+      /**
+       * Reads a test fixture.
+       *
+       * @returns {void}.
+       */
+      export function readFixture(path: string): void;
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+      /**
+       * Reads a test fixture.
+       */
+      export function readFixture(path: string): void;
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+      /**
+       * Reads a test fixture.
+       */
+      export function readFixture(path: string);
       `,
       parser: require.resolve('@typescript-eslint/parser'),
     },

--- a/test/rules/assertions/requireReturnsCheck.js
+++ b/test/rules/assertions/requireReturnsCheck.js
@@ -371,6 +371,68 @@ export default {
         },
       ],
     },
+    {
+      code: `
+      /**
+       * Reads a test fixture.
+       *
+       * @param path The path to resolve relative to the fixture base. It will be normalized for the
+       * operating system.
+       *
+       * @returns The file contents as buffer.
+       */
+      export function readFixture(path: string): void;
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'JSDoc @returns declaration present but return expression not available in function.',
+        },
+      ],
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+      /**
+       * Reads a test fixture.
+       *
+       * @param path The path to resolve relative to the fixture base. It will be normalized for the
+       * operating system.
+       *
+       * @returns The file contents as buffer.
+       */
+      export function readFixture(path: string);
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'JSDoc @returns declaration present but return expression not available in function.',
+        },
+      ],
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+      /**
+       * Reads a test fixture.
+       *
+       * @param path The path to resolve relative to the fixture base. It will be normalized for the
+       * operating system.
+       *
+       * @returns The file contents as buffer.
+       */
+      export function readFixture(path: string): void {
+        return;
+      };
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'JSDoc @returns declaration present but return expression not available in function.',
+        },
+      ],
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
   ],
   valid: [
     {
@@ -950,6 +1012,50 @@ export default {
         assert(typeof val === 'number');
       }
       `,
+    },
+    {
+      code: `
+      /**
+       * Reads a test fixture.
+       *
+       * @param path The path to resolve relative to the fixture base. It will be normalized for the
+       * operating system.
+       *
+       * @returns The file contents as buffer.
+       */
+      export function readFixture(path: string): Promise<Buffer>;
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+      /**
+       * Reads a test fixture.
+       *
+       * @param path The path to resolve relative to the fixture base. It will be normalized for the
+       * operating system.
+       *
+       * @returns The file contents as buffer.
+       */
+      export function readFixture(path: string): Promise<Buffer> {
+        return new Promise(() => {});
+      }
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+      /**
+       * Reads a test fixture.
+       *
+       * @param path The path to resolve relative to the fixture base. It will be normalized for the
+       * operating system.
+       *
+       * @returns {void} The file contents as buffer.
+       */
+      export function readFixture(path: string);
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
     },
   ],
 };


### PR DESCRIPTION
fix(require-returns, require-returns-check): treat non-void `TSDeclareFunction` type annotations as having a return value; fixes part of #903