### PR TITLE
fix(`require-yields`): avoid error when `ExportNamedDeclaration` has no declaration prop

### DIFF
--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -1353,7 +1353,7 @@ const getUtils = (
          * @type {import('estree').ExportNamedDeclaration|
          *   import('estree').ExportDefaultDeclaration}
          */ (node).declaration
-      ).generator,
+      )?.generator,
     );
   };
 

--- a/test/rules/assertions/requireYields.js
+++ b/test/rules/assertions/requireYields.js
@@ -1884,5 +1884,18 @@ export default {
           }
       `,
     },
+    {
+      code: `
+          /**
+           *
+           */
+          export { foo } from "bar"
+      `,
+      options: [
+        {
+          contexts: ['ExportNamedDeclaration']
+        }
+      ]
+    }
   ],
 };


### PR DESCRIPTION
Fixes #1231.