### PR TITLE
Deprecated `typeParameters`

### DIFF
--- a/src/utils/hasReturnValue.js
+++ b/src/utils/hasReturnValue.js
@@ -20,7 +20,7 @@ const isNewPromiseExpression = (node) => {
  */
 const isVoidPromise = (node) => {
   if ( ! node ) {
-    retun false;
+    return false;
   }
   
   const typeArguments = node.typeArguments || node.typeParameters;

--- a/src/utils/hasReturnValue.js
+++ b/src/utils/hasReturnValue.js
@@ -19,14 +19,8 @@ const isNewPromiseExpression = (node) => {
  * @returns {boolean}
  */
 const isVoidPromise = (node) => {
-  if ( ! node ) {
-    return false;
-  }
-
-  /** @type {import('@typescript-eslint/types').TSESTree.TSTypeReference} */
-  const typeArguments = node.typeArguments || node.typeParameters;
-  
-  return typeArguments?.params?.[0]?.type === 'TSVoidKeyword';
+  return /** @type {import('@typescript-eslint/types').TSESTree.TSTypeReference} */ (node)?.typeArguments?.params?.[0]?.type === 'TSVoidKeyword'
+    || /** @type {import('@typescript-eslint/types').TSESTree.TSTypeReference} */ (node)?.typeParameters?.params?.[0]?.type === 'TSVoidKeyword';
 };
 
 const undefinedKeywords = new Set([

--- a/src/utils/hasReturnValue.js
+++ b/src/utils/hasReturnValue.js
@@ -19,9 +19,9 @@ const isNewPromiseExpression = (node) => {
  * @returns {boolean}
  */
 const isVoidPromise = (node) => {
-  const arguments = node.typeArguments || node.typeParameters;
+  const typeArguments = node.typeArguments || node.typeParameters;
   return /** @type {import('@typescript-eslint/types').TSESTree.TSTypeReference} */
-    arguments?.params?.[0]?.type === 'TSVoidKeyword';
+    typeArguments?.params?.[0]?.type === 'TSVoidKeyword';
 };
 
 const undefinedKeywords = new Set([

--- a/src/utils/hasReturnValue.js
+++ b/src/utils/hasReturnValue.js
@@ -22,10 +22,11 @@ const isVoidPromise = (node) => {
   if ( ! node ) {
     return false;
   }
-  
+
+  /** @type {import('@typescript-eslint/types').TSESTree.TSTypeReference} */
   const typeArguments = node.typeArguments || node.typeParameters;
-  return /** @type {import('@typescript-eslint/types').TSESTree.TSTypeReference} */
-    typeArguments?.params?.[0]?.type === 'TSVoidKeyword';
+  
+  return typeArguments?.params?.[0]?.type === 'TSVoidKeyword';
 };
 
 const undefinedKeywords = new Set([

--- a/src/utils/hasReturnValue.js
+++ b/src/utils/hasReturnValue.js
@@ -19,9 +19,9 @@ const isNewPromiseExpression = (node) => {
  * @returns {boolean}
  */
 const isVoidPromise = (node) => {
-  return /** @type {import('@typescript-eslint/types').TSESTree.TSTypeReference} */ (
-    node
-  )?.typeParameters?.params?.[0]?.type === 'TSVoidKeyword';
+  const arguments = node.typeArguments || node.typeParameters;
+  return /** @type {import('@typescript-eslint/types').TSESTree.TSTypeReference} */
+    arguments?.params?.[0]?.type === 'TSVoidKeyword';
 };
 
 const undefinedKeywords = new Set([

--- a/src/utils/hasReturnValue.js
+++ b/src/utils/hasReturnValue.js
@@ -19,6 +19,10 @@ const isNewPromiseExpression = (node) => {
  * @returns {boolean}
  */
 const isVoidPromise = (node) => {
+  if ( ! node ) {
+    retun false;
+  }
+  
   const typeArguments = node.typeArguments || node.typeParameters;
   return /** @type {import('@typescript-eslint/types').TSESTree.TSTypeReference} */
     typeArguments?.params?.[0]?.type === 'TSVoidKeyword';


### PR DESCRIPTION
https://typescript-eslint.io/troubleshooting/#the-key-property-is-deprecated-on-type-nodes-use-key-instead-warnings

`typeParameters` are deprecated, and should use `typeArguments` instead. Allow fallback to `typeParameters` to maintain backward compatibility.