### PR TITLE
fix(`valid-types`): whitelist pratt parser keywords

### DIFF
--- a/docs/rules/check-tag-names.md
+++ b/docs/rules/check-tag-names.md
@@ -722,7 +722,7 @@ function quux (foo) {}
  */
 function quux (foo) {}
 // Settings: {"jsdoc":{"mode":"jsdoc"}}
-// Message: Invalid JSDoc tag name "internal".
+// Message: Invalid JSDoc tag name "import".
 
 /** 
  * @externs

--- a/docs/rules/valid-types.md
+++ b/docs/rules/valid-types.md
@@ -877,5 +877,15 @@ function quux() {
 /**
  * An inline {@link text} tag with content.
  */
+
+/**
+ * @param typeof
+ * @param readonly
+ * @param import
+ * @param is
+ */
+function quux() {
+
+}
 ````
 

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -10,6 +10,13 @@ const inlineTags = new Set([
   'tutorial',
 ]);
 
+const jsdocTypePrattKeywords = new Set([
+  'typeof',
+  'readonly',
+  'import',
+  'is',
+]);
+
 const asExpression = /as\s+/u;
 
 const suppressTypes = new Set([
@@ -107,7 +114,10 @@ export default iterateJsdoc(({
      * @returns {boolean}
      */
     const validNamepathParsing = function (namepath, tagName) {
-      if (tryParsePathIgnoreError(namepath)) {
+      if (
+        tryParsePathIgnoreError(namepath) ||
+        jsdocTypePrattKeywords.has(namepath)
+      ) {
         return true;
       }
 

--- a/test/rules/assertions/validTypes.js
+++ b/test/rules/assertions/validTypes.js
@@ -1856,5 +1856,18 @@ export default {
        */
       `,
     },
+    {
+      code: `
+          /**
+           * @param typeof
+           * @param readonly
+           * @param import
+           * @param is
+           */
+          function quux() {
+
+          }
+      `
+    },
   ],
 };


### PR DESCRIPTION
fix(`valid-types`): whitelist pratt parser keywords; fixes #1221