### PR TITLE
no-undefined-types and TypeScript

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -118,21 +118,7 @@ as failing errors, you may use the "recommended-error" config:
 ```
 
 If you plan to use TypeScript syntax (and not just "typescript"
-`mode` to indicate the JSDoc flavor is TypeScript), you can configure
-the following:
-
-```javascript
-{
-    "rules": {
-      "jsdoc/no-types": 1,
-      "jsdoc/require-param-type": 0,
-      "jsdoc/require-property-type": 0,
-      "jsdoc/require-returns-type": 0,
-    }
-}
-```
-
-...or just use:
+`mode` to indicate the JSDoc flavor is TypeScript), you can use:
 
 ```json
 {
@@ -145,6 +131,26 @@ the following:
 ```json
 {
   "extends": ["plugin:jsdoc/recommended-typescript-error"]
+}
+```
+
+If you are not using TypeScript syntax (your source files are still `.js` files)
+but you are using the TypeScript flavor within JSDoc (i.e., the default
+"typescript" `mode` in `eslint-plugin-jsdoc`) and you are perhaps using
+`allowJs` and `checkJs` options of TypeScript's `tsconfig.json`), you may
+use:
+
+```json
+{
+  "extends": ["plugin:jsdoc/recommended-typescript-flavor"]
+}
+```
+
+...or to report with failing errors instead of mere warnings:
+
+```json
+{
+  "extends": ["plugin:jsdoc/recommended-typescript-flavor-error"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -131,21 +131,7 @@ as failing errors, you may use the "recommended-error" config:
 ```
 
 If you plan to use TypeScript syntax (and not just "typescript"
-`mode` to indicate the JSDoc flavor is TypeScript), you can configure
-the following:
-
-```javascript
-{
-    "rules": {
-      "jsdoc/no-types": 1,
-      "jsdoc/require-param-type": 0,
-      "jsdoc/require-property-type": 0,
-      "jsdoc/require-returns-type": 0,
-    }
-}
-```
-
-...or just use:
+`mode` to indicate the JSDoc flavor is TypeScript), you can use:
 
 ```json
 {
@@ -158,6 +144,26 @@ the following:
 ```json
 {
   "extends": ["plugin:jsdoc/recommended-typescript-error"]
+}
+```
+
+If you are not using TypeScript syntax (your source files are still `.js` files)
+but you are using the TypeScript flavor within JSDoc (i.e., the default
+"typescript" `mode` in `eslint-plugin-jsdoc`) and you are perhaps using
+`allowJs` and `checkJs` options of TypeScript's `tsconfig.json`), you may
+use:
+
+```json
+{
+  "extends": ["plugin:jsdoc/recommended-typescript-flavor"]
+}
+```
+
+...or to report with failing errors instead of mere warnings:
+
+```json
+{
+  "extends": ["plugin:jsdoc/recommended-typescript-flavor-error"]
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -205,6 +205,24 @@ const createRecommendedTypeScriptRuleset = (warnOrError) => {
   };
 };
 
+/**
+ * @param {"warn"|"error"} warnOrError
+ * @returns {import('eslint').ESLint.ConfigData}
+ */
+const createRecommendedTypeScriptFlavorRuleset = (warnOrError) => {
+  const ruleset = createRecommendedRuleset(warnOrError);
+
+  return {
+    ...ruleset,
+    rules: {
+      ...ruleset.rules,
+      /* eslint-disable indent -- Extra indent to avoid use by auto-rule-editing */
+        'jsdoc/no-undefined-types': 'off',
+      /* eslint-enable indent */
+    },
+  };
+};
+
 /* istanbul ignore if -- TS */
 if (!index.configs) {
   throw new Error('TypeScript guard');
@@ -214,5 +232,7 @@ index.configs.recommended = createRecommendedRuleset('warn');
 index.configs['recommended-error'] = createRecommendedRuleset('error');
 index.configs['recommended-typescript'] = createRecommendedTypeScriptRuleset('warn');
 index.configs['recommended-typescript-error'] = createRecommendedTypeScriptRuleset('error');
+index.configs['recommended-typescript-flavor'] = createRecommendedTypeScriptFlavorRuleset('warn');
+index.configs['recommended-typescript-flavor-error'] = createRecommendedTypeScriptFlavorRuleset('error');
 
 export default index;

--- a/src/index.js
+++ b/src/index.js
@@ -196,6 +196,7 @@ const createRecommendedTypeScriptRuleset = (warnOrError) => {
           },
         ],
         'jsdoc/no-types': warnOrError,
+        'jsdoc/no-undefined-types': 'off',
         'jsdoc/require-param-type': 'off',
         'jsdoc/require-property-type': 'off',
         'jsdoc/require-returns-type': 'off',


### PR DESCRIPTION
BREAKING CHANGE:

This should only impact users of typescript configs. TS should itself handle
checking for undefined types, so the (imperfect) rule has been disabled for
such users.

- feat: for typescript configs, disable `no-undefined-types`; fixes #888
- feat: add recommended-typescript-flavor configs