### PR TITLE
fix(`valid-types`): report postfix nullable in object or labeled tuple position

### DIFF
--- a/docs/rules/valid-types.md
+++ b/docs/rules/valid-types.md
@@ -471,6 +471,22 @@ function quux () {}
  */
 function quux () {}
 // Message: Invalid name: invalid default value syntax
+
+/**
+ * @type {{message: string?}}
+ */
+function quux (items) {
+}
+// Settings: {"jsdoc":{"mode":"closure"}}
+// Message: Syntax error in type: JsdocTypeNullable
+
+/**
+ * @type {[message: string?]}
+ */
+function quux (items) {
+}
+// Settings: {"jsdoc":{"mode":"typescript"}}
+// Message: Syntax error in type: JsdocTypeNullable
 ````
 
 

--- a/test/rules/assertions/validTypes.js
+++ b/test/rules/assertions/validTypes.js
@@ -1062,6 +1062,46 @@ export default {
         },
       ],
     },
+    {
+      code: `
+            /**
+             * @type {{message: string?}}
+             */
+            function quux (items) {
+            }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Syntax error in type: JsdocTypeNullable',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          mode: 'closure',
+        },
+      },
+    },
+    {
+      code: `
+            /**
+             * @type {[message: string?]}
+             */
+            function quux (items) {
+            }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Syntax error in type: JsdocTypeNullable',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          mode: 'typescript',
+        },
+      },
+    },
   ],
   valid: [
     {


### PR DESCRIPTION
fixes https://github.com/jsdoc-type-pratt-parser/jsdoc-type-pratt-parser/issues/62