### PR TITLE
chore: include release-notes-generator for Markdown in release notes

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -4,6 +4,7 @@
   ],
   "plugins": [
     "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
     "@semantic-release/github",
     "@semantic-release/npm"
   ]


### PR DESCRIPTION
fixes #973