### PR TITLE
fix(`imports-as-dependencies`): allow relative paths

### DIFF
--- a/.README/rules/imports-as-dependencies.md
+++ b/.README/rules/imports-as-dependencies.md
@@ -11,4 +11,10 @@ which is not listed in `dependencies` or `devDependencies`.
 |Settings||
 |Options||
 
-<!-- assertions importsAsDependencies -->
+## Failing examples
+
+<!-- assertions-failing importsAsDependencies -->
+
+## Passing examples
+
+<!-- assertions-passing importsAsDependencies -->

--- a/docs/rules/imports-as-dependencies.md
+++ b/docs/rules/imports-as-dependencies.md
@@ -13,4 +13,75 @@ which is not listed in `dependencies` or `devDependencies`.
 |Settings||
 |Options||
 
-<!-- assertions importsAsDependencies -->
+<a name="user-content-failing-examples"></a>
+<a name="failing-examples"></a>
+## Failing examples
+
+The following patterns are considered problems:
+
+````js
+/**
+ * @type {null|import('sth').SomeApi}
+ */
+// Message: import points to package which is not found in dependencies
+
+/**
+ * @type {null|import('sth').SomeApi}
+ */
+// Settings: {"jsdoc":{"mode":"permissive"}}
+// Message: import points to package which is not found in dependencies
+
+/**
+ * @type {null|import('missingpackage/subpackage').SomeApi}
+ */
+// Message: import points to package which is not found in dependencies
+
+/**
+ * @type {null|import('@sth/pkg').SomeApi}
+ */
+// Message: import points to package which is not found in dependencies
+````
+
+
+
+<a name="user-content-passing-examples"></a>
+<a name="passing-examples"></a>
+## Passing examples
+
+The following patterns are not considered problems:
+
+````js
+/**
+ * @type {null|import('eslint').ESLint}
+ */
+
+/**
+ * @type {null|import('eslint/use-at-your-own-risk').ESLint}
+ */
+
+/**
+ * @type {null|import('@es-joy/jsdoccomment').InlineTag}
+ */
+
+/**
+ * @type {null|import(}
+ */
+
+/**
+ * @type {null|import('esquery').ESQueryOptions}
+ */
+
+/**
+ * @type {null|import('@es-joy/jsdoccomment').InlineTag|
+ *   import('@es-joy/jsdoccomment').JsdocBlock}
+ */
+
+/**
+ * @type {null|import('typescript').Program}
+ */
+
+/**
+ * @type {null|import('./relativePath.js').Program}
+ */
+````
+

--- a/src/bin/generateRule.js
+++ b/src/bin/generateRule.js
@@ -127,7 +127,13 @@ export default iterateJsdoc(({
 |Settings||
 |Options||
 
-<!-- assertions ${camelCasedRuleName} -->
+## Failing examples
+
+<!-- assertions-failing ${camelCasedRuleName} -->
+
+## Passing examples
+
+<!-- assertions-passing ${camelCasedRuleName} -->
 `;
 
   const ruleReadmePath = `./.README/rules/${ruleName}.md`;

--- a/src/rules/importsAsDependencies.js
+++ b/src/rules/importsAsDependencies.js
@@ -67,6 +67,10 @@ export default iterateJsdoc(({
           /^(@[^/]+\/[^/]+|[^/]+).*$/u, '$1',
         );
 
+        if ((/^[./]/u).test(mod)) {
+          return;
+        }
+
         if (!moduleCheck.has(mod)) {
           let pkg;
           try {

--- a/test/rules/assertions/importsAsDependencies.js
+++ b/test/rules/assertions/importsAsDependencies.js
@@ -109,5 +109,12 @@ export default {
          */
       `,
     },
+    {
+      code: `
+        /**
+         * @type {null|import('./relativePath.js').Program}
+         */
+      `,
+    },
   ],
 };


### PR DESCRIPTION
Also:
- fix: generation of failing/passing examples