### PR TITLE
fix(`tag-lines`): `startLines` is intended to apply after tags only

### DIFF
--- a/.README/rules/tag-lines.md
+++ b/.README/rules/tag-lines.md
@@ -34,7 +34,8 @@ added after tags should not be added after the final tag.
 ##### `startLines` (defaults to `0`)
 
 If not set to `null`, will enforce end lines to the given count before the
-first tag only.
+first tag only, unless there is only whitespace content, in which case,
+a line count will not be enforced.
 
 ##### `endLines` (defaults to `0`)
 

--- a/README.md
+++ b/README.md
@@ -23026,7 +23026,8 @@ added after tags should not be added after the final tag.
 ##### <code>startLines</code> (defaults to <code>0</code>)
 
 If not set to `null`, will enforce end lines to the given count before the
-first tag only.
+first tag only, unless there is only whitespace content, in which case,
+a line count will not be enforced.
 
 <a name="user-content-eslint-plugin-jsdoc-rules-tag-lines-options-41-endlines-defaults-to-0"></a>
 <a name="eslint-plugin-jsdoc-rules-tag-lines-options-41-endlines-defaults-to-0"></a>
@@ -23465,6 +23466,21 @@ The following patterns are not considered problems:
  * @param {string} a
  */
 // "jsdoc/tag-lines": ["error"|"warn", "never",{"startLines":null}]
+
+/**
+ * @param {string} input
+ */
+function processSass (input) {
+}
+// "jsdoc/tag-lines": ["error"|"warn", "never",{"startLines":1}]
+
+/**
+ *
+ * @param {string} input
+ */
+function processSass (input) {
+}
+// "jsdoc/tag-lines": ["error"|"warn", "never",{"startLines":1}]
 ````
 
 

--- a/src/rules/tagLines.js
+++ b/src/rules/tagLines.js
@@ -203,6 +203,10 @@ export default iterateJsdoc(({
       description,
       lastDescriptionLine,
     } = utils.getDescription();
+    if (!(/\S/u).test(description)) {
+      return;
+    }
+
     const trailingLines = description.match(/\n+$/u)?.[0]?.length;
     const trailingDiff = (trailingLines ?? 0) - startLines;
     if (trailingDiff > 0) {

--- a/test/rules/assertions/tagLines.js
+++ b/test/rules/assertions/tagLines.js
@@ -1093,5 +1093,36 @@ export default {
         },
       ],
     },
+    {
+      code: `
+      /**
+       * @param {string} input
+       */
+      function processSass (input) {
+      }
+      `,
+      options: [
+        'never',
+        {
+          startLines: 1,
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       *
+       * @param {string} input
+       */
+      function processSass (input) {
+      }
+      `,
+      options: [
+        'never',
+        {
+          startLines: 1,
+        },
+      ],
+    },
   ],
 };


### PR DESCRIPTION
Fixes #1022