### PR TITLE
fix(`require-jsdoc`): do not report `MethodDefinition` with non-public `accessibility`

### DIFF
--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -639,7 +639,7 @@ export default class Test {
     this.a = a;
   }
 }
-// "jsdoc/require-jsdoc": ["error"|"warn", {"contexts":["MethodDefinition:not([accessibility=\"private\"]) > FunctionExpression"],"publicOnly":true,"require":{"ArrowFunctionExpression":false,"ClassDeclaration":false,"ClassExpression":false,"FunctionDeclaration":false,"FunctionExpression":false,"MethodDefinition":false}}]
+// "jsdoc/require-jsdoc": ["error"|"warn", {"contexts":["MethodDefinition > FunctionExpression"],"publicOnly":true,"require":{"ArrowFunctionExpression":false,"ClassDeclaration":false,"ClassExpression":false,"FunctionDeclaration":false,"FunctionExpression":false,"MethodDefinition":false}}]
 // Message: Missing JSDoc comment.
 
 e = function () {
@@ -1675,7 +1675,7 @@ export default class Test {
     this.a = a;
   }
 }
-// "jsdoc/require-jsdoc": ["error"|"warn", {"contexts":["MethodDefinition:not([accessibility=\"private\"]) > FunctionExpression"],"publicOnly":true,"require":{"ArrowFunctionExpression":false,"ClassDeclaration":false,"ClassExpression":false,"FunctionDeclaration":false,"FunctionExpression":false,"MethodDefinition":false}}]
+// "jsdoc/require-jsdoc": ["error"|"warn", {"contexts":["MethodDefinition > FunctionExpression"],"publicOnly":true,"require":{"ArrowFunctionExpression":false,"ClassDeclaration":false,"ClassExpression":false,"FunctionDeclaration":false,"FunctionExpression":false,"MethodDefinition":false}}]
 
 /**
  * Basic application controller.
@@ -1846,5 +1846,12 @@ class A {
   }
 }
 // "jsdoc/require-jsdoc": ["error"|"warn", {"contexts":[{"context":"MethodDefinition","minLineCount":4}],"require":{"ClassDeclaration":false,"FunctionExpression":false,"MethodDefinition":false}}]
+
+export default class Test {
+  private abc(a) {
+    this.a = a;
+  }
+}
+// "jsdoc/require-jsdoc": ["error"|"warn", {"publicOnly":true,"require":{"ArrowFunctionExpression":false,"ClassDeclaration":false,"ClassExpression":false,"FunctionDeclaration":false,"FunctionExpression":false,"MethodDefinition":true}}]
 ````
 

--- a/src/exportParser.js
+++ b/src/exportParser.js
@@ -893,6 +893,21 @@ const parse = function (ast, node, opt) {
   };
 };
 
+const accessibilityNodes = new Set([
+  'PropertyDefinition',
+  'MethodDefinition',
+]);
+
+/**
+ *
+ * @param {import('eslint').Rule.Node} node
+ * @returns {boolean}
+ */
+const hasAccessibility = (node) => {
+  return accessibilityNodes.has(node.type) && 'accessibility' in node &&
+    node.accessibility !== 'public';
+};
+
 /**
  *
  * @param {import('eslint').Rule.Node} node
@@ -905,10 +920,8 @@ const isUncommentedExport = function (node, sourceCode, opt, settings) {
   // console.log({node});
   // Optimize with ancestor check for esm
   if (opt.esm) {
-    if (
-      node.type === 'PropertyDefinition' && 'accessibility' in node &&
-      node.accessibility !== 'public'
-    ) {
+    if (hasAccessibility(node) ||
+      node.parent && hasAccessibility(node.parent)) {
       return false;
     }
 

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -2323,7 +2323,7 @@ function quux (foo) {
       options: [
         {
           contexts: [
-            'MethodDefinition:not([accessibility="private"]) > FunctionExpression',
+            'MethodDefinition > FunctionExpression',
           ],
           publicOnly: true,
           require: {
@@ -5629,7 +5629,7 @@ function quux (foo) {
       options: [
         {
           contexts: [
-            'MethodDefinition:not([accessibility="private"]) > FunctionExpression',
+            'MethodDefinition > FunctionExpression',
           ],
           publicOnly: true,
           require: {
@@ -6141,6 +6141,32 @@ function quux (foo) {
         },
       ],
       parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+    export default class Test {
+      private abc(a) {
+        this.a = a;
+      }
+    }
+    `,
+      options: [
+        {
+          publicOnly: true,
+          require: {
+            ArrowFunctionExpression: false,
+            ClassDeclaration: false,
+            ClassExpression: false,
+            FunctionDeclaration: false,
+            FunctionExpression: false,
+            MethodDefinition: true,
+          },
+        },
+      ],
+      parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: {
+        sourceType: 'module',
+      },
     },
   ],
 };


### PR DESCRIPTION
fixes #1124