### PR TITLE
fix(`require-param`): proper errors/fixing for succeeding destructured objects

### DIFF
--- a/docs/rules/check-param-names.md
+++ b/docs/rules/check-param-names.md
@@ -665,6 +665,22 @@ export interface B {
     methodB(paramB: string): void
 };
 // Message: Expected @param names to be "paramB". Got "paramA".
+
+interface A {
+  /**
+   * @param params Values for the placeholders
+   */
+  getText(key: string, ...params: string[]): string
+}
+// Message: Expected @param names to be "key, ...params". Got "params".
+
+/**
+ * @param arg Arg
+ */
+export function fn(...[type, arg]: FnArgs): void {
+  // ...
+}
+// Message: Expected @param name to be "type". Got "arg".
 ````
 
 
@@ -1095,5 +1111,13 @@ function quux (foo, bar) {
 function quux (foo, bar) {
 }
 // "jsdoc/check-param-names": ["error"|"warn", {"disableMissingParamChecks":true}]
+
+/**
+ * @param type Type
+ * @param arg Arg
+ */
+export function fn(...[type, arg]: FnArgs): void {
+  // ...
+}
 ````
 

--- a/docs/rules/require-param.md
+++ b/docs/rules/require-param.md
@@ -1151,6 +1151,17 @@ class A {
 }
 // "jsdoc/require-param": ["error"|"warn", {"contexts":["MethodDefinition"]}]
 // Message: Missing JSDoc @param "btnState" declaration.
+
+class A {
+  /**
+   * @param root0
+   * @param root0.foo
+   */
+  quux({ foo }, { bar }) {
+    console.log(foo, bar);
+  }
+}
+// Message: Missing JSDoc @param "root1" declaration.
 ````
 
 

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -220,10 +220,10 @@ export default iterateJsdoc(({
     functionParameterIdx,
     functionParameterName,
   ] of functionParameterNames.entries()) {
+
     let inc;
     if (Array.isArray(functionParameterName)) {
-      const matchedJsdoc = shallowJsdocParameterNames[functionParameterIdx - thisOffset] ||
-        jsdocParameterNames[functionParameterIdx - thisOffset];
+      const matchedJsdoc = shallowJsdocParameterNames[functionParameterIdx - thisOffset];
 
       /** @type {string} */
       let rootName;
@@ -237,12 +237,12 @@ export default iterateJsdoc(({
       } else {
         rootName = nextRootName;
         inc = incremented;
-        [
-          nextRootName,
-          incremented,
-          namer,
-        ] = namer();
       }
+      [
+        nextRootName,
+        incremented,
+        namer,
+      ] = namer();
 
       const {
         hasRestElement,

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -2493,6 +2493,40 @@ export default {
         parser: typescriptEslintParser
       },
     },
+    {
+      code: `
+        class A {
+          /**
+           * @param root0
+           * @param root0.foo
+           */
+          quux({ foo }, { bar }) {
+            console.log(foo, bar);
+          }
+        }
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "root1" declaration.',
+        },
+        {
+          message: 'Missing JSDoc @param "root1.bar" declaration.',
+        }
+      ],
+      output: `
+        class A {
+          /**
+           * @param root0
+           * @param root0.foo
+           * @param root1
+           * @param root1.bar
+           */
+          quux({ foo }, { bar }) {
+            console.log(foo, bar);
+          }
+        }
+      `,
+    },
   ],
   valid: [
     {


### PR DESCRIPTION
fix(`require-param`): proper errors/fixing for succeeding destructured objects; fixes #762