### PR TITLE
fix: avoid inserting `name` for eslintrc configs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,7 @@ const index = {
  */
 const createRecommendedRuleset = (warnOrError, flatName) => {
   return {
-    name: flatName,
+    ...(flatName ? {name: flatName} : {}),
     // @ts-expect-error Ok
     plugins:
       flatName ? {


### PR DESCRIPTION
fix: avoid inserting `name` for eslintrc configs; fixes #1239