### PR TITLE
fix(`require-complete-description-sentence`): allow triple backticks to end "sentence" and protect backtick content

### DIFF
--- a/README.md
+++ b/README.md
@@ -10981,7 +10981,7 @@ The following patterns are considered problems:
 function quux () {
 
 }
-// Message: Sentence should start with an uppercase character.
+// Message: Sentences should start with an uppercase character.
 
 /**
  * foo?
@@ -10989,7 +10989,7 @@ function quux () {
 function quux () {
 
 }
-// Message: Sentence should start with an uppercase character.
+// Message: Sentences should start with an uppercase character.
 
 /**
  * @description foo.
@@ -10997,7 +10997,7 @@ function quux () {
 function quux () {
 
 }
-// Message: Sentence should start with an uppercase character.
+// Message: Sentences should start with an uppercase character.
 
 /**
  * Foo)
@@ -11005,7 +11005,7 @@ function quux () {
 function quux () {
 
 }
-// Message: Sentence must end with a period.
+// Message: Sentences must end with a period.
 
 /**
  * `foo` is a variable
@@ -11013,7 +11013,7 @@ function quux () {
 function quux () {
 
 }
-// Message: Sentence must end with a period.
+// Message: Sentences must end with a period.
 
 /**
  * Foo.
@@ -11023,7 +11023,7 @@ function quux () {
 function quux () {
 
 }
-// Message: Sentence should start with an uppercase character.
+// Message: Sentences should start with an uppercase character.
 
 /**
  * тест.
@@ -11031,7 +11031,7 @@ function quux () {
 function quux () {
 
 }
-// Message: Sentence should start with an uppercase character.
+// Message: Sentences should start with an uppercase character.
 
 /**
  * Foo
@@ -11039,7 +11039,7 @@ function quux () {
 function quux () {
 
 }
-// Message: Sentence must end with a period.
+// Message: Sentences must end with a period.
 
 /**
  * Foo
@@ -11049,7 +11049,7 @@ function quux () {
 function quux () {
 
 }
-// Message: Sentence must end with a period.
+// Message: Sentences must end with a period.
 
 /**
  * Foo
@@ -11059,7 +11059,7 @@ function quux () {
 
 }
 // "jsdoc/require-description-complete-sentence": ["error"|"warn", {"newlineBeforeCapsAssumesBadSentenceEnd":true}]
-// Message: A line of text is started with an uppercase character, but preceding line does not end the sentence.
+// Message: A line of text is started with an uppercase character, but the preceding line does not end the sentence.
 
 /**
  * Foo.
@@ -11069,7 +11069,7 @@ function quux () {
 function quux (foo) {
 
 }
-// Message: Sentence should start with an uppercase character.
+// Message: Sentences should start with an uppercase character.
 
 /**
  * Foo.
@@ -11079,7 +11079,7 @@ function quux (foo) {
 function quux (foo) {
 
 }
-// Message: Sentence should start with an uppercase character.
+// Message: Sentences should start with an uppercase character.
 
 /**
  * {@see Foo.bar} buz
@@ -11087,7 +11087,7 @@ function quux (foo) {
 function quux (foo) {
 
 }
-// Message: Sentence should start with an uppercase character.
+// Message: Sentences should start with an uppercase character.
 
 /**
  * Foo.
@@ -11097,7 +11097,7 @@ function quux (foo) {
 function quux (foo) {
 
 }
-// Message: Sentence should start with an uppercase character.
+// Message: Sentences should start with an uppercase character.
 
 /**
  * Foo.
@@ -11107,7 +11107,7 @@ function quux (foo) {
 function quux (foo) {
 
 }
-// Message: Sentence should start with an uppercase character.
+// Message: Sentences should start with an uppercase character.
 
 /**
  * lorem ipsum dolor sit amet, consectetur adipiscing elit. pellentesque elit diam,
@@ -11120,7 +11120,7 @@ function quux (foo) {
 function longDescription (foo) {
 
 }
-// Message: Sentence should start with an uppercase character.
+// Message: Sentences should start with an uppercase character.
 
 /**
  * @arg {number} foo - Foo
@@ -11128,7 +11128,7 @@ function longDescription (foo) {
 function quux (foo) {
 
 }
-// Message: Sentence must end with a period.
+// Message: Sentences must end with a period.
 
 /**
  * @argument {number} foo - Foo
@@ -11136,7 +11136,7 @@ function quux (foo) {
 function quux (foo) {
 
 }
-// Message: Sentence must end with a period.
+// Message: Sentences must end with a period.
 
 /**
  * @return {number} foo
@@ -11144,7 +11144,7 @@ function quux (foo) {
 function quux (foo) {
 
 }
-// Message: Sentence should start with an uppercase character.
+// Message: Sentences should start with an uppercase character.
 
 /**
  * Returns bar.
@@ -11154,13 +11154,13 @@ function quux (foo) {
 function quux (foo) {
 
 }
-// Message: Sentence should start with an uppercase character.
+// Message: Sentences should start with an uppercase character.
 
 /**
  * @throws {object} Hello World
  * hello world
 */
