### PR TITLE
feat(check-param-names): Add disableMissingParamChecks option

### DIFF
--- a/.README/rules/check-param-names.md
+++ b/.README/rules/check-param-names.md
@@ -83,7 +83,7 @@ that are available and actually used in the function.
 
 ### `disableMissingParamChecks`
 
-Whether to check for missing `@param` definitions. Defaults to `false`. Change to `true` if you want to be able to omit properties.
+Whether to avoid checks for missing `@param` definitions. Defaults to `false`. Change to `true` if you want to be able to omit properties.
 
 ## Context and settings
 

--- a/.README/rules/check-param-names.md
+++ b/.README/rules/check-param-names.md
@@ -81,12 +81,16 @@ item at the same level is destructured as destructuring will prevent other
 access and this option is only intended to permit documenting extra properties
 that are available and actually used in the function.
 
+### `disableMissingParamChecks`
+
+Whether to check for missing `@param` definitions. Defaults to `false`. Change to `true` if you want to be able to omit properties.
+
 ## Context and settings
 
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
-|Options|`allowExtraTrailingParamDocs`, `checkDestructured`, `checkRestProperty`, `checkTypesPattern`, `disableExtraPropertyReporting`, `enableFixer`, `useDefaultObjectProperties`|
+|Options|`allowExtraTrailingParamDocs`, `checkDestructured`, `checkRestProperty`, `checkTypesPattern`, `disableExtraPropertyReporting`, `disableMissingParamChecks`, `enableFixer`, `useDefaultObjectProperties`|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
 |Recommended|true|

--- a/docs/rules/check-param-names.md
+++ b/docs/rules/check-param-names.md
@@ -116,6 +116,12 @@ item at the same level is destructured as destructuring will prevent other
 access and this option is only intended to permit documenting extra properties
 that are available and actually used in the function.
 
+<a name="user-content-check-param-names-options-disableMissingParamChecks"></a>
+<a name="check-param-names-options-disableMissingParamChecks"></a>
+### <code>disableMissingParamChecks</code>
+
+Whether to check for missing `@param` definitions. Defaults to `false`. Change to `true` if you want to be able to omit properties.
+
 <a name="user-content-check-param-names-context-and-settings"></a>
 <a name="check-param-names-context-and-settings"></a>
 ## Context and settings
@@ -123,7 +129,7 @@ that are available and actually used in the function.
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
-|Options|`allowExtraTrailingParamDocs`, `checkDestructured`, `checkRestProperty`, `checkTypesPattern`, `disableExtraPropertyReporting`, `enableFixer`, `useDefaultObjectProperties`|
+|Options|`allowExtraTrailingParamDocs`, `checkDestructured`, `checkRestProperty`, `checkTypesPattern`, `disableExtraPropertyReporting`, `disableMissingParamChecks`, `enableFixer`, `useDefaultObjectProperties`|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
 |Recommended|true|

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -227,7 +227,7 @@ const validateParameterNames = (
       funcParamName = functionParameterName;
     }
 
