### PR TITLE
fix(`informative-docs`, `require-asterisk-prefix`): add missing and update out-of-date doc URL

### DIFF
--- a/src/rules/informativeDocs.js
+++ b/src/rules/informativeDocs.js
@@ -140,7 +140,7 @@ export default iterateJsdoc(({
     docs: {
       description:
         'This rule reports doc comments that only restate their attached name.',
-      url: 'https://github.com/gajus/eslint-plugin-jsdoc#informative-docs',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/informative-docs.md#repos-sticky-header',
     },
     schema: [
       {

--- a/src/rules/requireAsteriskPrefix.js
+++ b/src/rules/requireAsteriskPrefix.js
@@ -141,6 +141,11 @@ export default iterateJsdoc(({
 }, {
   iterateAllJsdocs: true,
   meta: {
+    docs: {
+      description:
+        'Requires that each JSDoc line starts with an `*`.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-asterisk-prefix.md#repos-sticky-header',
+    },
     fixable: 'code',
     schema: [
       {


### PR DESCRIPTION
fixes #1094