### PR TITLE
chore: remove is-builtin-module

### DIFF
--- a/.ncurc.cjs
+++ b/.ncurc.cjs
@@ -7,7 +7,6 @@ module.exports = {
     'chai',
     'decamelize',
     'escape-string-regexp',
-    'is-builtin-module',
     'open-editor',
   ],
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "debug": "^4.3.4",
     "escape-string-regexp": "^4.0.0",
     "esquery": "^1.5.0",
-    "is-builtin-module": "^3.2.1",
     "semver": "^7.6.1",
     "spdx-expression-parse": "^4.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       esquery:
         specifier: ^1.5.0
         version: 1.5.0
-      is-builtin-module:
-        specifier: ^3.2.1
-        version: 3.2.1
       semver:
         specifier: ^7.6.1
         version: 7.6.1
@@ -8104,7 +8101,7 @@ snapshots:
       '@typescript-eslint/parser': 7.8.0(eslint@9.2.0)(typescript@5.3.3)
       eslint: 9.2.0
       eslint-config-prettier: 9.1.0(eslint@9.2.0)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-plugin-i@2.29.1)(eslint@9.2.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.2.0))(eslint@9.2.0)
       eslint-plugin-ava: 14.0.0(eslint@9.2.0)
       eslint-plugin-canonical: 4.18.0(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.2.0))(eslint@9.2.0)(typescript@5.3.3)
       eslint-plugin-cypress: 2.15.1(eslint@9.2.0)
@@ -8163,12 +8160,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-plugin-i@2.29.1)(eslint@9.2.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.2.0))(eslint@9.2.0):
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       enhanced-resolve: 5.15.0
       eslint: 9.2.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-plugin-i@2.29.1)(eslint@9.2.0))(eslint@9.2.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.2.0))(eslint@9.2.0))(eslint@9.2.0)
       eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.2.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
@@ -8180,14 +8177,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-plugin-i@2.29.1)(eslint@9.2.0))(eslint@9.2.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.2.0))(eslint@9.2.0))(eslint@9.2.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.8.0(eslint@9.2.0)(typescript@5.3.3)
       eslint: 9.2.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-plugin-i@2.29.1)(eslint@9.2.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.2.0))(eslint@9.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8208,8 +8205,8 @@ snapshots:
       '@typescript-eslint/utils': 6.19.1(eslint@9.2.0)(typescript@5.3.3)
       chance: 1.1.11
       debug: 4.3.4(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-plugin-i@2.29.1)(eslint@9.2.0)
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-plugin-i@2.29.1)(eslint@9.2.0))(eslint@9.2.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.2.0))(eslint@9.2.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.2.0))(eslint@9.2.0))(eslint@9.2.0)
       is-get-set-prop: 1.0.0
       is-js-type: 2.0.0
       is-obj-prop: 1.0.0
@@ -8269,7 +8266,7 @@ snapshots:
       doctrine: 3.0.0
       eslint: 9.2.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-plugin-i@2.29.1)(eslint@9.2.0))(eslint@9.2.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.8.0(eslint@9.2.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.2.0))(eslint@9.2.0))(eslint@9.2.0)
       get-tsconfig: 4.7.2
       is-glob: 4.0.3
       minimatch: 3.1.2

--- a/src/rules/importsAsDependencies.js
+++ b/src/rules/importsAsDependencies.js
@@ -7,7 +7,7 @@ import {
 import {
   readFileSync,
 } from 'fs';
-import isBuiltinModule from 'is-builtin-module';
+import {isBuiltin as isBuiltinModule} from 'node:module';
 import {
   join,
 } from 'path';


### PR DESCRIPTION
Removes `is-builtin-module` and uses the built in function provided by node itself (via `node:module`).

As per your `engines`, all node versions you support have this.