-// Message: Sentence must end with a period.
+// Message: Sentences must end with a period.
 
 /**
  * @summary Foo
@@ -11168,7 +11168,7 @@ function quux (foo) {
 function quux () {
 
 }
-// Message: Sentence must end with a period.
+// Message: Sentences must end with a period.
 
 /**
  * @throws {SomeType} Foo
@@ -11176,7 +11176,7 @@ function quux () {
 function quux () {
 
 }
-// Message: Sentence must end with a period.
+// Message: Sentences must end with a period.
 
 /**
  * @see Foo
@@ -11185,7 +11185,7 @@ function quux () {
 
 }
 // "jsdoc/require-description-complete-sentence": ["error"|"warn", {"tags":["see"]}]
-// Message: Sentence must end with a period.
+// Message: Sentences must end with a period.
 
 /**
  * @param foo Foo bar
@@ -11195,7 +11195,7 @@ function quux (foo) {
 }
 // Settings: {"jsdoc":{"tagNamePreference":{"description":false}}}
 // "jsdoc/require-description-complete-sentence": ["error"|"warn", {"tags":["param"]}]
-// Message: Sentence must end with a period.
+// Message: Sentences must end with a period.
 
 /**
  * Sorry, but this isn't a complete sentence, Mr.
@@ -11204,7 +11204,7 @@ function quux () {
 
 }
 // "jsdoc/require-description-complete-sentence": ["error"|"warn", {"abbreviations":["Mr"]}]
-// Message: Sentence must end with a period.
+// Message: Sentences must end with a period.
 
 /**
  * Sorry, but this isn't a complete sentence Mr.
@@ -11213,7 +11213,7 @@ function quux () {
 
 }
 // "jsdoc/require-description-complete-sentence": ["error"|"warn", {"abbreviations":["Mr."]}]
-// Message: Sentence must end with a period.
+// Message: Sentences must end with a period.
 
 /**
  * Sorry, but this isn't a complete sentence Mr. 
@@ -11222,7 +11222,7 @@ function quux () {
 
 }
 // "jsdoc/require-description-complete-sentence": ["error"|"warn", {"abbreviations":["Mr"]}]
-// Message: Sentence must end with a period.
+// Message: Sentences must end with a period.
 
 /**
  * Sorry, but this isn't a complete sentence Mr. and Mrs.
@@ -11231,7 +11231,7 @@ function quux () {
 
 }
 // "jsdoc/require-description-complete-sentence": ["error"|"warn", {"abbreviations":["Mr","Mrs"]}]
-// Message: Sentence must end with a period.
+// Message: Sentences must end with a period.
 
 /**
  * This is a complete sentence. But this isn't, Mr.
@@ -11240,7 +11240,7 @@ function quux () {
 
 }
 // "jsdoc/require-description-complete-sentence": ["error"|"warn", {"abbreviations":["Mr"]}]
-// Message: Sentence must end with a period.
+// Message: Sentences must end with a period.
 
 /**
  * This is a complete Mr. sentence. But this isn't, Mr.
@@ -11249,7 +11249,7 @@ function quux () {
 
 }
 // "jsdoc/require-description-complete-sentence": ["error"|"warn", {"abbreviations":["Mr"]}]
-// Message: Sentence must end with a period.
+// Message: Sentences must end with a period.
 
 /**
  * This is a complete Mr. sentence.
@@ -11257,7 +11257,7 @@ function quux () {
 function quux () {
 
 }
-// Message: Sentence should start with an uppercase character.
+// Message: Sentences should start with an uppercase character.
 
 /**
  * This is fun, i.e. enjoyable, but not superlatively so, e.g. not
@@ -11266,7 +11266,7 @@ function quux () {
 function quux () {
 
 }
-// Message: Sentence should start with an uppercase character.
+// Message: Sentences should start with an uppercase character.
 
 /**
  * Do not have dynamic content; e.g. homepage. Here a simple unique id
@@ -11275,7 +11275,7 @@ function quux () {
  function quux () {
 
  }
-// Message: Sentence should start with an uppercase character.
+// Message: Sentences should start with an uppercase character.
 
 /**
  * Implements support for the
@@ -11284,7 +11284,7 @@ function quux () {
 function speak() {
 }
 // "jsdoc/require-description-complete-sentence": ["error"|"warn", {"newlineBeforeCapsAssumesBadSentenceEnd":true}]
-// Message: A line of text is started with an uppercase character, but preceding line does not end the sentence.
+// Message: A line of text is started with an uppercase character, but the preceding line does not end the sentence.
 
 /**
  * Foo.
@@ -11295,7 +11295,7 @@ function quux (foo) {
 
 }
 // "jsdoc/require-description-complete-sentence": ["error"|"warn", {"tags":["template"]}]
-// Message: Sentence should start with an uppercase character.
+// Message: Sentences should start with an uppercase character.
 
 /**
  * Just a component.
@@ -11303,7 +11303,7 @@ function quux (foo) {
  * @return {ReactElement}.
  */
 function quux () {}