-    if (funcParamName !== tag.name.trim() && !disableMissingParamChecks) {
+    if (funcParamName !== tag.name.trim()) {
       // Todo: Improve for array or object child items
       const actualNames = paramTagsNonNested.map(([
         , {
@@ -247,10 +247,20 @@ const validateParameterNames = (
         return item;
       }).filter((item) => {
         return item !== 'this';
-      }).join(', ');
+      });
+
+      // When disableMissingParamChecks is true tag names can be omitted.
+      // Report when the tag names do not match the expected names or they are used out of order.
+      if (disableMissingParamChecks) {
+        const usedExpectedNames = expectedNames.map(a => a?.toString()).filter(expectedName => !!expectedName && actualNames.includes(expectedName));
+        const usedInOrder = actualNames.every((actualName, idx) => actualName === usedExpectedNames[idx]);
+        if (usedInOrder) {
+          return false;
+        }
+      }
 
       report(
-        `Expected @${targetTagName} names to be "${expectedNames}". Got "${actualNames.join(', ')}".`,
+        `Expected @${targetTagName} names to be "${expectedNames.join(', ')}". Got "${actualNames.join(', ')}".`,
         null,
         tag,
       );

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -252,7 +252,7 @@ const validateParameterNames = (
       // When disableMissingParamChecks is true tag names can be omitted.
       // Report when the tag names do not match the expected names or they are used out of order.
       if (disableMissingParamChecks) {
-        const usedExpectedNames = expectedNames.map(a => a?.toString()).filter(expectedName => Boolean(expectedName) && actualNames.includes(expectedName));
+        const usedExpectedNames = expectedNames.map(a => a?.toString()).filter(expectedName => expectedName && actualNames.includes(expectedName));
         const usedInOrder = actualNames.every((actualName, idx) => actualName === usedExpectedNames[idx]);
         if (usedInOrder) {
           return false;

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -252,7 +252,7 @@ const validateParameterNames = (
       // When disableMissingParamChecks is true tag names can be omitted.
       // Report when the tag names do not match the expected names or they are used out of order.
       if (disableMissingParamChecks) {
-        const usedExpectedNames = expectedNames.map(a => a?.toString()).filter(expectedName => !!expectedName && actualNames.includes(expectedName));
+        const usedExpectedNames = expectedNames.map(a => a?.toString()).filter(expectedName => Boolean(expectedName) && actualNames.includes(expectedName));
         const usedInOrder = actualNames.every((actualName, idx) => actualName === usedExpectedNames[idx]);
         if (usedInOrder) {
           return false;

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -7,6 +7,7 @@ import iterateJsdoc from '../iterateJsdoc.js';
  * @param {boolean} checkRestProperty
  * @param {RegExp} checkTypesRegex
  * @param {boolean} disableExtraPropertyReporting
+ * @param {boolean} disableMissingParamChecks
  * @param {boolean} enableFixer
  * @param {import('../jsdocUtils.js').ParamNameInfo[]} functionParameterNames
  * @param {import('comment-parser').Block} jsdoc
@@ -21,6 +22,7 @@ const validateParameterNames = (
   checkRestProperty,
   checkTypesRegex,
   disableExtraPropertyReporting,
+  disableMissingParamChecks,
   enableFixer,
   functionParameterNames, jsdoc, utils, report,
 ) => {
@@ -225,7 +227,7 @@ const validateParameterNames = (
       funcParamName = functionParameterName;
     }
 
-    if (funcParamName !== tag.name.trim()) {
+    if (funcParamName !== tag.name.trim() && !disableMissingParamChecks) {
       // Todo: Improve for array or object child items
       const actualNames = paramTagsNonNested.map(([
         , {
@@ -329,6 +331,7 @@ export default iterateJsdoc(({
     enableFixer = false,
     useDefaultObjectProperties = false,
     disableExtraPropertyReporting = false,
+    disableMissingParamChecks = false,
   } = context.options[0] || {};
 
   const checkTypesRegex = utils.getRegexFromString(checkTypesPattern);
@@ -349,6 +352,7 @@ export default iterateJsdoc(({
     checkRestProperty,
     checkTypesRegex,
     disableExtraPropertyReporting,
+    disableMissingParamChecks,
     enableFixer,
     functionParameterNames,
     jsdoc,
@@ -387,6 +391,9 @@ export default iterateJsdoc(({
             type: 'string',
           },
           disableExtraPropertyReporting: {
+            type: 'boolean',
+          },
+          disableMissingParamChecks: {
             type: 'boolean',
           },
           enableFixer: {

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -1244,7 +1244,28 @@ export default {
           message: 'Expected @param names to be "foo, bar". Got "bar, foo".',
         },
       ],
-    }
+    },
+    {
+      code: `
+        /**
+         * @param foo
+         * @param bar
+         */
+        function quux (foo) {
+        }
+      `,
+      options: [
+        {
+          disableMissingParamChecks: true,
+        },
+      ],
+      errors: [
+        {
+          line: 4,
+          message: '@param "bar" does not match an existing function parameter.',
+        },
+      ],
+    },
   ],
   valid: [
     {
@@ -1900,10 +1921,9 @@ export default {
     {
       code: `
         /**
-         * @param foo
-         * @param foo.bar
+         * Documentation
          */
-        function quux (bar, foo) {
+        function quux (foo, bar) {
         }
       `,
       options: [
@@ -1911,6 +1931,21 @@ export default {
           disableMissingParamChecks: true,
         },
       ],
-    }
+    },
+    {
+      code: `
+        /**
+         * @param bar
+         * @param bar.baz
+         */
+        function quux (foo, bar) {
+        }
+      `,
+      options: [
+        {
+          disableMissingParamChecks: true,
+        },
+      ],
+    },
   ],
 };

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -1947,5 +1947,19 @@ export default {
         },
       ],
     },
+    {
+      code: `
+        /**
+         * @param foo
+         */
+        function quux (foo, bar) {
+        }
+      `,
+      options: [
+        {
+          disableMissingParamChecks: true,
+        },
+      ],
+    },
   ],
 };

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -1203,6 +1203,47 @@ export default {
           message: 'Expected @param names to be "bar, foo". Got "foo".',
         },
       ],
+    },
+    {
+      code: `
+        /**
+         * @param foo
+         */
+        function quux (bar, baz) {
+        }
+      `,
+      options: [
+        {
+          disableMissingParamChecks: true,
+        },
+      ],
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @param names to be "bar, baz". Got "foo".',
+        },
+      ],
+    },
+    {
+      code: `
+        /**
+         * @param bar
+         * @param foo
+         */
+        function quux (foo, bar) {
+        }
+      `,
+      options: [
+        {
+          disableMissingParamChecks: true,
+        },
+      ],
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @param names to be "foo, bar". Got "bar, foo".',
+        },
+      ],
     }
   ],
   valid: [

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -1183,6 +1183,27 @@ export default {
         parser: typescriptEslintParser
       },
     },
+    {
+      code: `
+        /**
+         * @param foo
+         * @param foo.bar
+         */
+        function quux (bar, foo) {
+        }
+      `,
+      options: [
+        {
+          disableMissingParamChecks: false,
+        },
+      ],
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @param names to be "bar, foo". Got "foo".',
+        },
+      ],
+    }
   ],
   valid: [
     {
@@ -1835,5 +1856,20 @@ export default {
         parser: typescriptEslintParser
       },
     },
+    {
+      code: `
+        /**
+         * @param foo
+         * @param foo.bar
+         */
+        function quux (bar, foo) {
+        }
+      `,
+      options: [
+        {
+          disableMissingParamChecks: true,
+        },
+      ],
+    }
   ],
 };

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -292,6 +292,7 @@ export default {
       `,
       errors: [
         {
+          line: 2,
           message: 'Missing JSDoc @param "options.foo" declaration.',
         },
       ],
@@ -1783,6 +1784,7 @@ export default {
       `,
       errors: [
         {
+          line: 2,
           message: 'Missing JSDoc @param "options.foo" declaration.',
         },
       ],
@@ -1828,6 +1830,7 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Missing JSDoc @param "options.permissions" declaration.',
         },
       ],
@@ -1943,6 +1946,7 @@ export default {
       `,
       errors: [
         {
+          line: 2,
           message: 'Missing JSDoc @param "cfg.extra" declaration.',
         },
       ],
@@ -1976,6 +1980,7 @@ export default {
       `,
       errors: [
         {
+          line: 2,
           message: 'Missing JSDoc @param "cfg.opts.extra" declaration.',
         },
       ],
@@ -2010,6 +2015,7 @@ export default {
       `,
       errors: [
         {
+          line: 2,
           message: 'Missing JSDoc @param "cfg."1"" declaration.',
         },
       ],
@@ -2067,15 +2073,19 @@ export default {
       `,
       errors: [
         {
+          line: 2,
           message: 'Missing JSDoc @param "bbox.x" declaration.',
         },
         {
+          line: 2,
           message: 'Missing JSDoc @param "bbox.y" declaration.',
         },
         {
+          line: 2,
           message: 'Missing JSDoc @param "bbox.width" declaration.',
         },
         {
+          line: 2,
           message: 'Missing JSDoc @param "bbox.height" declaration.',
         },
       ],
@@ -2110,15 +2120,19 @@ export default {
       `,
       errors: [
         {
+          line: 2,
           message: 'Missing JSDoc @param "bbox.x" declaration.',
         },
         {
+          line: 2,
           message: 'Missing JSDoc @param "bbox.y" declaration.',
         },
         {
+          line: 2,
           message: 'Missing JSDoc @param "bbox.width" declaration.',
         },
         {
+          line: 2,
           message: 'Missing JSDoc @param "bbox.height" declaration.',
         },
       ],
@@ -2149,9 +2163,11 @@ export default {
       `,
       errors: [
         {
+          line: 3,
           message: 'Missing JSDoc @param "fetchOptions.url" declaration.',
         },
         {
+          line: 3,
           message: 'Missing JSDoc @param "fetchOptions.options" declaration.',
         },
       ],
@@ -2218,6 +2234,7 @@ export default {
       `,
       errors: [
         {
+          line: 2,
           message: 'Missing JSDoc @param "options.foo.bar" declaration.',
         },
       ],
@@ -2242,6 +2259,7 @@ export default {
       `,
       errors: [
         {
+          line: 2,
           message: 'Missing JSDoc @param "options.foo.bar" declaration.',
         },
       ],
@@ -2271,9 +2289,11 @@ export default {
       `,
       errors: [
         {
+          line: 2,
           message: 'Missing JSDoc @param "options.foo" declaration.',
         },
         {
+          line: 2,
           message: 'Missing JSDoc @param "options.foo.bar" declaration.',
         },
       ],
@@ -2299,6 +2319,7 @@ export default {
       `,
       errors: [
         {
+          line: 2,
           message: 'Missing JSDoc @param "options.foo.bar" declaration.',
         },
       ],
@@ -2324,6 +2345,7 @@ export default {
       `,
       errors: [
         {
+          line: 2,
           message: 'Missing JSDoc @param "options.foo.bar.baz" declaration.',
         },
       ],
@@ -2351,9 +2373,11 @@ export default {
       `,
       errors: [
         {
+          line: 2,
           message: 'Missing JSDoc @param "props.prop.a" declaration.',
         },
         {
+          line: 2,
           message: 'Missing JSDoc @param "props.prop.b" declaration.',
         },
       ],
@@ -2385,12 +2409,15 @@ export default {
       `,
       errors: [
         {
+          line: 2,
           message: 'Missing JSDoc @param "a" declaration.',
         },
         {
+          line: 2,
           message: 'Missing JSDoc @param "b" declaration.',
         },
         {
+          line: 2,
           message: 'Missing JSDoc @param "c" declaration.',
         },
       ],
@@ -2414,6 +2441,7 @@ export default {
       `,
       errors: [
         {
+          line: 2,
           message: 'Missing JSDoc @param "baz" declaration.',
         },
       ],
@@ -2455,6 +2483,7 @@ export default {
       `,
       errors: [
         {
+          line: 2,
           message: 'Missing JSDoc @param "verbose" declaration.',
         },
       ],
@@ -2502,6 +2531,7 @@ export default {
       `,
       errors: [
         {
+          line: 6,
           message: 'Missing JSDoc @param "btnState" declaration.',
         },
       ],

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -292,7 +292,6 @@ export default {
       `,
       errors: [
         {
-          line: 2,
           message: 'Missing JSDoc @param "options.foo" declaration.',
         },
       ],
@@ -1784,7 +1783,6 @@ export default {
       `,
       errors: [
         {
-          line: 2,
           message: 'Missing JSDoc @param "options.foo" declaration.',
         },
       ],
@@ -1830,7 +1828,6 @@ export default {
       `,
       errors: [
         {
-          line: 3,
           message: 'Missing JSDoc @param "options.permissions" declaration.',
         },
       ],
@@ -1946,7 +1943,6 @@ export default {
       `,
       errors: [
         {
-          line: 2,
           message: 'Missing JSDoc @param "cfg.extra" declaration.',
         },
       ],
@@ -1980,7 +1976,6 @@ export default {
       `,
       errors: [
         {
-          line: 2,
           message: 'Missing JSDoc @param "cfg.opts.extra" declaration.',
         },
       ],
@@ -2015,7 +2010,6 @@ export default {
       `,
       errors: [
         {
-          line: 2,
           message: 'Missing JSDoc @param "cfg."1"" declaration.',
         },
       ],
@@ -2073,19 +2067,15 @@ export default {
       `,
       errors: [
         {
-          line: 2,
           message: 'Missing JSDoc @param "bbox.x" declaration.',
         },
         {
-          line: 2,
           message: 'Missing JSDoc @param "bbox.y" declaration.',
         },
         {
-          line: 2,
           message: 'Missing JSDoc @param "bbox.width" declaration.',
         },
         {
-          line: 2,
           message: 'Missing JSDoc @param "bbox.height" declaration.',
         },
       ],
@@ -2120,19 +2110,15 @@ export default {
       `,
       errors: [
         {
-          line: 2,
           message: 'Missing JSDoc @param "bbox.x" declaration.',
         },
         {
-          line: 2,
           message: 'Missing JSDoc @param "bbox.y" declaration.',
         },
         {
-          line: 2,
           message: 'Missing JSDoc @param "bbox.width" declaration.',
         },
         {
-          line: 2,
           message: 'Missing JSDoc @param "bbox.height" declaration.',
         },
       ],
@@ -2163,11 +2149,9 @@ export default {
       `,
       errors: [
         {
-          line: 3,
           message: 'Missing JSDoc @param "fetchOptions.url" declaration.',
         },
         {
-          line: 3,
           message: 'Missing JSDoc @param "fetchOptions.options" declaration.',
         },
       ],
@@ -2234,7 +2218,6 @@ export default {
       `,
       errors: [
         {
-          line: 2,
           message: 'Missing JSDoc @param "options.foo.bar" declaration.',
         },
       ],
@@ -2259,7 +2242,6 @@ export default {
       `,
       errors: [
         {
-          line: 2,
           message: 'Missing JSDoc @param "options.foo.bar" declaration.',
         },
       ],
@@ -2289,11 +2271,9 @@ export default {
       `,
       errors: [
         {
-          line: 2,
           message: 'Missing JSDoc @param "options.foo" declaration.',
         },
         {
-          line: 2,
           message: 'Missing JSDoc @param "options.foo.bar" declaration.',
         },
       ],
@@ -2319,7 +2299,6 @@ export default {
       `,
       errors: [
         {
-          line: 2,
           message: 'Missing JSDoc @param "options.foo.bar" declaration.',
         },
       ],
@@ -2345,7 +2324,6 @@ export default {
       `,
       errors: [
         {
-          line: 2,
           message: 'Missing JSDoc @param "options.foo.bar.baz" declaration.',
         },
       ],
@@ -2373,11 +2351,9 @@ export default {
       `,
       errors: [
         {
-          line: 2,
           message: 'Missing JSDoc @param "props.prop.a" declaration.',
         },
         {
-          line: 2,
           message: 'Missing JSDoc @param "props.prop.b" declaration.',
         },
       ],
@@ -2409,15 +2385,12 @@ export default {
       `,
       errors: [
         {
-          line: 2,
           message: 'Missing JSDoc @param "a" declaration.',
         },
         {
-          line: 2,
           message: 'Missing JSDoc @param "b" declaration.',
         },
         {
-          line: 2,
           message: 'Missing JSDoc @param "c" declaration.',
         },
       ],
@@ -2441,7 +2414,6 @@ export default {
       `,
       errors: [
         {
-          line: 2,
           message: 'Missing JSDoc @param "baz" declaration.',
         },
       ],
@@ -2483,7 +2455,6 @@ export default {
       `,
       errors: [
         {
-          line: 2,
           message: 'Missing JSDoc @param "verbose" declaration.',
         },
       ],
@@ -2531,7 +2502,6 @@ export default {
       `,
       errors: [
         {
-          line: 6,
           message: 'Missing JSDoc @param "btnState" declaration.',
         },
       ],


### PR DESCRIPTION
### Proposed Changes

- feat(check-param-names): Add disableMissingParamChecks option
- test(require-param): Add missing line numbers in errors<br>
  This ~suppressed~ fixes the output like this:
  ```
  Rule, `require-param`, missing line numbers in errors: 21
  ```

### Things to Note

- This PR closes #1169.
- I believe the tests cases should give us confidence in the behaviour when the option is not provided, and when it is set. Did you want test cases for other languageOptions?
- I haven't been able to run `create-docs` locally :thinking: 

