### PR TITLE
fix(`match-description`): drop `throws` and `yields` from being reported for non-empty descriptions by `nonemptyTags` default

### DIFF
--- a/.README/rules/match-description.md
+++ b/.README/rules/match-description.md
@@ -69,8 +69,6 @@ some content:
 - `@example`
 - `@see`
 - `@todo`
-- `@throws`/`@exception`
-- `@yields`/`@yield`
 
 If you supply your own tag description for any of the above tags in `tags`,
 your description will take precedence.

--- a/docs/rules/match-description.md
+++ b/docs/rules/match-description.md
@@ -89,8 +89,6 @@ some content:
 - `@example`
 - `@see`
 - `@todo`
-- `@throws`/`@exception`
-- `@yields`/`@yield`
 
 If you supply your own tag description for any of the above tags in `tags`,
 your description will take precedence.

--- a/src/rules/matchDescription.js
+++ b/src/rules/matchDescription.js
@@ -109,9 +109,7 @@ export default iterateJsdoc(({
       'copyright',
       'example',
       'see',
-      'throws',
       'todo',
-      'yields',
     ]) {
       utils.forEachPreferredTag(tag, (matchingJsdocTag, targetTagName) => {
         const desc = (matchingJsdocTag.name + ' ' + utils.getTagDescription(matchingJsdocTag)).trim();


### PR DESCRIPTION
#1126