### PR TITLE
fix(`imports-as-dependencies`): catch `typings` as possible publishing source

### DIFF
--- a/src/rules/importsAsDependencies.js
+++ b/src/rules/importsAsDependencies.js
@@ -66,9 +66,6 @@ export default iterateJsdoc(({
         let mod = nde.element.value.replace(
           /^(@[^/]+\/[^/]+|[^/]+).*$/u, '$1',
         );
-        if (mod === 'typescript') {
-          return;
-        }
 
         if (!moduleCheck.has(mod)) {
           let pkg;
@@ -81,7 +78,7 @@ export default iterateJsdoc(({
             // Ignore
           }
 
-          if (!pkg || !pkg.types) {
+          if (!pkg || (!pkg.types && !pkg.typings)) {
             mod = `@types/${mod}`;
           }
 


### PR DESCRIPTION
fixes #1107