### PR TITLE
fix(`tag-lines`): avoid new `startLines` option expecting whitespace when no tags are present

### DIFF
--- a/README.md
+++ b/README.md
@@ -23481,6 +23481,13 @@ function processSass (input) {
 function processSass (input) {
 }
 // "jsdoc/tag-lines": ["error"|"warn", "never",{"startLines":1}]
+
+/**
+ * Toggles the deselect all icon button action
+ */
+function updateIconButton () {
+}
+// "jsdoc/tag-lines": ["error"|"warn", "never",{"startLines":1}]
 ````
 
 

--- a/src/rules/tagLines.js
+++ b/src/rules/tagLines.js
@@ -199,6 +199,10 @@ export default iterateJsdoc(({
   });
 
   if (typeof startLines === 'number') {
+    if (!jsdoc.tags.length) {
+      return;
+    }
+
     const {
       description,
       lastDescriptionLine,

--- a/test/rules/assertions/tagLines.js
+++ b/test/rules/assertions/tagLines.js
@@ -1124,5 +1124,20 @@ export default {
         },
       ],
     },
+    {
+      code: `
+      /**
+       * Toggles the deselect all icon button action
+       */
+      function updateIconButton () {
+      }
+      `,
+      options: [
+        'never',
+        {
+          startLines: 1,
+        },
+      ],
+    },
   ],
 };


### PR DESCRIPTION
Fixes #1024