### PR TITLE
fix(`imports-as-dependencies`): don't report TypeScript proper

### DIFF
--- a/src/rules/importsAsDependencies.js
+++ b/src/rules/importsAsDependencies.js
@@ -66,6 +66,10 @@ export default iterateJsdoc(({
         let mod = nde.element.value.replace(
           /^(@[^/]+\/[^/]+|[^/]+).*$/u, '$1',
         );
+        if (mod === 'typescript') {
+          return;
+        }
+
         if (!moduleCheck.has(mod)) {
           let pkg;
           try {

--- a/test/rules/assertions/importsAsDependencies.js
+++ b/test/rules/assertions/importsAsDependencies.js
@@ -102,5 +102,12 @@ export default {
          */
       `,
     },
+    {
+      code: `
+        /**
+         * @type {null|import('typescript').Program}
+         */
+      `,
+    },
   ],
 };


### PR DESCRIPTION
#1107