### PR TITLE
fix: complete sentence period placement

### DIFF
--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -81,7 +81,7 @@ const validateDescription = (
       let text = sourceCode.getText(jsdocNode);
 
       if (!/[.:?!]$/u.test(paragraph)) {
-        const line = paragraph.split('\n').pop();
+        const line = paragraph.split('\n').filter(Boolean).pop();
 
         text = text.replace(new RegExp(`${escapeStringRegexp(line)}$`, 'mu'), `${line}.`);
       }

--- a/test/rules/assertions/requireDescriptionCompleteSentence.js
+++ b/test/rules/assertions/requireDescriptionCompleteSentence.js
@@ -200,6 +200,34 @@ export default {
       code: `
           /**
            * Foo
+           *
+           * @param x
+           */
+          function quux () {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Sentence must end with a period.',
+        },
+      ],
+      output: `
+          /**
+           * Foo.
+           *
+           * @param x
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * Foo
            * Bar.
            */
           function quux () {


### PR DESCRIPTION
This fixes https://github.com/gajus/eslint-plugin-jsdoc/issues/779. 

The previous implementation was matching an empty line following the paragraph and performing a regex replacement on it. Added an extra test to verify the fix.