### PR TITLE
fix(informative-docs): Improve wording in rule description

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -238,7 +238,7 @@ non-default-recommended fixer).
 |:heavy_check_mark:||[check-values](./docs/rules/check-values.md#readme)|Checks for expected content within some miscellaneous tags (`@version`, `@since`, `@license`, `@author`)|
 |:heavy_check_mark:|:wrench:|[empty-tags](./docs/rules/empty-tags.md#readme)|Checks tags that are expected to be empty (e.g., `@abstract` or `@async`), reporting if they have content|
 |:heavy_check_mark:||[implements-on-classes](./docs/rules/implements-on-classes.md#readme)|Prohibits use of `@implements` on non-constructor functions (to enforce the tag only being used on classes/constructors)|
-|||[informative-docs](./docs/rules/informative-docs.md#readme)|Reports on JSDoc texts that serve only to restart their attached name.|
+|||[informative-docs](./docs/rules/informative-docs.md#readme)|Reports on JSDoc texts that serve only to restate their attached name.|
 |||[match-description](./docs/rules/match-description.md#readme)|Defines customizable regular expression rules for your tag descriptions|
 ||:wrench:|[match-name](./docs/rules/match-name.md#readme)|Reports the name portion of a JSDoc tag if matching or not matching a given regular expression|
 |:heavy_check_mark:|:wrench:|[multiline-blocks](./docs/rules/multiline-blocks.md#readme)|Controls how and whether jsdoc blocks can be expressed as single or multiple line blocks|

--- a/.README/rules/informative-docs.md
+++ b/.README/rules/informative-docs.md
@@ -2,7 +2,7 @@
 
 {"gitdown": "contents", "rootId": "informative-docs"}
 
-Reports on JSDoc texts that serve only to restart their attached name.
+Reports on JSDoc texts that serve only to restate their attached name.
 
 Devs sometimes write JSDoc descriptions that add no additional information just to fill out the doc:
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ non-default-recommended fixer).
 |:heavy_check_mark:||[check-values](./docs/rules/check-values.md#readme)|Checks for expected content within some miscellaneous tags (`@version`, `@since`, `@license`, `@author`)|
 |:heavy_check_mark:|:wrench:|[empty-tags](./docs/rules/empty-tags.md#readme)|Checks tags that are expected to be empty (e.g., `@abstract` or `@async`), reporting if they have content|
 |:heavy_check_mark:||[implements-on-classes](./docs/rules/implements-on-classes.md#readme)|Prohibits use of `@implements` on non-constructor functions (to enforce the tag only being used on classes/constructors)|
-|||[informative-docs](./docs/rules/informative-docs.md#readme)|Reports on JSDoc texts that serve only to restart their attached name.|
+|||[informative-docs](./docs/rules/informative-docs.md#readme)|Reports on JSDoc texts that serve only to restate their attached name.|
 |||[match-description](./docs/rules/match-description.md#readme)|Defines customizable regular expression rules for your tag descriptions|
 ||:wrench:|[match-name](./docs/rules/match-name.md#readme)|Reports the name portion of a JSDoc tag if matching or not matching a given regular expression|
 |:heavy_check_mark:|:wrench:|[multiline-blocks](./docs/rules/multiline-blocks.md#readme)|Controls how and whether jsdoc blocks can be expressed as single or multiple line blocks|

--- a/docs/rules/informative-docs.md
+++ b/docs/rules/informative-docs.md
@@ -10,7 +10,7 @@
 * [Passing examples](#user-content-informative-docs-passing-examples)
 
 
-Reports on JSDoc texts that serve only to restart their attached name.
+Reports on JSDoc texts that serve only to restate their attached name.
 
 Devs sometimes write JSDoc descriptions that add no additional information just to fill out the doc:
 


### PR DESCRIPTION
"Restart" doesn't make sense here, I'm pretty sure ["restate"](https://www.merriam-webster.com/dictionary/restate) fits the intended meaning better.