### PR TITLE
feat(`no-undefined-types`): checking inline tags

### DIFF
--- a/docs/rules/no-undefined-types.md
+++ b/docs/rules/no-undefined-types.md
@@ -247,20 +247,12 @@ function quux () {}
 // Message: The type 'SomeType' is undefined.
 
 /**
- * @namepathDefiner SomeType
+ * @namepathReferencing SomeType
  */
 /**
  * @type {SomeType}
  */
-// Settings: {"jsdoc":{"structuredTags":{"namepathDefiner":{"name":"namepath-referencing"}}}}
-// Message: The type 'SomeType' is undefined.
-
-/**
- * @namepathDefiner SomeType
- */
-/**
- * @type {SomeType}
- */
+// Settings: {"jsdoc":{"structuredTags":{"namepathReferencing":{"name":"namepath-referencing"}}}}
 // Message: The type 'SomeType' is undefined.
 
 /**

--- a/docs/rules/no-undefined-types.md
+++ b/docs/rules/no-undefined-types.md
@@ -745,5 +745,29 @@ function quux(foo, bar) {
 
 }
 // "jsdoc/no-undefined-types": ["error"|"warn", {"disableReporting":true}]
+
+class MyClass {}
+class AnotherClass {}
+
+/**
+ * A description mentioning {@link MyClass} and {@link AnotherClass | another class} and a URL via [this link]{@link https://www.example.com}.
+ */
+function quux(foo) {
+  console.log(foo);
+}
+
+quux(0);
+
+class MyClass {}
+class AnotherClass {}
+
+/**
+ * @see A tag mentioning {@link MyClass} and {@link AnotherClass | another class} and a URL via [this link]{@link https://www.example.com}.
+ */
+function quux(foo) {
+  console.log(foo);
+}
+
+quux(0);
 ````
 

--- a/src/getDefaultTagStructureForMode.js
+++ b/src/getDefaultTagStructureForMode.js
@@ -470,11 +470,6 @@ const getDefaultTagStructureForMode = (mode) => {
         [
           'typeOrNameRequired', true,
         ],
-
-        // "type"
-        [
-          'typeAllowed', true,
-        ],
       ]),
     ],
 
@@ -490,11 +485,6 @@ const getDefaultTagStructureForMode = (mode) => {
         [
           'typeOrNameRequired', true,
         ],
-
-        // "type"
-        [
-          'typeAllowed', true,
-        ],
       ]),
     ],
 
@@ -509,11 +499,6 @@ const getDefaultTagStructureForMode = (mode) => {
         // "namepath"
         [
           'typeOrNameRequired', true,
-        ],
-
-        // "type"
-        [
-          'typeAllowed', true,
         ],
       ]),
     ],

