### PR TITLE
fix(`require-jsdoc`): avoid erring on #-marked private methods

### DIFF
--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -1898,5 +1898,12 @@ export default {
   }
 };
 // "jsdoc/require-jsdoc": ["error"|"warn", {"contexts":["ExportDefaultDeclaration > ObjectExpression > Property[key.name!=/^(created|beforeUpdate)$/] > FunctionExpression","ExportDefaultDeclaration > ObjectExpression > Property[key.name!=/^(watch|computed|methods)$/] > ObjectExpression > Property > FunctionExpression"]}]
+
+export class MyClass {
+  #myPrivateMethod(): void { }
+
+  #myPrivateProp = 5;
+}
+// "jsdoc/require-jsdoc": ["error"|"warn", {"publicOnly":true,"contexts":["PropertyDefinition"],"require":{"MethodDefinition":true}}]
 ````
 

--- a/src/exportParser.js
+++ b/src/exportParser.js
@@ -899,9 +899,14 @@ const accessibilityNodes = new Set([
  * @param {import('eslint').Rule.Node} node
  * @returns {boolean}
  */
-const hasAccessibility = (node) => {
-  return accessibilityNodes.has(node.type) && 'accessibility' in node &&
-    node.accessibility !== 'public' && node.accessibility !== undefined;
+const isPrivate = (node) => {
+  return accessibilityNodes.has(node.type) &&
+    (
+      'accessibility' in node &&
+      node.accessibility !== 'public' && node.accessibility !== undefined
+    ) ||
+  'key' in node &&
+    node.key.type === 'PrivateIdentifier';
 };
 
 /**
@@ -916,8 +921,8 @@ const isUncommentedExport = function (node, sourceCode, opt, settings) {
   // console.log({node});
   // Optimize with ancestor check for esm
   if (opt.esm) {
-    if (hasAccessibility(node) ||
-      node.parent && hasAccessibility(node.parent)) {
+    if (isPrivate(node) ||
+      node.parent && isPrivate(node.parent)) {
       return false;
     }
 

--- a/test/rules/assertions/requireJsdoc.js
+++ b/test/rules/assertions/requireJsdoc.js
@@ -6342,5 +6342,26 @@ function quux (foo) {
         parser: typescriptEslintParser,
       }
     },
+    {
+      code: `
+        export class MyClass {
+          #myPrivateMethod(): void { }
+
+          #myPrivateProp = 5;
+        }
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      options: [
+        {
+          publicOnly: true,
+          contexts: ['PropertyDefinition'],
+          require: {
+            MethodDefinition: true,
+          },
+        },
+      ],
+    },
   ],
 };


### PR DESCRIPTION
fix(`require-jsdoc`): avoid erring on #-marked private methods; fixes #1212