### PR TITLE
fix(`check-line-alignment`): avoid adding whitespace if hyphen at end of line

### DIFF
--- a/README.md
+++ b/README.md
@@ -2864,6 +2864,12 @@ const fn = ( lorem, sit ) => {};
  */
 const fn = ( a, b ) => {};
 // "jsdoc/check-line-alignment": ["error"|"warn", "always"]
+
+/**
+ * @param {string|string[]|TemplateResult|TemplateResult[]} event.detail.description -
+ *    Notification description
+ */
+function quux () {}
 ````
 
 

--- a/src/rules/checkLineAlignment.js
+++ b/src/rules/checkLineAlignment.js
@@ -66,7 +66,7 @@ const checkNotAlignedPerTag = (utils, tag, customSpacings) => {
 
   const postHyphenSpacing = customSpacings?.postHyphen ?? 1;
   const exactHyphenSpacing = new RegExp(`^\\s*-\\s{${postHyphenSpacing},${postHyphenSpacing}}(?!\\s)`, 'u');
-  const hasNoHyphen = !(/^\s*-/u).test(tokens.description);
+  const hasNoHyphen = !(/^\s*-(?!$)/u).test(tokens.description);
   const hasExactHyphenSpacing = exactHyphenSpacing.test(
     tokens.description,
   );

--- a/test/rules/assertions/checkLineAlignment.js
+++ b/test/rules/assertions/checkLineAlignment.js
@@ -1909,5 +1909,14 @@ export default {
         'always',
       ],
     },
+    {
+      code: `
+      /**
+       * @param {string|string[]|TemplateResult|TemplateResult[]} event.detail.description -
+       *    Notification description
+       */
+      function quux () {}
+      `,
+    },
   ],
 };


### PR DESCRIPTION
fixes #983