### PR TITLE
Line alignment hyphens

### DIFF
--- a/docs/rules/check-line-alignment.md
+++ b/docs/rules/check-line-alignment.md
@@ -991,5 +991,12 @@ function quux () {
  */
 function quux () {}
 // "jsdoc/check-line-alignment": ["error"|"warn", "never",{"wrapIndent":"   "}]
+
+/**
+ * Returns cached value of negative scale of the world transform.
+ *
+ * @returns {number} -1 if world transform has negative scale, 1 otherwise.
+ */
+// "jsdoc/check-line-alignment": ["error"|"warn", "never"]
 ````
 

--- a/docs/rules/require-param.md
+++ b/docs/rules/require-param.md
@@ -1812,5 +1812,9 @@ function foo(this: T, bar: number): number {
   console.log(this.name);
   return bar;
 }
+
+/** {@link someOtherval} */
+function a (b) {}
+// "jsdoc/require-param": ["error"|"warn", {"contexts":[{"comment":"*:not(JsdocBlock:has(JsdocInlineTag[tag=link]))","context":"FunctionDeclaration"}]}]
 ````
 

--- a/src/alignTransform.js
+++ b/src/alignTransform.js
@@ -306,7 +306,7 @@ const alignTransform = ({
     }
 
     const postHyphenSpacing = customSpacings?.postHyphen ?? 1;
-    const hyphenSpacing = /^\s*-\s*/u;
+    const hyphenSpacing = /^\s*-\s+/u;
     tokens.description = tokens.description.replace(
       hyphenSpacing, '-' + ''.padStart(postHyphenSpacing, ' '),
     );

--- a/src/rules/checkLineAlignment.js
+++ b/src/rules/checkLineAlignment.js
@@ -94,7 +94,7 @@ const checkNotAlignedPerTag = (utils, tag, customSpacings) => {
 
   const postHyphenSpacing = customSpacings?.postHyphen ?? 1;
   const exactHyphenSpacing = new RegExp(`^\\s*-\\s{${postHyphenSpacing},${postHyphenSpacing}}(?!\\s)`, 'u');
-  const hasNoHyphen = !(/^\s*-(?!$)/u).test(tokens.description);
+  const hasNoHyphen = !(/^\s*-(?!$)(?=\s)/u).test(tokens.description);
   const hasExactHyphenSpacing = exactHyphenSpacing.test(
     tokens.description,
   );
@@ -144,7 +144,7 @@ const checkNotAlignedPerTag = (utils, tag, customSpacings) => {
     }
 
     if (!hasExactHyphenSpacing) {
-      const hyphenSpacing = /^\s*-\s*/u;
+      const hyphenSpacing = /^\s*-\s+/u;
       tokens.description = tokens.description.replace(
         hyphenSpacing, '-' + ''.padStart(postHyphenSpacing, ' '),
       );

--- a/test/rules/assertions/checkLineAlignment.js
+++ b/test/rules/assertions/checkLineAlignment.js
@@ -2170,5 +2170,17 @@ export default {
         },
       ],
     },
+    {
+      code: `
+      /**
+       * Returns cached value of negative scale of the world transform.
+       *
+       * @returns {number} -1 if world transform has negative scale, 1 otherwise.
+       */
+      `,
+      options: [
+        'never',
+      ],
+    },
   ],
 };

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -3525,5 +3525,21 @@ export default {
       `,
       parser: require.resolve('@typescript-eslint/parser'),
     },
+    {
+      code: `
+        /** {@link someOtherval} */
+        function a (b) {}
+      `,
+      options: [
+        {
+          contexts: [
+            {
+              comment: '*:not(JsdocBlock:has(JsdocInlineTag[tag=link]))',
+              context: 'FunctionDeclaration',
+            },
+          ],
+        },
+      ],
+    },
   ],
 };


### PR DESCRIPTION
fix(`check-line-alignment`): only treat hyphen as separator if followed by whitespace; fixes #1091