### PR TITLE
fix(`no-undefined-types`): prevent linting of "type" within @import

### DIFF
--- a/docs/rules/no-undefined-types.md
+++ b/docs/rules/no-undefined-types.md
@@ -776,5 +776,9 @@ function quux(foo) {
 }
 
 quux(0);
+
+/**
+ * @import { Linter } from "eslint"
+ */
 ````
 

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -245,7 +245,7 @@ export default iterateJsdoc(({
   const typeTags = utils.filterTags(({
     tag,
   }) => {
-    return utils.tagMightHaveTypePosition(tag) && (tag !== 'suppress' || settings.mode !== 'closure');
+    return tag !== 'import' && utils.tagMightHaveTypePosition(tag) && (tag !== 'suppress' || settings.mode !== 'closure');
   }).map(tagToParsedType('type'));
 
   const namepathReferencingTags = utils.filterTags(({

--- a/src/tagNames.js
+++ b/src/tagNames.js
@@ -137,6 +137,7 @@ const typeScriptTags = {
   ...jsdocTags,
 
   // https://github.com/microsoft/TypeScript/issues/22160
+  // https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#the-jsdoc-import-tag
   import: [],
 
   // https://www.typescriptlang.org/tsconfig/#stripInternal

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -1436,5 +1436,12 @@ export default {
         'no-unused-vars': 'error',
       },
     },
+    {
+      code: `
+        /**
+         * @import { Linter } from "eslint"
+         */
+      `,
+    },
   ],
 };


### PR DESCRIPTION
fix(`no-undefined-types`): prevent linting of "type" within @import; fixes #1242