### PR TITLE
fix: if return type is missing, only check one path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17813,7 +17813,7 @@ function quux () {
 // Message: JSDoc @returns declaration present but return expression not available in function.
 
 /**
- * @returns Baz.
+ * @returns {SomeType} Baz.
  */
 function foo() {
     switch (true) {
@@ -17827,7 +17827,7 @@ function foo() {
 // Message: JSDoc @returns declaration present but return expression not available in function.
 
 /**
- * @returns Baz.
+ * @returns {SomeType} Baz.
  */
 function foo() {
     switch (true) {
@@ -18249,6 +18249,16 @@ export function readFixture(path: string): Promise<Buffer>;
  * @param path The path to resolve relative to the fixture base. It will be normalized for the
  * operating system.
  *
+ * @returns {SomeType} The file contents as buffer.
+ */
+export function readFixture(path: string): Promise<Buffer>;
+
+/**
+ * Reads a test fixture.
+ *
+ * @param path The path to resolve relative to the fixture base. It will be normalized for the
+ * operating system.
+ *
  * @returns The file contents as buffer.
  */
 export function readFixture(path: string): Promise<Buffer> {
@@ -18430,6 +18440,41 @@ function foo( bar ) {
     return functionWithUnknownReturnType();
   }
 }
+
+/**
+ * @returns Baz.
+ */
+function foo() {
+    switch (true) {
+        default:
+            switch (false) {
+                default: return;
+            }
+            return "baz";
+    }
+};
+
+/**
+ * @returns Baz.
+ */
+function foo() {
+    switch (true) {
+        default:
+            switch (false) {
+                default: return;
+            }
+            return "baz";
+    }
+};
+
+/**
+ * @returns
+ */
+const quux = (someVar) => {
+  if (someVar) {
+    return true;
+  }
+};
 ````
 
 

--- a/src/rules/requireReturnsCheck.js
+++ b/src/rules/requireReturnsCheck.js
@@ -94,10 +94,14 @@ export default iterateJsdoc(({
       reportMissingReturnForUndefinedTypes ||
       !utils.mayBeUndefinedTypeTag(tag)
     ) &&
-    !utils.hasValueOrExecutorHasNonEmptyResolveValue(
+    (tag.type === '' && !utils.hasValueOrExecutorHasNonEmptyResolveValue(
+      exemptAsync,
+    ) ||
+    tag.type !== '' && !utils.hasValueOrExecutorHasNonEmptyResolveValue(
       exemptAsync,
       true,
-    ) && (!exemptGenerators || !node.generator)
+    )) &&
+    (!exemptGenerators || !node.generator)
   ) {
     report(`JSDoc @${tagName} declaration present but return expression not available in function.`);
   }

--- a/test/rules/assertions/requireReturnsCheck.js
+++ b/test/rules/assertions/requireReturnsCheck.js
@@ -613,7 +613,7 @@ export default {
     {
       code: `
       /**
-       * @returns Baz.
+       * @returns {SomeType} Baz.
        */
       function foo() {
           switch (true) {
@@ -635,7 +635,7 @@ export default {
     {
       code: `
       /**
-       * @returns Baz.
+       * @returns {SomeType} Baz.
        */
       function foo() {
           switch (true) {
@@ -1268,6 +1268,20 @@ export default {
        * @param path The path to resolve relative to the fixture base. It will be normalized for the
        * operating system.
        *
+       * @returns {SomeType} The file contents as buffer.
+       */
+      export function readFixture(path: string): Promise<Buffer>;
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+      /**
+       * Reads a test fixture.
+       *
+       * @param path The path to resolve relative to the fixture base. It will be normalized for the
+       * operating system.
+       *
        * @returns The file contents as buffer.
        */
       export function readFixture(path: string): Promise<Buffer> {
@@ -1517,6 +1531,50 @@ export default {
         }
       }
       `,
+    },
+    {
+      code: `
+      /**
+       * @returns Baz.
+       */
+      function foo() {
+          switch (true) {
+              default:
+                  switch (false) {
+                      default: return;
+                  }
+                  return "baz";
+          }
+      };
+      `,
+    },
+    {
+      code: `
+      /**
+       * @returns Baz.
+       */
+      function foo() {
+          switch (true) {
+              default:
+                  switch (false) {
+                      default: return;
+                  }
+                  return "baz";
+          }
+      };
+      `,
+    },
+    {
+      code: `
+      /**
+       * @returns
+       */
+      const quux = (someVar) => {
+        if (someVar) {
+          return true;
+        }
+      };
+  `,
     },
   ],
 };


### PR DESCRIPTION
fixes #949

Users can still rely on `require-returns-type` to catch missing types