### PR TITLE
fix(informative-docs): trim description text

### DIFF
--- a/README.md
+++ b/README.md
@@ -7649,6 +7649,13 @@ function takesOne(param) {}
  * takes abc param
  */
 function takesOne(param) {}
+
+/**
+ * @class 
+ *
+ * @param {number} value - Some useful text
+ */      
+function MyAmazingThing(value) {}
 ````
 
 

--- a/src/rules/informativeDocs.js
+++ b/src/rules/informativeDocs.js
@@ -70,7 +70,8 @@ export default iterateJsdoc(({
   const nodeNames = getNamesFromNode(node);
 
   const descriptionIsRedundant = (text, extraName = '') => {
-    return Boolean(text) && !areDocsInformative(text, [
+    const textTrimmed = text.trim();
+    return Boolean(textTrimmed) && !areDocsInformative(textTrimmed, [
       extraName, nodeNames,
     ].filter(Boolean).join(' '), {
       aliases,

--- a/test/rules/assertions/informativeDocs.js
+++ b/test/rules/assertions/informativeDocs.js
@@ -749,5 +749,15 @@ export default {
         function takesOne(param) {}
       `,
     },
+    {
+      code: `
+        /**
+         * @class 
+         *
+         * @param {number} value - Some useful text
+         */      
+        function MyAmazingThing(value) {}
+      `,
+    },
   ],
 };


### PR DESCRIPTION
Right now, `informative-docs` isn't trimming the text it passes to `are-docs-informative`. The `Boolean(text)` check that's supposed to filter out blank text isn't accounting for whitespace. That means when there's a tag like `@class`, it calls the equivalent of:

```js
areDocsInformative('\n', 'MyAmazingThing')
```

...which is false.

This `.trim()`s the text so that whitespace is ignored.

Fixes #1039.