### PR TITLE
fix: fall back to deprecated `getSourceCode()`

### DIFF
--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -694,8 +694,10 @@ const getUtils = (
   indent,
 ) => {
   const ancestors = /** @type {import('eslint').Rule.Node[]} */ (context.getAncestors());
+
+  // istanbul ignore next -- Fallback to deprecated method
   const {
-    sourceCode,
+    sourceCode = context.getSourceCode(),
   } = context;
 
   const utils = /** @type {Utils} */ (getBasicUtils(context, settings));
@@ -2149,8 +2151,9 @@ const iterateAllJsdocs = (iterator, ruleConfig, contexts, additiveCommentContext
    * @returns {void}
    */
   const callIterator = (context, node, jsdocNodes, state, lastCall) => {
+    // istanbul ignore next -- Fallback to deprecated method
     const {
-      sourceCode,
+      sourceCode = context.getSourceCode(),
     } = context;
     const {
       lines,
@@ -2262,8 +2265,9 @@ const iterateAllJsdocs = (iterator, ruleConfig, contexts, additiveCommentContext
   return {
     // @ts-expect-error ESLint accepts
     create (context) {
+      // istanbul ignore next -- Fallback to deprecated method
       const {
-        sourceCode,
+        sourceCode = context.getSourceCode(),
       } = context;
       settings = getSettings(context);
       if (!settings) {
@@ -2340,8 +2344,9 @@ const iterateAllJsdocs = (iterator, ruleConfig, contexts, additiveCommentContext
 const checkFile = (iterator, ruleConfig) => {
   return {
     create (context) {
+      // istanbul ignore next -- Fallback to deprecated method
       const {
-        sourceCode,
+        sourceCode = context.getSourceCode(),
       } = context;
       const settings = getSettings(context);
       if (!settings) {
@@ -2459,8 +2464,9 @@ export default function iterateJsdoc (iterator, ruleConfig) {
         }
       }
 
+      // istanbul ignore next -- Fallback to deprecated method
       const {
-        sourceCode,
+        sourceCode = context.getSourceCode(),
       } = context;
       const {
         lines,

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -288,8 +288,9 @@ const getOptions = (context, settings) => {
 /** @type {import('eslint').Rule.RuleModule} */
 export default {
   create (context) {
+    // istanbul ignore next -- Fallback to deprecated method
     const {
-      sourceCode,
+      sourceCode = context.getSourceCode(),
     } = context;
     const settings = getSettings(context);
     if (!settings) {

--- a/src/rules/requireReturns.js
+++ b/src/rules/requireReturns.js
@@ -104,8 +104,9 @@ export default iterateJsdoc(({
         initModuleExports: Boolean(publicOnly?.cjs ?? true),
         initWindow: Boolean(publicOnly?.window ?? false),
       };
+      // istanbul ignore next -- Fallback to deprecated method
       const {
-        sourceCode,
+        sourceCode = context.getSourceCode(),
       } = context;
       const exported = exportParser.isUncommentedExport(
         /** @type {import('eslint').Rule.Node} */ (node), sourceCode, opt, settings,


### PR DESCRIPTION
fix: fall back to deprecated `getSourceCode()`; fixes #1159