### PR TITLE
fix: add names to flat configs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -128,17 +128,19 @@ const index = {
 
 /**
  * @param {"warn"|"error"} warnOrError
- * @param {boolean} [flat]
+ * @param {string} [flatName]
  * @returns {import('eslint').Linter.FlatConfig}
  */
-const createRecommendedRuleset = (warnOrError, flat) => {
+const createRecommendedRuleset = (warnOrError, flatName) => {
   return {
+    name: flatName,
     // @ts-expect-error Ok
-    plugins: flat ? {
-      jsdoc: index,
-    } : [
-      'jsdoc',
-    ],
+    plugins:
+      flatName ? {
+        jsdoc: index,
+      } : [
+        'jsdoc',
+      ],
     rules: {
       'jsdoc/check-access': warnOrError,
       'jsdoc/check-alignment': warnOrError,
@@ -199,11 +201,11 @@ const createRecommendedRuleset = (warnOrError, flat) => {
 
 /**
  * @param {"warn"|"error"} warnOrError
- * @param {boolean} [flat]
+ * @param {string} [flatName]
  * @returns {import('eslint').Linter.FlatConfig}
  */
-const createRecommendedTypeScriptRuleset = (warnOrError, flat) => {
-  const ruleset = createRecommendedRuleset(warnOrError, flat);
+const createRecommendedTypeScriptRuleset = (warnOrError, flatName) => {
+  const ruleset = createRecommendedRuleset(warnOrError, flatName);
 
   return {
     ...ruleset,
@@ -227,11 +229,11 @@ const createRecommendedTypeScriptRuleset = (warnOrError, flat) => {
 
 /**
  * @param {"warn"|"error"} warnOrError
- * @param {boolean} [flat]
+ * @param {string} [flatName]
  * @returns {import('eslint').Linter.FlatConfig}
  */
-const createRecommendedTypeScriptFlavorRuleset = (warnOrError, flat) => {
-  const ruleset = createRecommendedRuleset(warnOrError, flat);
+const createRecommendedTypeScriptFlavorRuleset = (warnOrError, flatName) => {
+  const ruleset = createRecommendedRuleset(warnOrError, flatName);
 
   return {
     ...ruleset,
@@ -256,11 +258,11 @@ index.configs['recommended-typescript-error'] = createRecommendedTypeScriptRules
 index.configs['recommended-typescript-flavor'] = createRecommendedTypeScriptFlavorRuleset('warn');
 index.configs['recommended-typescript-flavor-error'] = createRecommendedTypeScriptFlavorRuleset('error');
 
-index.configs['flat/recommended'] = createRecommendedRuleset('warn', true);
-index.configs['flat/recommended-error'] = createRecommendedRuleset('error', true);
-index.configs['flat/recommended-typescript'] = createRecommendedTypeScriptRuleset('warn', true);
-index.configs['flat/recommended-typescript-error'] = createRecommendedTypeScriptRuleset('error', true);
-index.configs['flat/recommended-typescript-flavor'] = createRecommendedTypeScriptFlavorRuleset('warn', true);
-index.configs['flat/recommended-typescript-flavor-error'] = createRecommendedTypeScriptFlavorRuleset('error', true);
+index.configs['flat/recommended'] = createRecommendedRuleset('warn', 'flat/recommended');
+index.configs['flat/recommended-error'] = createRecommendedRuleset('error', 'flat/recommended-error');
+index.configs['flat/recommended-typescript'] = createRecommendedTypeScriptRuleset('warn', 'flat/recommended-typescript');
+index.configs['flat/recommended-typescript-error'] = createRecommendedTypeScriptRuleset('error', 'flat/recommended-typescript-error');
+index.configs['flat/recommended-typescript-flavor'] = createRecommendedTypeScriptFlavorRuleset('warn', 'flat/recommended-typescript-flavor');
+index.configs['flat/recommended-typescript-flavor-error'] = createRecommendedTypeScriptFlavorRuleset('error', 'flat/recommended-typescript-flavor-error');
 
 export default index;


### PR DESCRIPTION
See https://eslint.org/docs/latest/use/configure/configuration-files#configuration-naming-conventions and eg https://github.com/eslint-community/eslint-plugin-eslint-plugin/pull/459

Improves presentation in the config inspector: https://github.com/eslint/config-inspector