### PR TITLE
fix(`require-param`): skip `this` parameter in checks (when followed by destructured content)

### DIFF
--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -1016,6 +1016,16 @@ export class MyClass {
 export const Comp = observer(() => <>Hello</>);
 // "jsdoc/require-jsdoc": ["error"|"warn", {"contexts":["CallExpression[callee.name=\"observer\"]"],"enableFixer":false,"publicOnly":true,"require":{"ArrowFunctionExpression":true,"ClassDeclaration":true,"ClassExpression":true,"FunctionDeclaration":true,"FunctionExpression":true,"MethodDefinition":true}}]
 // Message: Missing JSDoc comment.
+
+/**
+ * Command options for the login command
+ */
+export type LoginOptions = CmdOptions<{
+  username?: string;
+  password?: string;
+}>;
+// "jsdoc/require-jsdoc": ["error"|"warn", {"publicOnly":{"ancestorsOnly":true},"contexts":["TSTypeAliasDeclaration","TSInterfaceDeclaration","TSMethodSignature","TSPropertySignature"]}]
+// Message: Missing JSDoc comment.
 ````
 
 

--- a/docs/rules/require-param.md
+++ b/docs/rules/require-param.md
@@ -1832,5 +1832,16 @@ function foo(this: T, bar: number): number {
 /** {@link someOtherval} */
 function a (b) {}
 // "jsdoc/require-param": ["error"|"warn", {"contexts":[{"comment":"*:not(JsdocBlock:has(JsdocInlineTag[tag=link]))","context":"FunctionDeclaration"}]}]
+
+/**
+ * Returns the sum of two numbers
+ * @param options Object to destructure
+ * @param options.a First value
+ * @param options.b Second value
+ * @returns Sum of a and b
+ */
+function sumDestructure(this: unknown, { a, b }: { a: number, b: number }) {
+  return a + b;
+}
 ````
 

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -214,14 +214,16 @@ export default iterateJsdoc(({
     ...unnamedRootBase,
   ], autoIncrementBase);
 
+  const thisOffset = functionParameterNames[0] === 'this' ? 1 : 0;
+
   for (const [
     functionParameterIdx,
     functionParameterName,
   ] of functionParameterNames.entries()) {
     let inc;
     if (Array.isArray(functionParameterName)) {
-      const matchedJsdoc = shallowJsdocParameterNames[functionParameterIdx] ||
-        jsdocParameterNames[functionParameterIdx];
+      const matchedJsdoc = shallowJsdocParameterNames[functionParameterIdx - thisOffset] ||
+        jsdocParameterNames[functionParameterIdx - thisOffset];
 
       /** @type {string} */
       let rootName;

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -3640,5 +3640,22 @@ export default {
         },
       ],
     },
+    {
+      code: `
+        /**
+         * Returns the sum of two numbers
+         * @param options Object to destructure
+         * @param options.a First value
+         * @param options.b Second value
+         * @returns Sum of a and b
+         */
+        function sumDestructure(this: unknown, { a, b }: { a: number, b: number }) {
+          return a + b;
+        }
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+    },
   ],
 };


### PR DESCRIPTION
fix(`require-param`): skip `this` parameter in checks (when followed by destructured content); fixes #1190