### PR TITLE
fix(`require-jsdoc`): do not report `PropertyDefinition`'s with non-public `accessibility`

### DIFF
--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -990,6 +990,19 @@ class A {
 }
 // "jsdoc/require-jsdoc": ["error"|"warn", {"contexts":[{"context":"MethodDefinition","minLineCount":3}],"require":{"ClassDeclaration":false,"FunctionExpression":false,"MethodDefinition":false}}]
 // Message: Missing JSDoc comment.
+
+export class MyClass {
+
+  public myPublicProperty: number = 1;
+      /* ^ Missing JSDoc comment. eslint(jsdoc/require-jsdoc) - expected ✅ */
+
+  private myPrivateProp: number = -1;
+      /* ^ Missing JSDoc comment. eslint(jsdoc/require-jsdoc) - unexpected ❌ */
+
+  // ...
+}
+// "jsdoc/require-jsdoc": ["error"|"warn", {"contexts":["PropertyDefinition"],"publicOnly":true}]
+// Message: Missing JSDoc comment.
 ````
 
 

--- a/src/exportParser.js
+++ b/src/exportParser.js
@@ -905,6 +905,13 @@ const isUncommentedExport = function (node, sourceCode, opt, settings) {
   // console.log({node});
   // Optimize with ancestor check for esm
   if (opt.esm) {
+    if (
+      node.type === 'PropertyDefinition' && 'accessibility' in node &&
+      node.accessibility !== 'public'
+    ) {
+      return false;
+    }
+
     const exportNode = getExportAncestor(node);
 
     // Is export node comment

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -4081,6 +4081,50 @@ function quux (foo) {
       `,
       parser: require.resolve('@typescript-eslint/parser'),
     },
+    {
+      code: `
+        export class MyClass {
+
+          public myPublicProperty: number = 1;
+              /* ^ Missing JSDoc comment. eslint(jsdoc/require-jsdoc) - expected ✅ */
+
+          private myPrivateProp: number = -1;
+              /* ^ Missing JSDoc comment. eslint(jsdoc/require-jsdoc) - unexpected ❌ */
+
+          // ...
+        }
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Missing JSDoc comment.',
+        },
+      ],
+      options: [
+        {
+          contexts: [
+            'PropertyDefinition',
+          ],
+          publicOnly: true,
+        },
+      ],
+      output: `
+        export class MyClass {
+
+          /**
+           *
+           */
+          public myPublicProperty: number = 1;
+              /* ^ Missing JSDoc comment. eslint(jsdoc/require-jsdoc) - expected ✅ */
+
+          private myPrivateProp: number = -1;
+              /* ^ Missing JSDoc comment. eslint(jsdoc/require-jsdoc) - unexpected ❌ */
+
+          // ...
+        }
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
   ],
   valid: [
     {


### PR DESCRIPTION
fixes #1122