### PR TITLE
fix(`require-description-complete-sentence`): capture multiple newlines as "paragraphs"

### DIFF
--- a/docs/rules/require-description-complete-sentence.md
+++ b/docs/rules/require-description-complete-sentence.md
@@ -818,5 +818,16 @@ function quux () {
 }
 
 /** @param options {@link RequestOptions} specifying path parameters and query parameters. */
+
+/**
+ * A single line for testing.
+ *
+ * ```js
+ * const aCodeExample = true;
+ * ```
+ *
+ * @param parameter
+ */
+const code = (parameter) => 123;
 ````
 

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -14,7 +14,7 @@ const otherDescriptiveTags = new Set([
  * @returns {string[]}
  */
 const extractParagraphs = (text) => {
-  return text.split(/(?<![;:])\n\n/u);
+  return text.split(/(?<![;:])\n\n+/u);
 };
 
 /**

--- a/test/rules/assertions/requireDescriptionCompleteSentence.js
+++ b/test/rules/assertions/requireDescriptionCompleteSentence.js
@@ -1577,5 +1577,19 @@ export default {
       /** @param options {@link RequestOptions} specifying path parameters and query parameters. */
       `,
     },
+    {
+      code: `
+        /**
+         * A single line for testing.
+         *
+         * \`\`\`js
+         * const aCodeExample = true;
+         * \`\`\`
+         *
+         * @param parameter
+         */
+        const code = (parameter) => 123;
+      `,
+    },
   ],
 };


### PR DESCRIPTION
fix(`require-description-complete-sentence`): capture multiple newlines as "paragraphs"; fixes #1193