### PR TITLE
fix: exclude unused files from publish process

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ test
 .*
 *.log
 CONTRIBUTING.md
+tsconfig*.json

--- a/package.json
+++ b/package.json
@@ -67,6 +67,10 @@
   "engines": {
     "node": ">=16"
   },
+  "files": [
+    "dist",
+    "docs"
+  ],
   "keywords": [
     "eslint",
     "plugin",

--- a/package.json
+++ b/package.json
@@ -67,10 +67,6 @@
   "engines": {
     "node": ">=16"
   },
-  "files": [
-    "dist",
-    "docs"
-  ],
   "keywords": [
     "eslint",
     "plugin",

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -166,10 +166,10 @@ const flattenRoots = (params, root = '') => {
 };
 
 /**
- * @param {import('@typescript-eslint/types').TSESTree.TSIndexSignature|
- *  import('@typescript-eslint/types').TSESTree.TSConstructSignatureDeclaration|
- *  import('@typescript-eslint/types').TSESTree.TSCallSignatureDeclaration|
- *  import('@typescript-eslint/types').TSESTree.TSPropertySignature} propSignature
+ * @param {import('@typescript-eslint/types/dist').TSESTree.TSIndexSignature|
+ *  import('@typescript-eslint/types/dist').TSESTree.TSConstructSignatureDeclaration|
+ *  import('@typescript-eslint/types/dist').TSESTree.TSCallSignatureDeclaration|
+ *  import('@typescript-eslint/types/dist').TSESTree.TSPropertySignature} propSignature
  * @returns {undefined|string|[string, string[]]}
  */
 const getPropertiesFromPropertySignature = (propSignature) => {
@@ -183,13 +183,13 @@ const getPropertiesFromPropertySignature = (propSignature) => {
 
   if (propSignature.typeAnnotation && propSignature.typeAnnotation.typeAnnotation.type === 'TSTypeLiteral') {
     return [
-      /** @type {import('@typescript-eslint/types').TSESTree.Identifier} */ (
+      /** @type {import('@typescript-eslint/types/dist').TSESTree.Identifier} */ (
         propSignature.key
       ).name,
       propSignature.typeAnnotation.typeAnnotation.members.map((member) => {
         return /** @type {string} */ (
           getPropertiesFromPropertySignature(
-            /** @type {import('@typescript-eslint/types').TSESTree.TSPropertySignature} */ (
+            /** @type {import('@typescript-eslint/types/dist').TSESTree.TSPropertySignature} */ (
               member
             ),
           )
@@ -198,7 +198,7 @@ const getPropertiesFromPropertySignature = (propSignature) => {
     ];
   }
 
-  return /** @type {import('@typescript-eslint/types').TSESTree.Identifier} */ (
+  return /** @type {import('@typescript-eslint/types/dist').TSESTree.Identifier} */ (
     propSignature.key
   ).name;
 };
@@ -217,13 +217,13 @@ const getFunctionParameterNames = (
    * @param {import('estree').Identifier|import('estree').AssignmentPattern|
    *   import('estree').ObjectPattern|import('estree').Property|
    *   import('estree').RestElement|import('estree').ArrayPattern|
-   *   import('@typescript-eslint/types').TSESTree.TSParameterProperty|
-   *   import('@typescript-eslint/types').TSESTree.Property|
-   *   import('@typescript-eslint/types').TSESTree.RestElement|
-   *   import('@typescript-eslint/types').TSESTree.Identifier|
-   *   import('@typescript-eslint/types').TSESTree.ObjectPattern|
-   *   import('@typescript-eslint/types').TSESTree.BindingName|
-   *   import('@typescript-eslint/types').TSESTree.Parameter
+   *   import('@typescript-eslint/types/dist').TSESTree.TSParameterProperty|
+   *   import('@typescript-eslint/types/dist').TSESTree.Property|
+   *   import('@typescript-eslint/types/dist').TSESTree.RestElement|
+   *   import('@typescript-eslint/types/dist').TSESTree.Identifier|
+   *   import('@typescript-eslint/types/dist').TSESTree.ObjectPattern|
+   *   import('@typescript-eslint/types/dist').TSESTree.BindingName|
+   *   import('@typescript-eslint/types/dist').TSESTree.Parameter
    * } param
    * @param {boolean} [isProperty]
    * @returns {ParamNameInfo|[string, ParamNameInfo[]]}
@@ -234,16 +234,16 @@ const getFunctionParameterNames = (
 
     if ('typeAnnotation' in param || hasLeftTypeAnnotation) {
       const typeAnnotation = hasLeftTypeAnnotation ?
-        /** @type {import('@typescript-eslint/types').TSESTree.Identifier} */ (
+        /** @type {import('@typescript-eslint/types/dist').TSESTree.Identifier} */ (
           param.left
         ).typeAnnotation :
-        /** @type {import('@typescript-eslint/types').TSESTree.Identifier|import('@typescript-eslint/types').TSESTree.ObjectPattern} */
+        /** @type {import('@typescript-eslint/types/dist').TSESTree.Identifier|import('@typescript-eslint/types/dist').TSESTree.ObjectPattern} */
         (param).typeAnnotation;
 
       if (typeAnnotation?.typeAnnotation?.type === 'TSTypeLiteral') {
         const propertyNames = typeAnnotation.typeAnnotation.members.map((member) => {
           return getPropertiesFromPropertySignature(
-            /** @type {import('@typescript-eslint/types').TSESTree.TSPropertySignature} */
+            /** @type {import('@typescript-eslint/types/dist').TSESTree.TSPropertySignature} */
             (member),
           );
         });
@@ -257,10 +257,10 @@ const getFunctionParameterNames = (
         if ('name' in param || hasLeftName) {
           return [
             hasLeftName ?
-              /** @type {import('@typescript-eslint/types').TSESTree.Identifier} */ (
+              /** @type {import('@typescript-eslint/types/dist').TSESTree.Identifier} */ (
                 param.left
               ).name :
-              /** @type {import('@typescript-eslint/types').TSESTree.Identifier} */ (
+              /** @type {import('@typescript-eslint/types/dist').TSESTree.Identifier} */ (
                 param
               ).name,
             flattened,
@@ -288,12 +288,12 @@ const getFunctionParameterNames = (
         param
       ).left.type === 'ObjectPattern')
     ) {
-      const properties = /** @type {import('@typescript-eslint/types').TSESTree.ObjectPattern} */ (
+      const properties = /** @type {import('@typescript-eslint/types/dist').TSESTree.ObjectPattern} */ (
         param
       ).properties ||
         /** @type {import('estree').ObjectPattern} */
         (
-          /** @type {import('@typescript-eslint/types').TSESTree.AssignmentPattern} */ (
+          /** @type {import('@typescript-eslint/types/dist').TSESTree.AssignmentPattern} */ (
             param
           ).left
         )?.properties;
@@ -435,8 +435,8 @@ const getFunctionParameterNames = (
     ].includes(param.type)) {
       return {
         isRestProperty: isProperty,
-        name: /** @type {import('@typescript-eslint/types').TSESTree.Identifier} */ (
-          /** @type {import('@typescript-eslint/types').TSESTree.RestElement} */ (
+        name: /** @type {import('@typescript-eslint/types/dist').TSESTree.Identifier} */ (
+          /** @type {import('@typescript-eslint/types/dist').TSESTree.RestElement} */ (
             param
           ).argument).name,
         restElement: true,
@@ -445,8 +445,8 @@ const getFunctionParameterNames = (
 
     if (param.type === 'TSParameterProperty') {
       return getParamName(
-        /** @type {import('@typescript-eslint/types').TSESTree.Identifier} */ (
-          /** @type {import('@typescript-eslint/types').TSESTree.TSParameterProperty} */ (
+        /** @type {import('@typescript-eslint/types/dist').TSESTree.Identifier} */ (
+          /** @type {import('@typescript-eslint/types/dist').TSESTree.TSParameterProperty} */ (
             param
           ).parameter
         ),
@@ -461,9 +461,9 @@ const getFunctionParameterNames = (
     return [];
   }
 
-  return (/** @type {import('@typescript-eslint/types').TSESTree.FunctionDeclaration} */ (
+  return (/** @type {import('@typescript-eslint/types/dist').TSESTree.FunctionDeclaration} */ (
     functionNode
-  ).params || /** @type {import('@typescript-eslint/types').TSESTree.MethodDefinition} */ (
+  ).params || /** @type {import('@typescript-eslint/types/dist').TSESTree.MethodDefinition} */ (
     functionNode
   ).value?.params || []).map((param) => {
     return getParamName(param);
@@ -476,7 +476,7 @@ const getFunctionParameterNames = (
  */
 const hasParams = (functionNode) => {
   // Should also check `functionNode.value.params` if supporting `MethodDefinition`
-  return /** @type {import('@typescript-eslint/types').TSESTree.FunctionDeclaration} */ (
+  return /** @type {import('@typescript-eslint/types/dist').TSESTree.FunctionDeclaration} */ (
     functionNode
   ).params.length;
 };
@@ -1059,7 +1059,7 @@ const hasNonFunctionYield = (node, checkYieldReturnValue) => {
         node.handler && node.handler.body, checkYieldReturnValue,
       ) ||
       hasNonFunctionYield(
-        /** @type {import('@typescript-eslint/types').TSESTree.BlockStatement} */
+        /** @type {import('@typescript-eslint/types/dist').TSESTree.BlockStatement} */
         (node.finalizer),
         checkYieldReturnValue,
       );
@@ -1201,13 +1201,13 @@ const hasNonFunctionYield = (node, checkYieldReturnValue) => {
  * @returns {boolean}
  */
 const hasYieldValue = (node, checkYieldReturnValue) => {
-  return /** @type {import('@typescript-eslint/types').TSESTree.FunctionDeclaration} */ (
+  return /** @type {import('@typescript-eslint/types/dist').TSESTree.FunctionDeclaration} */ (
     node
   ).generator && (
-    /** @type {import('@typescript-eslint/types').TSESTree.FunctionDeclaration} */ (
+    /** @type {import('@typescript-eslint/types/dist').TSESTree.FunctionDeclaration} */ (
       node
     ).expression || hasNonFunctionYield(
-      /** @type {import('@typescript-eslint/types').TSESTree.FunctionDeclaration} */
+      /** @type {import('@typescript-eslint/types/dist').TSESTree.FunctionDeclaration} */
       (node).body,
       checkYieldReturnValue,
     )
@@ -1466,7 +1466,7 @@ const getIndent = (sourceCode) => {
  */
 const isConstructor = (node) => {
   return node?.type === 'MethodDefinition' && node.kind === 'constructor' ||
-  /** @type {import('@typescript-eslint/types').TSESTree.MethodDefinition} */ (
+  /** @type {import('@typescript-eslint/types/dist').TSESTree.MethodDefinition} */ (
     node?.parent
   )?.kind === 'constructor';
 };
@@ -1478,8 +1478,8 @@ const isConstructor = (node) => {
 const isGetter = (node) => {
   return node !== null &&
   /**
-   * @type {import('@typescript-eslint/types').TSESTree.MethodDefinition|
-   *   import('@typescript-eslint/types').TSESTree.Property}
+   * @type {import('@typescript-eslint/types/dist').TSESTree.MethodDefinition|
+   *   import('@typescript-eslint/types/dist').TSESTree.Property}
    */ (
     node.parent
   )?.kind === 'get';
@@ -1492,8 +1492,8 @@ const isGetter = (node) => {
 const isSetter = (node) => {
   return node !== null &&
   /**
-   * @type {import('@typescript-eslint/types').TSESTree.MethodDefinition|
-   *   import('@typescript-eslint/types').TSESTree.Property}
+   * @type {import('@typescript-eslint/types/dist').TSESTree.MethodDefinition|
+   *   import('@typescript-eslint/types/dist').TSESTree.Property}
    */(
     node.parent
   )?.kind === 'set';
@@ -1510,22 +1510,22 @@ const hasAccessorPair = (node) => {
     key,
   } =
     /**
-     * @type {import('@typescript-eslint/types').TSESTree.MethodDefinition|
-     *   import('@typescript-eslint/types').TSESTree.Property}
+     * @type {import('@typescript-eslint/types/dist').TSESTree.MethodDefinition|
+     *   import('@typescript-eslint/types/dist').TSESTree.Property}
      */ (node);
 
   const sourceName =
-    /** @type {import('@typescript-eslint/types').TSESTree.Identifier} */ (
+    /** @type {import('@typescript-eslint/types/dist').TSESTree.Identifier} */ (
       key
     ).name;
 
   const oppositeKind = sourceKind === 'get' ? 'set' : 'get';
 
   const sibling = type === 'MethodDefinition' ?
-    /** @type {import('@typescript-eslint/types').TSESTree.ClassBody} */ (
+    /** @type {import('@typescript-eslint/types/dist').TSESTree.ClassBody} */ (
       node.parent
     ).body :
-    /** @type {import('@typescript-eslint/types').TSESTree.ObjectExpression} */ (
+    /** @type {import('@typescript-eslint/types/dist').TSESTree.ObjectExpression} */ (
       node.parent
     ).properties;
 
@@ -1535,12 +1535,12 @@ const hasAccessorPair = (node) => {
         kind,
         key: ky,
       } = /**
-           * @type {import('@typescript-eslint/types').TSESTree.MethodDefinition|
-           *   import('@typescript-eslint/types').TSESTree.Property}
+           * @type {import('@typescript-eslint/types/dist').TSESTree.MethodDefinition|
+           *   import('@typescript-eslint/types/dist').TSESTree.Property}
            */ (child);
 
       const name =
-        /** @type {import('@typescript-eslint/types').TSESTree.Identifier} */ (
+        /** @type {import('@typescript-eslint/types/dist').TSESTree.Identifier} */ (
           ky
         ).name;
 

--- a/src/rules/checkTagNames.js
+++ b/src/rules/checkTagNames.js
@@ -122,7 +122,7 @@ export default iterateJsdoc(({
     return subNode.type === 'Program' ?
       context.getFilename().endsWith('.d.ts') :
       Boolean(
-        /** @type {import('@typescript-eslint/types').TSESTree.VariableDeclaration} */ (
+        /** @type {import('@typescript-eslint/types/dist').TSESTree.VariableDeclaration} */ (
           subNode
         ).declare,
       ) || isInAmbientContext(subNode.parent);

--- a/src/rules/informativeDocs.js
+++ b/src/rules/informativeDocs.js
@@ -16,7 +16,7 @@ const defaultUselessWords = [
 /* eslint-disable complexity -- Temporary */
 
 /**
- * @param {import('eslint').Rule.Node|import('@typescript-eslint/types').TSESTree.Node|null|undefined} node
+ * @param {import('eslint').Rule.Node|import('@typescript-eslint/types/dist').TSESTree.Node|null|undefined} node
  * @returns {string[]}
  */
 const getNamesFromNode = (node) => {
@@ -29,12 +29,12 @@ const getNamesFromNode = (node) => {
   case 'TSAbstractPropertyDefinition':
     return [
       ...getNamesFromNode(
-        /** @type {import('@typescript-eslint/types').TSESTree.Node} */ (
+        /** @type {import('@typescript-eslint/types/dist').TSESTree.Node} */ (
           node.parent
         ).parent,
       ),
       ...getNamesFromNode(
-        /** @type {import('@typescript-eslint/types').TSESTree.Node} */
+        /** @type {import('@typescript-eslint/types/dist').TSESTree.Node} */
         (node.key),
       ),
     ];
@@ -50,7 +50,7 @@ const getNamesFromNode = (node) => {
   case 'TSInterfaceDeclaration':
   case 'TSTypeAliasDeclaration':
     return getNamesFromNode(
-      /** @type {import('@typescript-eslint/types').TSESTree.ClassDeclaration} */
+      /** @type {import('@typescript-eslint/types/dist').TSESTree.ClassDeclaration} */
       (node).id,
     );
   case 'Identifier':
@@ -59,22 +59,22 @@ const getNamesFromNode = (node) => {
     ];
   case 'Property':
     return getNamesFromNode(
-      /** @type {import('@typescript-eslint/types').TSESTree.Node} */
+      /** @type {import('@typescript-eslint/types/dist').TSESTree.Node} */
       (node.key),
     );
   case 'VariableDeclaration':
     return getNamesFromNode(
-      /** @type {import('@typescript-eslint/types').TSESTree.Node} */
+      /** @type {import('@typescript-eslint/types/dist').TSESTree.Node} */
       (node.declarations[0]),
     );
   case 'VariableDeclarator':
     return [
       ...getNamesFromNode(
-        /** @type {import('@typescript-eslint/types').TSESTree.Node} */
+        /** @type {import('@typescript-eslint/types/dist').TSESTree.Node} */
         (node.id),
       ),
       ...getNamesFromNode(
-        /** @type {import('@typescript-eslint/types').TSESTree.Node} */
+        /** @type {import('@typescript-eslint/types/dist').TSESTree.Node} */
         (node.init),
       ),
     ].filter(Boolean);

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -413,7 +413,7 @@ export default {
       const fix = /** @type {import('eslint').Rule.ReportFixer} */ (fixer) => {
         // Default to one line break if the `minLines`/`maxLines` settings allow
         const lines = settings.minLines === 0 && settings.maxLines >= 1 ? 1 : settings.minLines;
-        /** @type {import('eslint').Rule.Node|import('@typescript-eslint/types').TSESTree.Decorator} */
+        /** @type {import('eslint').Rule.Node|import('@typescript-eslint/types/dist').TSESTree.Decorator} */
         let baseNode = getReducedASTNode(node, sourceCode);
 
         const decorator = getDecorator(baseNode);
@@ -529,8 +529,8 @@ export default {
           ].includes(node.parent.type) &&
             node ===
               /**
-               * @type {import('@typescript-eslint/types').TSESTree.Property|
-               *   import('@typescript-eslint/types').TSESTree.PropertyDefinition
+               * @type {import('@typescript-eslint/types/dist').TSESTree.Property|
+               *   import('@typescript-eslint/types/dist').TSESTree.PropertyDefinition
                * }
                */
               (node.parent).value
@@ -585,8 +585,8 @@ export default {
           ].includes(node.parent.type) &&
             node ===
               /**
-               * @type {import('@typescript-eslint/types').TSESTree.Property|
-               *   import('@typescript-eslint/types').TSESTree.PropertyDefinition
+               * @type {import('@typescript-eslint/types/dist').TSESTree.Property|
+               *   import('@typescript-eslint/types/dist').TSESTree.PropertyDefinition
                * }
                */
               (node.parent).value

--- a/src/utils/hasReturnValue.js
+++ b/src/utils/hasReturnValue.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {import('estree').Node|
- *   import('@typescript-eslint/types').TSESTree.Node} ESTreeOrTypeScriptNode
+ *   import('@typescript-eslint/types/dist').TSESTree.Node} ESTreeOrTypeScriptNode
  */
 
 /**
@@ -19,7 +19,7 @@ const isNewPromiseExpression = (node) => {
  * @returns {boolean}
  */
 const isVoidPromise = (node) => {
-  return /** @type {import('@typescript-eslint/types').TSESTree.TSTypeReference} */ (
+  return /** @type {import('@typescript-eslint/types/dist').TSESTree.TSTypeReference} */ (
     node
   )?.typeParameters?.params?.[0]?.type === 'TSVoidKeyword';
 };
@@ -149,7 +149,7 @@ const allBrancheshaveReturnValues = (node, promFilter) => {
   case 'ArrowFunctionExpression': {
     return 'expression' in node && node.expression && (!isNewPromiseExpression(node.body) || !isVoidPromise(node.body)) ||
       allBrancheshaveReturnValues(node.body, promFilter) ||
-      /** @type {import('@typescript-eslint/types').TSESTree.BlockStatement} */
+      /** @type {import('@typescript-eslint/types/dist').TSESTree.BlockStatement} */
       (node.body).body.some((nde) => {
         return nde.type === 'ReturnStatement';
       });
@@ -164,7 +164,7 @@ const allBrancheshaveReturnValues = (node, promFilter) => {
   case 'DoWhileStatement':
     if (
       /**
-       * @type {import('@typescript-eslint/types').TSESTree.Literal}
+       * @type {import('@typescript-eslint/types/dist').TSESTree.Literal}
        */
       (node.test).value === true
     ) {
@@ -213,7 +213,7 @@ const allBrancheshaveReturnValues = (node, promFilter) => {
   }
 
   case 'SwitchStatement': {
-    return /** @type {import('@typescript-eslint/types').TSESTree.SwitchStatement} */ (node).cases.every(
+    return /** @type {import('@typescript-eslint/types/dist').TSESTree.SwitchStatement} */ (node).cases.every(
       (someCase) => {
         return !someCase.consequent.some((consNode) => {
           return consNode.type === 'BreakStatement' ||
@@ -262,7 +262,7 @@ const allBrancheshaveReturnValues = (node, promFilter) => {
  * This could check for redeclaration of the resolver, but as such is
  * unlikely, we avoid the performance cost of checking everywhere for
  * (re)declarations or assignments.
- * @param {import('@typescript-eslint/types').TSESTree.Node|null|undefined} node
+ * @param {import('@typescript-eslint/types/dist').TSESTree.Node|null|undefined} node
  * @param {string} resolverName
  * @returns {boolean}
  */
@@ -278,7 +278,7 @@ const hasNonEmptyResolverCall = (node, resolverName) => {
   // istanbul ignore next -- In Babel?
   case 'OptionalCallExpression':
   case 'CallExpression':
-    return /** @type {import('@typescript-eslint/types').TSESTree.Identifier} */ (
+    return /** @type {import('@typescript-eslint/types/dist').TSESTree.Identifier} */ (
       node.callee
     ).name === resolverName && (
 
@@ -305,7 +305,7 @@ const hasNonEmptyResolverCall = (node, resolverName) => {
   case 'FunctionDeclaration':
   case 'ArrowFunctionExpression': {
     // Shadowing
-    if (/** @type {import('@typescript-eslint/types').TSESTree.Identifier} */ (
+    if (/** @type {import('@typescript-eslint/types/dist').TSESTree.Identifier} */ (
       node.params[0]
     )?.name === resolverName) {
       return false;
@@ -524,10 +524,10 @@ const hasValueOrExecutorHasNonEmptyResolveValue = (node, anyPromiseAsReturn, all
       body,
     } =
     /**
-     * @type {import('@typescript-eslint/types').TSESTree.FunctionExpression|
-     * import('@typescript-eslint/types').TSESTree.ArrowFunctionExpression}
+     * @type {import('@typescript-eslint/types/dist').TSESTree.FunctionExpression|
+     * import('@typescript-eslint/types/dist').TSESTree.ArrowFunctionExpression}
      */ (
-      /** @type {import('@typescript-eslint/types').TSESTree.NewExpression} */ (
+      /** @type {import('@typescript-eslint/types/dist').TSESTree.NewExpression} */ (
           prom
         ).arguments[0]
       ) || {};
@@ -538,7 +538,7 @@ const hasValueOrExecutorHasNonEmptyResolveValue = (node, anyPromiseAsReturn, all
 
     const {
       name: resolverName,
-    } = /** @type {import('@typescript-eslint/types').TSESTree.Identifier} */ (
+    } = /** @type {import('@typescript-eslint/types/dist').TSESTree.Identifier} */ (
       params[0]
     );
 


### PR DESCRIPTION
## Issue

This pull request addresses the issue of including unused files in the [publish](https://www.npmjs.com/package/eslint-plugin-jsdoc?activeTab=code) process.
ex: `tsconfig.json` and `tsconfig-prod.json`

## Solution

With this pull request, when adding the `src` and `docs` folders to the `files` section in `package.json`, the build process will automatically exclude other unused files. Note that `readme` and `license` files are always included (for documentation purposes please refer to [this link](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#files)).

### Before

![filesbefore](https://github.com/gajus/eslint-plugin-jsdoc/assets/59191719/2b6d2376-9512-4297-beed-3101bb48aebf)

### After

1. run `npm pack`
2. To visually identify which files are packaged, you have two options:
   - Check the log for added files.
   - Extract the tarball to see the files.

![after](https://github.com/gajus/eslint-plugin-jsdoc/assets/59191719/fbcc9ed8-00d4-4886-9b96-e384f8dfca13)


### Additional Comments:

- I had to add the suffix `/dist` to imports requiring `@typescript-eslint/types` because it was being inferred as `any`, leading to lint errors.