### PR TITLE
feat(`check-param-names`): check `TSMethodSignature` (as on interface methods)

### DIFF
--- a/docs/rules/check-param-names.md
+++ b/docs/rules/check-param-names.md
@@ -657,6 +657,14 @@ function quux (foo) {
 }
 // "jsdoc/check-param-names": ["error"|"warn", {"disableMissingParamChecks":true}]
 // Message: @param "bar" does not match an existing function parameter.
+
+export interface B {
+    /**
+     * @param paramA Something something
+     */
+    methodB(paramB: string): void
+};
+// Message: Expected @param names to be "paramB". Got "paramA".
 ````
 
 

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -378,6 +378,11 @@ export default iterateJsdoc(({
     targetTagName, allowExtraTrailingParamDocs, jsdocParameterNamesDeep, jsdoc, report,
   );
 }, {
+  contextDefaults: [
+    'ArrowFunctionExpression', 'FunctionDeclaration', 'FunctionExpression', 'TSDeclareFunction',
+    // Add this to above defaults
+    'TSMethodSignature'
+  ],
   meta: {
     docs: {
       description: 'Ensures that parameter names in JSDoc match those in the function declaration.',

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -1257,6 +1257,26 @@ export default {
         },
       ],
     },
+    {
+      code: `
+        export interface B {
+            /**
+             * @param paramA Something something
+             */
+            methodB(paramB: string): void
+        };
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Expected @param names to be "paramB". Got "paramA".',
+        },
+      ],
+      languageOptions: {
+        parser: typescriptEslintParser,
+        sourceType: 'module',
+      },
+    }
   ],
   valid: [
     {


### PR DESCRIPTION
feat(`check-param-names`): check `TSMethodSignature` (as on interface methods); fixes #1249