--- a/src/getDefaultTagStructureForMode.js
+++ b/src/getDefaultTagStructureForMode.js
@@ -11,7 +11,7 @@ const getDefaultTagStructureForMode = (mode) => {
   const isJsdocTypescriptOrPermissive = isJsdocOrTypescript || isPermissive;
 
   // Properties:
-  // `nameContents` - 'namepath-referencing'|'namepath-defining'|'namepath-or-url-referencing'|'text'|false
+  // `namepathRole` - 'namepath-referencing'|'namepath-defining'|'namepath-or-url-referencing'|'text'|false
   // `typeAllowed` - boolean
   // `nameRequired` - boolean
   // `typeRequired` - boolean
@@ -23,7 +23,7 @@ const getDefaultTagStructureForMode = (mode) => {
   //  `property`/`prop` (no signature)
   //  `modifies` (undocumented)
 
-  // None of the `nameContents: 'namepath-defining'` show as having curly
+  // None of the `namepathRole: 'namepath-defining'` show as having curly
   //  brackets for their name/namepath
 
   // Among `namepath-defining` and `namepath-referencing`, these do not seem
@@ -43,7 +43,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'alias', new Map([
         // Signature seems to require a "namepath" (and no counter-examples)
         [
-          'nameContents', 'namepath-referencing',
+          'namepathRole', 'namepath-referencing',
         ],
 
         // "namepath"
@@ -56,7 +56,7 @@ const getDefaultTagStructureForMode = (mode) => {
     [
       'arg', new Map([
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         // See `param`
@@ -75,7 +75,7 @@ const getDefaultTagStructureForMode = (mode) => {
     [
       'argument', new Map([
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         // See `param`
@@ -95,7 +95,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'augments', new Map([
         // Signature seems to require a "namepath" (and no counter-examples)
         [
-          'nameContents', 'namepath-referencing',
+          'namepathRole', 'namepath-referencing',
         ],
 
         // Does not show curly brackets in either the signature or examples
@@ -115,7 +115,7 @@ const getDefaultTagStructureForMode = (mode) => {
         // `borrows` has a different format, however, so needs special parsing;
         //   seems to require both, and as "namepath"'s
         [
-          'nameContents', 'namepath-referencing',
+          'namepathRole', 'namepath-referencing',
         ],
 
         // "namepath"
@@ -131,7 +131,7 @@ const getDefaultTagStructureForMode = (mode) => {
         //   counter-examples); TypeScript does not enforce but seems
         //   problematic as not attached so presumably not useable without it
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         // "namepath"
@@ -145,7 +145,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'class', new Map([
         // Allows for "name"'s in signature, but indicated as optional
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         // Not in use, but should be this value if using to power `empty-tags`
@@ -163,7 +163,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'const', new Map([
         // Allows for "name"'s in signature, but indicated as optional
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         [
@@ -175,7 +175,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'constant', new Map([
         // Allows for "name"'s in signature, but indicated as optional
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         [
@@ -187,7 +187,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'constructor', new Map([
         // Allows for "name"'s in signature, but indicated as optional
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         [
@@ -200,7 +200,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'constructs', new Map([
         // Allows for "name"'s in signature, but indicated as optional
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         [
@@ -225,7 +225,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'emits', new Map([
         // Signature seems to require a "name" (of an event) and no counter-examples
         [
-          'nameContents', 'namepath-referencing',
+          'namepathRole', 'namepath-referencing',
         ],
 
         [
@@ -258,7 +258,7 @@ const getDefaultTagStructureForMode = (mode) => {
         //  different from other "name"'s (including as described
         //  at https://jsdoc.app/about-namepaths.html )
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
       ]),
     ],
@@ -284,7 +284,7 @@ const getDefaultTagStructureForMode = (mode) => {
     [
       'exports', new Map([
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         [
@@ -301,7 +301,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'extends', new Map([
         // Signature seems to require a "namepath" (and no counter-examples)
         [
-          'nameContents', 'namepath-referencing',
+          'namepathRole', 'namepath-referencing',
         ],
 
         // Does not show curly brackets in either the signature or examples
@@ -326,7 +326,7 @@ const getDefaultTagStructureForMode = (mode) => {
         //  different from other "name"'s (including as described
         //  at https://jsdoc.app/about-namepaths.html )
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         // "name" (and a special syntax for the `external` name)
@@ -345,7 +345,7 @@ const getDefaultTagStructureForMode = (mode) => {
         // Signature seems to require a "name" (of an event) and no
         //  counter-examples
         [
-          'nameContents', 'namepath-referencing',
+          'namepathRole', 'namepath-referencing',
         ],
 
         [
@@ -362,7 +362,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'function', new Map([
         // Allows for "name"'s in signature, but indicated as optional
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         [
@@ -378,7 +378,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'func', new Map([
         // Allows for "name"'s in signature, but indicated as optional
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
       ]),
     ],
@@ -389,7 +389,7 @@ const getDefaultTagStructureForMode = (mode) => {
         //  different from other "name"'s (including as described
         //  at https://jsdoc.app/about-namepaths.html )
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         // See `external`
@@ -407,7 +407,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'interface', new Map([
         // Allows for "name" in signature, but indicates as optional
         [
-          'nameContents',
+          'namepathRole',
           isJsdocTypescriptOrPermissive ? 'namepath-defining' : false,
         ],
 
@@ -426,7 +426,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'internal', new Map([
         // https://www.typescriptlang.org/tsconfig/#stripInternal
         [
-          'nameContents', false,
+          'namepathRole', false,
         ],
         // Not in use, but should be this value if using to power `empty-tags`
         [
@@ -449,7 +449,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'lends', new Map([
         // Signature seems to require a "namepath" (and no counter-examples)
         [
-          'nameContents', 'namepath-referencing',
+          'namepathRole', 'namepath-referencing',
         ],
 
         // "namepath"
@@ -463,7 +463,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'link', new Map([
         // Signature seems to require a namepath OR URL and might be checked as such.
         [
-          'nameContents', 'namepath-or-url-referencing',
+          'namepathRole', 'namepath-or-url-referencing',
         ],
 
       ]),
@@ -474,7 +474,7 @@ const getDefaultTagStructureForMode = (mode) => {
         // Synonym for "link"
         // Signature seems to require a namepath OR URL and might be checked as such.
         [
-          'nameContents', 'namepath-or-url-referencing',
+          'namepathRole', 'namepath-or-url-referencing',
         ],
       ]),
     ],
@@ -484,7 +484,7 @@ const getDefaultTagStructureForMode = (mode) => {
         // Synonym for "link"
         // Signature seems to require a namepath OR URL and might be checked as such.
         [
-          'nameContents', 'namepath-or-url-referencing',
+          'namepathRole', 'namepath-or-url-referencing',
         ],
       ]),
     ],
@@ -494,7 +494,7 @@ const getDefaultTagStructureForMode = (mode) => {
         // Signature seems to require a "name" (of an event) and no
         //  counter-examples
         [
-          'nameContents', 'namepath-referencing',
+          'namepathRole', 'namepath-referencing',
         ],
 
         [
@@ -511,7 +511,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'member', new Map([
         // Allows for "name"'s in signature, but indicated as optional
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         // Has example showing curly brackets but not in doc signature
@@ -526,7 +526,7 @@ const getDefaultTagStructureForMode = (mode) => {
         // Signature seems to require a "namepath" (and no counter-examples),
         //  though it allows an incomplete namepath ending with connecting symbol
         [
-          'nameContents', 'namepath-referencing',
+          'namepathRole', 'namepath-referencing',
         ],
 
         // "namepath"
@@ -540,7 +540,7 @@ const getDefaultTagStructureForMode = (mode) => {
         // Signature seems to require a "namepath" (and no counter-examples),
         //  though it allows an incomplete namepath ending with connecting symbol
         [
-          'nameContents', 'namepath-referencing',
+          'namepathRole', 'namepath-referencing',
         ],
 
         // "namepath"
@@ -554,7 +554,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'method', new Map([
         // Allows for "name"'s in signature, but indicated as optional
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
       ]),
     ],
@@ -563,7 +563,7 @@ const getDefaultTagStructureForMode = (mode) => {
         // Signature seems to require a "OtherObjectPath" with no
         //   counter-examples
         [
-          'nameContents', 'namepath-referencing',
+          'namepathRole', 'namepath-referencing',
         ],
 
         // "OtherObjectPath"
@@ -577,7 +577,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'mixin', new Map([
         // Allows for "name"'s in signature, but indicated as optional
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         [
@@ -607,7 +607,7 @@ const getDefaultTagStructureForMode = (mode) => {
         //  this block impacts `no-undefined-types` and `valid-types` (search for
         //  "isNamepathDefiningTag|tagMightHaveNamepath|tagMightHaveEitherTypeOrNamePosition")
         [
-          'nameContents', isJsdoc ? 'namepath-defining' : 'text',
+          'namepathRole', isJsdoc ? 'namepath-defining' : 'text',
         ],
 
         // Shows the signature with curly brackets but not in the example
@@ -622,7 +622,7 @@ const getDefaultTagStructureForMode = (mode) => {
         // Seems to require a "namepath" in the signature (with no
         //   counter-examples)
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         // "namepath"
@@ -641,7 +641,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'namespace', new Map([
         // Allows for "name"'s in signature, but indicated as optional
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         // Shows the signature with curly brackets but not in the example
@@ -663,7 +663,7 @@ const getDefaultTagStructureForMode = (mode) => {
     [
       'param', new Map([
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         // Though no signature provided requiring, per
@@ -695,7 +695,7 @@ const getDefaultTagStructureForMode = (mode) => {
     [
       'prop', new Map([
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         // See `property`
@@ -714,7 +714,7 @@ const getDefaultTagStructureForMode = (mode) => {
     [
       'property', new Map([
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         // No docs indicate required, but since parallel to `param`, we treat as
@@ -754,7 +754,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'requires', new Map([
         // <someModuleName>
         [
-          'nameContents', 'namepath-referencing',
+          'namepathRole', 'namepath-referencing',
         ],
 
         [
@@ -798,7 +798,7 @@ const getDefaultTagStructureForMode = (mode) => {
         // Signature allows for "namepath" or text, so user must configure to
         //  'namepath-referencing' to enforce checks
         [
-          'nameContents', 'text',
+          'namepathRole', 'text',
         ],
       ]),
     ],
@@ -815,7 +815,7 @@ const getDefaultTagStructureForMode = (mode) => {
     [
       'suppress', new Map([
         [
-          'nameContents', !isClosure,
+          'namepathRole', !isClosure,
         ],
         [
           'typeRequired', isClosure,
@@ -826,10 +826,10 @@ const getDefaultTagStructureForMode = (mode) => {
     [
       'template', new Map([
         [
-          'nameContents', isJsdoc ? 'text' : 'namepath-referencing',
+          'namepathRole', isJsdoc ? 'text' : 'namepath-referencing',
         ],
 
-        // Though defines `nameContents: 'namepath-defining'` in a sense, it is
+        // Though defines `namepathRole: 'namepath-defining'` in a sense, it is
         //   not parseable in the same way for template (e.g., allowing commas),
         //   so not adding
         [
@@ -843,7 +843,7 @@ const getDefaultTagStructureForMode = (mode) => {
         // Signature seems to require a "namepath" (and no counter-examples)
         // Not used with namepath in Closure/TypeScript, however
         [
-          'nameContents', isJsdoc ? 'namepath-referencing' : false,
+          'namepathRole', isJsdoc ? 'namepath-referencing' : false,
         ],
 
         [
@@ -894,7 +894,7 @@ const getDefaultTagStructureForMode = (mode) => {
         // Seems to require a "namepath" in the signature (with no
         //  counter-examples)
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         // TypeScript may allow it to be dropped if followed by @property or @member;
@@ -924,7 +924,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'var', new Map([
         // Allows for "name"'s in signature, but indicated as optional
         [
-          'nameContents', 'namepath-defining',
+          'namepathRole', 'namepath-defining',
         ],
 
         // Has example showing curly brackets but not in doc signature

--- a/src/getDefaultTagStructureForMode.js
+++ b/src/getDefaultTagStructureForMode.js
@@ -11,7 +11,7 @@ const getDefaultTagStructureForMode = (mode) => {
   const isJsdocTypescriptOrPermissive = isJsdocOrTypescript || isPermissive;
 
   // Properties:
-  // `nameContents` - 'namepath-referencing'|'namepath-defining'|'text'|false
+  // `nameContents` - 'namepath-referencing'|'namepath-defining'|'namepath-or-url-referencing'|'text'|false
   // `typeAllowed` - boolean
   // `nameRequired` - boolean
   // `typeRequired` - boolean
@@ -463,13 +463,9 @@ const getDefaultTagStructureForMode = (mode) => {
       'link', new Map([
         // Signature seems to require a namepath OR URL and might be checked as such.
         [
-          'nameContents', 'namepath-referencing',
+          'nameContents', 'namepath-or-url-referencing',
         ],
 
-        // "namepath"
-        [
-          'typeOrNameRequired', true,
-        ],
       ]),
     ],
 
@@ -478,12 +474,7 @@ const getDefaultTagStructureForMode = (mode) => {
         // Synonym for "link"
         // Signature seems to require a namepath OR URL and might be checked as such.
         [
-          'nameContents', 'namepath-referencing',
-        ],
-
-        // "namepath"
-        [
-          'typeOrNameRequired', true,
+          'nameContents', 'namepath-or-url-referencing',
         ],
       ]),
     ],
@@ -493,12 +484,7 @@ const getDefaultTagStructureForMode = (mode) => {
         // Synonym for "link"
         // Signature seems to require a namepath OR URL and might be checked as such.
         [
-          'nameContents', 'namepath-referencing',
-        ],
-
-        // "namepath"
-        [
-          'typeOrNameRequired', true,
+          'nameContents', 'namepath-or-url-referencing',
         ],
       ]),
     ],

--- a/src/getDefaultTagStructureForMode.js
+++ b/src/getDefaultTagStructureForMode.js
@@ -35,8 +35,6 @@ const getDefaultTagStructureForMode = (mode) => {
   //   "namepath" (e.g., param can't define a namepath)
 
   // Once checking inline tags:
-  // Todo: Re: `typeOrNameRequired`, `@link` (or @linkcode/@linkplain) seems
-  //  to require a namepath OR URL and might be checked as such.
   // Todo: Should support a `tutorialID` type (for `@tutorial` block and
   //  inline)
 
@@ -457,6 +455,65 @@ const getDefaultTagStructureForMode = (mode) => {
         // "namepath"
         [
           'typeOrNameRequired', true,
+        ],
+      ]),
+    ],
+
+    [
+      'link', new Map([
+        // Signature seems to require a namepath OR URL and might be checked as such.
+        [
+          'nameContents', 'namepath-referencing',
+        ],
+
+        // "namepath"
+        [
+          'typeOrNameRequired', true,
+        ],
+
+        // "type"
+        [
+          'typeAllowed', true,
+        ],
+      ]),
+    ],
+
+    [
+      'linkcode', new Map([
+        // Synonym for "link"
+        // Signature seems to require a namepath OR URL and might be checked as such.
+        [
+          'nameContents', 'namepath-referencing',
+        ],
+
+        // "namepath"
+        [
+          'typeOrNameRequired', true,
+        ],
+
+        // "type"
+        [
+          'typeAllowed', true,
+        ],
+      ]),
+    ],
+
+    [
+      'linkplain', new Map([
+        // Synonym for "link"
+        // Signature seems to require a namepath OR URL and might be checked as such.
+        [
+          'nameContents', 'namepath-referencing',
+        ],
+
+        // "namepath"
+        [
+          'typeOrNameRequired', true,
+        ],
+
+        // "type"
+        [
+          'typeAllowed', true,
         ],
       ]),
     ],

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -769,7 +769,6 @@ const getUtils = (
   for (const method of [
     'tagMightHaveNamePosition',
     'tagMightHaveTypePosition',
-    'tagMightHaveEitherTypeOrNamePosition',
   ]) {
     utils[method] = (tagName, otherModeMaps) => {
       const result = jsdocUtils[method](tagName);
@@ -816,6 +815,8 @@ const getUtils = (
 
   for (const method of [
     'isNamepathDefiningTag',
+    'isNamepathReferencingTag',
+    'isNamepathOrUrlReferencingTag',
     'tagMightHaveNamepath',
   ]) {
     utils[method] = (tagName) => {
@@ -869,8 +870,9 @@ const getUtils = (
     });
   };
 
-  utils.filterTags = (filter) => {
-    return jsdocUtils.filterTags(jsdocUtils.getAllTags(jsdoc), filter);
+  utils.filterTags = (filter, includeInlineTags = false) => {
+    const tags = jsdocUtils.getAllTags(jsdoc, includeInlineTags);
+    return jsdocUtils.filterTags(tags, filter);
   };
 
   utils.getTagsByType = (tags) => {

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -869,7 +869,7 @@ const getUtils = (
   };
 
   utils.filterTags = (filter) => {
-    return jsdocUtils.filterTags(jsdoc.tags, filter);
+    return jsdocUtils.filterTags(jsdocUtils.getAllTags(jsdoc), filter);
   };
 
   utils.getTagsByType = (tags) => {

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -769,6 +769,7 @@ const getUtils = (
   for (const method of [
     'tagMightHaveNamePosition',
     'tagMightHaveTypePosition',
+    'tagMightHaveEitherTypeOrNamePosition',
   ]) {
     utils[method] = (tagName, otherModeMaps) => {
       const result = jsdocUtils[method](tagName);

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -560,7 +560,7 @@ const overrideTagStructure = (structuredTags, tagMap = tagStructure) => {
   ] of Object.entries(structuredTags)) {
     const tagStruct = ensureMap(tagMap, tag);
 
-    tagStruct.set('nameContents', name);
+    tagStruct.set('namepathRole', name);
     tagStruct.set('typeAllowed', type);
 
     const requiredName = required.includes('name');
@@ -615,7 +615,7 @@ const getTagStructureForMode = (mode, structuredTags) => {
 const isNamepathDefiningTag = (tag, tagMap = tagStructure) => {
   const tagStruct = ensureMap(tagMap, tag);
 
-  return tagStruct.get('nameContents') === 'namepath-defining';
+  return tagStruct.get('namepathRole') === 'namepath-defining';
 };
 
 /**
@@ -625,7 +625,7 @@ const isNamepathDefiningTag = (tag, tagMap = tagStructure) => {
  */
 const isNamepathReferencingTag = (tag, tagMap = tagStructure) => {
   const tagStruct = ensureMap(tagMap, tag);
-  return tagStruct.get('nameContents') === 'namepath-referencing';
+  return tagStruct.get('namepathRole') === 'namepath-referencing';
 };
 
 /**
@@ -635,7 +635,7 @@ const isNamepathReferencingTag = (tag, tagMap = tagStructure) => {
  */
 const isNamepathOrUrlReferencingTag = (tag, tagMap = tagStructure) => {
   const tagStruct = ensureMap(tagMap, tag);
-  return tagStruct.get('nameContents') === 'namepath-or-url-referencing';
+  return tagStruct.get('namepathRole') === 'namepath-or-url-referencing';
 };
 
 /**
@@ -678,7 +678,7 @@ const namepathTypes = new Set([
 const tagMightHaveNamePosition = (tag, tagMap = tagStructure) => {
   const tagStruct = ensureMap(tagMap, tag);
 
-  const ret = tagStruct.get('nameContents');
+  const ret = tagStruct.get('namepathRole');
 
   return ret === undefined ? true : Boolean(ret);
 };
@@ -691,7 +691,7 @@ const tagMightHaveNamePosition = (tag, tagMap = tagStructure) => {
 const tagMightHaveNamepath = (tag, tagMap = tagStructure) => {
   const tagStruct = ensureMap(tagMap, tag);
 
-  return namepathTypes.has(tagStruct.get('nameContents'));
+  return namepathTypes.has(tagStruct.get('namepathRole'));
 };
 
 /**

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -453,6 +453,22 @@ const hasTag = (jsdoc, targetTagName) => {
 };
 
 /**
+ * Get all tags, inline tags and inline tags in tags
+ *
+ * @param {object} jsdoc
+ * @returns {Array}
+ */
+const getAllTags = (jsdoc) => {
+  return [
+    ...jsdoc.tags,
+    ...jsdoc.inlineTags,
+    ...jsdoc.tags.flatMap((tag) => {
+      return tag.inlineTags;
+    }),
+  ];
+};
+
+/**
  * @param {object} jsdoc
  * @param {Array} targetTagNames
  * @returns {boolean}
@@ -1232,6 +1248,7 @@ export default {
   exemptSpeciaMethods,
   filterTags,
   flattenRoots,
+  getAllTags,
   getContextObject,
   getFunctionParameterNames,
   getIndent,

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -1274,6 +1274,7 @@ export default {
   parseClosureTemplateTag,
   pathDoesNotBeginWith,
   setTagStructure,
+  tagMightHaveEitherTypeOrNamePosition,
   tagMightHaveNamepath,
   tagMightHaveNamePosition,
   tagMightHaveTypePosition,

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -458,7 +458,7 @@ const hasTag = (jsdoc, targetTagName) => {
  * @param {object} jsdoc
  * @returns {Array}
  */
-const getAllTags = (jsdoc, includeInlineTags = false) => {
+const getAllTags = (jsdoc, includeInlineTags) => {
   return includeInlineTags ? [
     ...jsdoc.tags,
     ...jsdoc.inlineTags,

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -458,14 +458,14 @@ const hasTag = (jsdoc, targetTagName) => {
  * @param {object} jsdoc
  * @returns {Array}
  */
-const getAllTags = (jsdoc) => {
-  return [
+const getAllTags = (jsdoc, includeInlineTags = false) => {
+  return includeInlineTags ? [
     ...jsdoc.tags,
     ...jsdoc.inlineTags,
     ...jsdoc.tags.flatMap((tag) => {
       return tag.inlineTags;
     }),
-  ];
+  ] : jsdoc.tags;
 };
 
 /**
@@ -616,6 +616,26 @@ const isNamepathDefiningTag = (tag, tagMap = tagStructure) => {
   const tagStruct = ensureMap(tagMap, tag);
 
   return tagStruct.get('nameContents') === 'namepath-defining';
+};
+
+/**
+ * @param tag
+ * @param {Map} tagMap
+ * @returns {boolean}
+ */
+const isNamepathReferencingTag = (tag, tagMap = tagStructure) => {
+  const tagStruct = ensureMap(tagMap, tag);
+  return tagStruct.get('nameContents') === 'namepath-referencing';
+};
+
+/**
+ * @param tag
+ * @param {Map} tagMap
+ * @returns {boolean}
+ */
+const isNamepathOrUrlReferencingTag = (tag, tagMap = tagStructure) => {
+  const tagStruct = ensureMap(tagMap, tag);
+  return tagStruct.get('nameContents') === 'namepath-or-url-referencing';
 };
 
 /**
@@ -1267,6 +1287,8 @@ export default {
   isConstructor,
   isGetter,
   isNamepathDefiningTag,
+  isNamepathOrUrlReferencingTag,
+  isNamepathReferencingTag,
   isSetter,
   isValidTag,
   mayBeUndefinedTypeTag,

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -189,11 +189,11 @@ export default iterateJsdoc(({
   const jsdocTagsWithPossibleType = utils.filterTags(({
     tag,
   }) => {
-    return utils.tagMightHaveTypePosition(tag) && (tag !== 'suppress' || settings.mode !== 'closure');
+    return utils.tagMightHaveEitherTypeOrNamePosition(tag) && (tag !== 'suppress' || settings.mode !== 'closure');
   });
 
   for (const tag of jsdocTagsWithPossibleType) {
-    const possibleType = tag.type || tag.namepathOrURL;
+    const possibleType = tag.type || tag.name || tag.namepathOrURL;
 
     let parsedType;
 

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -193,10 +193,12 @@ export default iterateJsdoc(({
   });
 
   for (const tag of jsdocTagsWithPossibleType) {
+    const possibleType = tag.type || tag.namepathOrURL;
+
     let parsedType;
 
     try {
-      parsedType = mode === 'permissive' ? tryParseType(tag.type) : parseType(tag.type, mode);
+      parsedType = mode === 'permissive' ? tryParseType(possibleType) : parseType(possibleType, mode);
     } catch {
       // On syntax error, will be handled by valid-types.
       continue;

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -200,25 +200,28 @@ export default iterateJsdoc(({
     };
   };
 
+  const typeTags = utils.filterTags(({
+    tag,
+  }) => {
+    return utils.tagMightHaveTypePosition(tag) && (tag !== 'suppress' || settings.mode !== 'closure');
+  }).map(tagToParsedType('type'));
+
+  const namepathReferencingTags = utils.filterTags(({
+    tag,
+  }) => {
+    return utils.isNamepathReferencingTag(tag);
+  }).map(tagToParsedType('name'));
+
+  const namepathOrUrlReferencingTags = utils.filterTags(({
+    tag,
+  }) => {
+    return utils.isNamepathOrUrlReferencingTag(tag);
+  }, true).map(tagToParsedType('namepathOrURL'));
+
   const tagsWithTypes = [
-    // Tags with type
-    ...utils.filterTags(({
-      tag,
-    }) => {
-      return utils.tagMightHaveTypePosition(tag) && (tag !== 'suppress' || settings.mode !== 'closure');
-    }).map(tagToParsedType('type')),
-    // Tags with namepaths
-    ...utils.filterTags(({
-      tag,
-    }) => {
-      return utils.isNamepathReferencingTag(tag) && (tag !== 'suppress' || settings.mode !== 'closure');
-    }).map(tagToParsedType('name')),
-    // Inline tags
-    ...utils.filterTags(({
-      tag,
-    }) => {
-      return utils.isNamepathOrUrlReferencingTag(tag) && (tag !== 'suppress' || settings.mode !== 'closure');
-    }, true).map(tagToParsedType('namepathOrURL')),
+    ...typeTags,
+    ...namepathReferencingTags,
+    ...namepathOrUrlReferencingTags,
   ].filter((result) => {
     // Remove types which failed to parse
     return result;

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -380,7 +380,7 @@ export default {
     {
       code: `
       /**
-       * @namepathDefiner SomeType
+       * @namepathReferencing SomeType
        */
       /**
        * @type {SomeType}
@@ -399,7 +399,7 @@ export default {
       settings: {
         jsdoc: {
           structuredTags: {
-            namepathDefiner: {
+            namepathReferencing: {
               name: 'namepath-referencing',
             },
           },
@@ -407,9 +407,11 @@ export default {
       },
     },
     {
+      // An unknown tag without an namepath contents declared via settings,
+      // defaults to not having an impact on the type.
       code: `
       /**
-       * @namepathDefiner SomeType
+       * @namepathMentioning SomeType
        */
       /**
        * @type {SomeType}
@@ -417,14 +419,11 @@ export default {
       `,
       errors: [
         {
-          line: 3,
-          message: 'The type \'SomeType\' is undefined.',
-        },
-        {
           line: 6,
           message: 'The type \'SomeType\' is undefined.',
         },
       ],
+      ignoreReadme: true,
     },
     {
       code: `

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -407,7 +407,7 @@ export default {
       },
     },
     {
-      // An unknown tag without an namepath contents declared via settings,
+      // An unknown tag without any namepath contents declared via settings,
       // defaults to not having an impact on the type.
       code: `
       /**

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -388,6 +388,10 @@ export default {
       `,
       errors: [
         {
+          line: 3,
+          message: 'The type \'SomeType\' is undefined.',
+        },
+        {
           line: 6,
           message: 'The type \'SomeType\' is undefined.',
         },
@@ -412,6 +416,10 @@ export default {
        */
       `,
       errors: [
+        {
+          line: 3,
+          message: 'The type \'SomeType\' is undefined.',
+        },
         {
           line: 6,
           message: 'The type \'SomeType\' is undefined.',

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -1324,5 +1324,41 @@ export default {
         sourceType: 'module',
       },
     },
+    {
+      code: `
+          class MyClass {}
+          class AnotherClass {}
+
+          /**
+           * A description mentioning {@link MyClass} and {@link AnotherClass | another class} and a URL via [this link]{@link https://www.example.com}.
+           */
+          function quux(foo) {
+            console.log(foo);
+          }
+
+          quux(0);
+      `,
+      rules: {
+        'no-unused-vars': 'error',
+      },
+    },
+    {
+      code: `
+          class MyClass {}
+          class AnotherClass {}
+
+          /**
+           * @see A tag mentioning {@link MyClass} and {@link AnotherClass | another class} and a URL via [this link]{@link https://www.example.com}.
+           */
+          function quux(foo) {
+            console.log(foo);
+          }
+
+          quux(0);
+      `,
+      rules: {
+        'no-unused-vars': 'error',
+      },
+    },
   ],
 };


### PR DESCRIPTION
While it doesn't add a new / separate rule like https://github.com/gajus/eslint-plugin-jsdoc/pull/1058 aims to, this does solve the underlying need communicated in https://github.com/gajus/eslint-plugin-jsdoc/issues/858 by updating the `no-undefined-types` rule to incorporate the [recently added feature from jsdoccomment](https://github.com/es-joy/jsdoccomment/pull/12) of parsing inline tags. Since it already marks types from other tags as used, this seem like a valuable addition until this is refactored into a separate rule or setting on `no-undefined-types`.