### PR TITLE
fix(`no-undefined-types`): treat `@alias` as namepath-defining

### DIFF
--- a/src/getDefaultTagStructureForMode.js
+++ b/src/getDefaultTagStructureForMode.js
@@ -43,7 +43,7 @@ const getDefaultTagStructureForMode = (mode) => {
       'alias', new Map([
         // Signature seems to require a "namepath" (and no counter-examples)
         [
-          'namepathRole', 'namepath-referencing',
+          'namepathRole', 'namepath-defining',
         ],
 
         // "namepath"


### PR DESCRIPTION
fixes #1070