-// Message: Sentence must be more than punctuation.
+// Message: Sentences must be more than punctuation.
 ````
 
 The following patterns are not considered problems:
@@ -11638,6 +11638,47 @@ export default (foo) => {
 
 /**
  * This is a complete sentence...
+ */
+function quux () {
+
+}
+
+/**
+ * He wanted a few items: a jacket and shirt...
+ */
+function quux () {
+
+}
+
+/**
+ * The code in question was...
+ * ```
+ * alert('hello');
+ * ```
+ */
+function quux () {
+
+}
+
+/**
+ * @param {number|string|Date|Object|OverType|WhateverElse} multiType -
+ * Nice long explanation...
+ */
+function test (multiType) {
+}
+
+/**
+ * Any kind of fowl (e.g., a duck).
+ */
+function quux () {}
+
+/**
+ * The code in question was...
+ * ```
+ * do something
+ *
+ * interesting
+ * ```
  */
 function quux () {
 

--- a/test/rules/assertions/requireDescriptionCompleteSentence.js
+++ b/test/rules/assertions/requireDescriptionCompleteSentence.js
@@ -12,7 +12,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence should start with an uppercase character.',
+          message: 'Sentences should start with an uppercase character.',
         },
       ],
       output: `
@@ -36,7 +36,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence should start with an uppercase character.',
+          message: 'Sentences should start with an uppercase character.',
         },
       ],
       output: `
@@ -60,7 +60,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence should start with an uppercase character.',
+          message: 'Sentences should start with an uppercase character.',
         },
       ],
       output: `
@@ -84,7 +84,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       output: `
@@ -108,7 +108,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       output: `
@@ -134,7 +134,7 @@ export default {
       errors: [
         {
           line: 5,
-          message: 'Sentence should start with an uppercase character.',
+          message: 'Sentences should start with an uppercase character.',
         },
       ],
       output: `
@@ -160,7 +160,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence should start with an uppercase character.',
+          message: 'Sentences should start with an uppercase character.',
         },
       ],
       output: `
@@ -184,7 +184,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       output: `
@@ -210,7 +210,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       output: `
@@ -237,7 +237,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'A line of text is started with an uppercase character, but preceding line does not end the sentence.',
+          message: 'A line of text is started with an uppercase character, but the preceding line does not end the sentence.',
         },
       ],
       options: [
@@ -260,7 +260,7 @@ export default {
       errors: [
         {
           line: 5,
-          message: 'Sentence should start with an uppercase character.',
+          message: 'Sentences should start with an uppercase character.',
         },
       ],
       output: `
