### PR TITLE
fix(`require-template`, `check-template-names`): avoid erring out with missing or bad typedef type

### DIFF
--- a/docs/rules/check-template-names.md
+++ b/docs/rules/check-template-names.md
@@ -125,5 +125,10 @@ export type Extras<D, U, V> = [D, U, V | undefined];
  * @typedef {[D, U, V | undefined]} Extras
  * @typedef {[D, U, V | undefined]} Extras
  */
+
+/**
+ * @typedef Foo
+ * @prop {string} bar
+ */
 ````
 

--- a/docs/rules/require-template.md
+++ b/docs/rules/require-template.md
@@ -143,5 +143,10 @@ export type Extras<D, U, V> = [D, U, V | undefined];
  * @typedef {[D, U, V | undefined]} Extras
  * @typedef {[D, U, V | undefined]} Extras
  */
+
+/**
+ * @typedef Foo
+ * @prop {string} bar
+ */
 ````
 

--- a/src/rules/checkTemplateNames.js
+++ b/src/rules/checkTemplateNames.js
@@ -65,9 +65,16 @@ export default iterateJsdoc(({
   }
 
   const potentialType = typedefTags[0].type;
-  const parsedType = mode === 'permissive' ?
-    tryParseType(/** @type {string} */ (potentialType)) :
-    parseType(/** @type {string} */ (potentialType), mode)
+
+  let parsedType;
+  try {
+    parsedType = mode === 'permissive' ?
+      tryParseType(/** @type {string} */ (potentialType)) :
+      parseType(/** @type {string} */ (potentialType), mode)
+  } catch {
+    // Todo: Should handle types in @prop/erty
+    return;
+  }
 
   traverse(parsedType, (nde) => {
     const {

--- a/src/rules/requireTemplate.js
+++ b/src/rules/requireTemplate.js
@@ -76,9 +76,16 @@ export default iterateJsdoc(({
   }
 
   const potentialType = typedefTags[0].type;
-  const parsedType = mode === 'permissive' ?
-    tryParseType(/** @type {string} */ (potentialType)) :
-    parseType(/** @type {string} */ (potentialType), mode)
+
+  let parsedType;
+  try {
+    parsedType = mode === 'permissive' ?
+      tryParseType(/** @type {string} */ (potentialType)) :
+      parseType(/** @type {string} */ (potentialType), mode)
+  } catch {
+    // Todo: Should handle types in @prop/erty
+    return;
+  }
 
   traverse(parsedType, (nde) => {
     const {

--- a/test/rules/assertions/checkTemplateNames.js
+++ b/test/rules/assertions/checkTemplateNames.js
@@ -193,5 +193,13 @@ export default {
          */
       `,
     },
+    {
+      code: `
+        /**
+         * @typedef Foo
+         * @prop {string} bar
+         */
+      `,
+    },
   ],
 };

--- a/test/rules/assertions/requireTemplate.js
+++ b/test/rules/assertions/requireTemplate.js
@@ -205,5 +205,13 @@ export default {
          */
       `,
     },
+    {
+      code: `
+        /**
+         * @typedef Foo
+         * @prop {string} bar
+         */
+      `,
+    },
   ],
 };


### PR DESCRIPTION
fix(`require-template`, `check-template-names`): avoid erring out with missing or bad typedef type; partial fix for #1269