### PR TITLE
fix(`valid-types`): disable checking of types/names within `import` tags

### DIFF
--- a/docs/rules/valid-types.md
+++ b/docs/rules/valid-types.md
@@ -880,5 +880,9 @@ function quux() {
 function quux() {
 
 }
+
+/**
+ * @import { TestOne, TestTwo } from "./types"
+ */
 ````
 

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -212,6 +212,12 @@ export default iterateJsdoc(({
       continue;
     }
 
+    if (tag.tag === 'import') {
+      // A named import will look like a type, but not be valid; we also don't
+      //  need to check the name/namepath
+      continue;
+    }
+
     if (tag.tag === 'borrows') {
       const thisNamepath = /** @type {string} */ (
         utils.getTagDescription(tag)

--- a/test/rules/assertions/validTypes.js
+++ b/test/rules/assertions/validTypes.js
@@ -1853,5 +1853,12 @@ export default {
           }
       `
     },
+    {
+      code: `
+        /**
+         * @import { TestOne, TestTwo } from "./types"
+         */
+      `,
+    }
   ],
 };


### PR DESCRIPTION
fix(`valid-types`): disable checking of types/names within `import` tags; fixes #1226