### PR TITLE
fix(`require-description-complete-sentence`): allow all inline tags at beginning of sentence

### DIFF
--- a/docs/rules/require-description-complete-sentence.md
+++ b/docs/rules/require-description-complete-sentence.md
@@ -211,7 +211,7 @@ function quux (foo) {
 function quux (foo) {
 
 }
-// Message: Sentences should start with an uppercase character.
+// Message: Sentences must end with a period.
 
 /**
  * Foo.
@@ -816,5 +816,7 @@ function quux () {}
 function quux () {
 
 }
+
+/** @param options {@link RequestOptions} specifying path parameters and query parameters. */
 ````
 

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -25,7 +25,7 @@ const extractParagraphs = (text) => {
 const extractSentences = (text, abbreviationsRegex) => {
   const txt = text
     // Remove all {} tags.
-    .replaceAll(/\{[\s\S]*?\}\s*/gu, '')
+    .replaceAll(/(?<!^)\{[\s\S]*?\}\s*/gu, '')
 
     // Remove custom abbreviations
     .replace(abbreviationsRegex, '');

--- a/test/rules/assertions/requireDescriptionCompleteSentence.js
+++ b/test/rules/assertions/requireDescriptionCompleteSentence.js
@@ -318,16 +318,12 @@ export default {
       errors: [
         {
           line: 3,
-          message: 'Sentences should start with an uppercase character.',
-        },
-        {
-          line: 3,
           message: 'Sentences must end with a period.',
         },
       ],
       output: `
           /**
-           * {@see Foo.bar} Buz.
+           * {@see Foo.bar} buz.
            */
           function quux (foo) {
 
@@ -1574,6 +1570,11 @@ export default {
           function quux () {
 
           }
+      `,
+    },
+    {
+      code: `
+      /** @param options {@link RequestOptions} specifying path parameters and query parameters. */
       `,
     },
   ],


### PR DESCRIPTION
fix(`require-description-complete-sentence`): allow all inline tags at beginning of sentence; fixes #1150