@@ -288,11 +288,11 @@ export default {
       errors: [
         {
           line: 5,
-          message: 'Sentence should start with an uppercase character.',
+          message: 'Sentences should start with an uppercase character.',
         },
         {
           line: 5,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       output: `
@@ -318,11 +318,11 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence should start with an uppercase character.',
+          message: 'Sentences should start with an uppercase character.',
         },
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       output: `
@@ -348,11 +348,11 @@ export default {
       errors: [
         {
           line: 5,
-          message: 'Sentence should start with an uppercase character.',
+          message: 'Sentences should start with an uppercase character.',
         },
         {
           line: 5,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       output: `
@@ -380,7 +380,7 @@ export default {
       errors: [
         {
           line: 5,
-          message: 'Sentence should start with an uppercase character.',
+          message: 'Sentences should start with an uppercase character.',
         },
       ],
       output: `
@@ -411,7 +411,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence should start with an uppercase character.',
+          message: 'Sentences should start with an uppercase character.',
         },
       ],
       output: `
@@ -440,7 +440,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       output: `
@@ -464,7 +464,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       output: `
@@ -488,11 +488,11 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence should start with an uppercase character.',
+          message: 'Sentences should start with an uppercase character.',
         },
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       output: `
@@ -518,11 +518,11 @@ export default {
       errors: [
         {
           line: 5,
-          message: 'Sentence should start with an uppercase character.',
+          message: 'Sentences should start with an uppercase character.',
         },
         {
           line: 5,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       output: `
@@ -546,7 +546,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       output: `
@@ -568,7 +568,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       output: `
@@ -592,7 +592,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       output: `
@@ -616,7 +616,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       options: [
@@ -647,7 +647,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       options: [
@@ -685,7 +685,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       options: [
@@ -708,7 +708,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       options: [
@@ -731,7 +731,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       options: [
@@ -762,7 +762,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       options: [
@@ -785,7 +785,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       options: [
@@ -808,7 +808,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence must end with a period.',
+          message: 'Sentences must end with a period.',
         },
       ],
       options: [
@@ -831,7 +831,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence should start with an uppercase character.',
+          message: 'Sentences should start with an uppercase character.',
         },
       ],
       output: `
@@ -856,7 +856,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence should start with an uppercase character.',
+          message: 'Sentences should start with an uppercase character.',
         },
       ],
       output: `
@@ -882,7 +882,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentence should start with an uppercase character.',
+          message: 'Sentences should start with an uppercase character.',
         },
       ],
       output: `
@@ -907,7 +907,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'A line of text is started with an uppercase character, but preceding line does not end the sentence.',
+          message: 'A line of text is started with an uppercase character, but the preceding line does not end the sentence.',
         },
       ],
       options: [
@@ -930,7 +930,7 @@ export default {
       errors: [
         {
           line: 5,
-          message: 'Sentence should start with an uppercase character.',
+          message: 'Sentences should start with an uppercase character.',
         },
       ],
       options: [
@@ -963,7 +963,7 @@ export default {
       errors: [
         {
           line: 5,
-          message: 'Sentence must be more than punctuation.',
+          message: 'Sentences must be more than punctuation.',
         },
       ],
     },
@@ -1508,6 +1508,62 @@ export default {
       code: `
           /**
            * This is a complete sentence...
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * He wanted a few items: a jacket and shirt...
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * The code in question was...
+           * \`\`\`
+           * alert('hello');
+           * \`\`\`
+           */
+          function quux () {
+
+          }
+      `,
+    },
+    {
+      code: `
+      /**
+       * @param {number|string|Date|Object|OverType|WhateverElse} multiType -
+       * Nice long explanation...
+       */
+      function test (multiType) {
+      }
+      `,
+    },
+    {
+      code: `
+      /**
+       * Any kind of fowl (e.g., a duck).
+       */
+      function quux () {}
+      `,
+    },
+    {
+      code: `
+          /**
+           * The code in question was...
+           * \`\`\`
+           * do something
+           *
+           * interesting
+           * \`\`\`
            */
           function quux () {
 


### PR DESCRIPTION
fixes #66