### PR TITLE
fix: check-tag-names crash on module comment

### DIFF
--- a/docs/rules/check-tag-names.md
+++ b/docs/rules/check-tag-names.md
@@ -1122,5 +1122,11 @@ interface WebTwain {
  * @satisfies
  */
 // Settings: {"jsdoc":{"mode":"typescript"}}
+
+/**
+ * @module
+ * A comment related to the module
+ */
+// "jsdoc/check-tag-names": ["error"|"warn", {"typed":true}]
 ````
 

--- a/src/rules/checkTagNames.js
+++ b/src/rules/checkTagNames.js
@@ -143,6 +143,10 @@ export default iterateJsdoc(({
       return false;
     }
 
+    if (node === null) {
+      return false;
+    }
+
     if (context.getFilename().endsWith('.d.ts') && [
       'Program', null, undefined,
     ].includes(node?.parent?.type)) {

--- a/test/rules/assertions/checkTagNames.js
+++ b/test/rules/assertions/checkTagNames.js
@@ -1455,5 +1455,18 @@ export default {
         },
       },
     },
+    {
+      code: `
+        /**
+         * @module
+         * A comment related to the module
+         */
+      `,
+      options: [
+        {
+          typed: true,
+        },
+      ],
+    },
   ],
 };


### PR DESCRIPTION
This fixes #1085 by:
1. Removing the `module` tag from the set of `typedTagsUnnecessaryOutsideDeclare`, since typedoc promotes this, even outside declarations: See https://typedoc.org/tags/module/ 
2. Adding an early return in the check-tag-names rule's `tagIsRedundantWhenTyped` function, to avoid crashing when encountering a comment, which is not associated with an AST node.
