### PR TITLE
fix(`require-description-complete-sentence`): avoid triggering punctuation warning after Markdown headings

### DIFF
--- a/docs/rules/match-name.md
+++ b/docs/rules/match-name.md
@@ -245,5 +245,12 @@ class A {
  * @param {Foo|Bar} opt_b
  */
 // "jsdoc/match-name": ["error"|"warn", {"match":[{"comment":"JsdocBlock:has(JsdocTag[tag=\"param\"]:has(JsdocTypeUnion:has(JsdocTypeName[value=\"Bar\"]:nth-child(1))))","disallowName":"/^opt_/i"}]}]
+
+/**
+ * @template {string} [T=typeof FOO]
+ * @typedef {object} Test
+ * @property {T} test
+ */
+// "jsdoc/match-name": ["error"|"warn", {"match":[{"allowName":"/^[A-Z]{1}$/","message":"The name should be a single capital letter.","tags":["template"]}]}]
 ````
 

--- a/docs/rules/require-description-complete-sentence.md
+++ b/docs/rules/require-description-complete-sentence.md
@@ -829,5 +829,17 @@ function quux () {
  * @param parameter
  */
 const code = (parameter) => 123;
+
+/**
+ * ### Overview
+ * My class is doing.
+ *
+ * ### Example
+ * ```javascript
+ *  const toto = 'toto';
+ * ```
+ */
+export class ClassExemple {
+}
 ````
 

--- a/docs/rules/require-yields.md
+++ b/docs/rules/require-yields.md
@@ -796,5 +796,11 @@ function * quux (foo) {
     yield foo;
   }
 }
+
+/**
+ *
+ */
+export { foo } from "bar"
+// "jsdoc/require-yields": ["error"|"warn", {"contexts":["ExportNamedDeclaration"]}]
 ````
 

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -192,7 +192,10 @@ const validateDescription = (
 
     const paragraphNoAbbreviations = paragraph.replace(abbreviationsRegex, '');
 
-    if (!/(?:[.?!|]|```)\s*$/u.test(paragraphNoAbbreviations)) {
+    if (
+      !/(?:[.?!|]|```)\s*$/u.test(paragraphNoAbbreviations) &&
+      !paragraphNoAbbreviations.startsWith('#')
+    ) {
       report('Sentences must end with a period.', fix, tag);
       return true;
     }

--- a/test/rules/assertions/requireDescriptionCompleteSentence.js
+++ b/test/rules/assertions/requireDescriptionCompleteSentence.js
@@ -1591,5 +1591,21 @@ export default {
         const code = (parameter) => 123;
       `,
     },
+    {
+      code: `
+        /**
+         * ### Overview
+         * My class is doing.
+         *
+         * ### Example
+         * \`\`\`javascript
+         *  const toto = 'toto';
+         * \`\`\`
+         */
+        export class ClassExemple {
+        }
+
+      `,
+    },
   ],
 };


### PR DESCRIPTION
fix(`require-description-complete-sentence`): avoid triggering punctuation warning after Markdown headings; fixes #1220