### PR TITLE
refactor: make exports named and move utils to own file for reuse

### DIFF
--- a/src/rules/convertToJsdocComments.js
+++ b/src/rules/convertToJsdocComments.js
@@ -2,7 +2,11 @@ import iterateJsdoc from '../iterateJsdoc.js';
 import {
   getSettings,
 } from '../iterateJsdoc.js';
-import jsdocUtils from '../jsdocUtils.js';
+import {
+  getIndent,
+  getContextObject,
+  enforcedContexts,
+} from '../jsdocUtils.js';
 import {
   getNonJsdocComment,
   getDecorator,
@@ -114,7 +118,7 @@ export default {
           );
         }
 
-        const indent = jsdocUtils.getIndent({
+        const indent = getIndent({
           text: sourceCode.getText(
             /** @type {import('eslint').Rule.Node} */ (baseNode),
             /** @type {import('eslint').AST.SourceLocation} */
@@ -255,17 +259,17 @@ export default {
 
     // Todo: add contexts to check after (and handle if want both before and after)
     return {
-      ...jsdocUtils.getContextObject(
-        jsdocUtils.enforcedContexts(context, true, settings),
+      ...getContextObject(
+        enforcedContexts(context, true, settings),
         checkNonJsdoc,
       ),
-      ...jsdocUtils.getContextObject(
+      ...getContextObject(
         contextsAfter,
         (_info, _handler, node) => {
           checkNonJsdocAfter(node, contextsAfter);
         },
       ),
-      ...jsdocUtils.getContextObject(
+      ...getContextObject(
         contextsBeforeAndAfter,
         (_info, _handler, node) => {
           checkNonJsdoc({}, null, node);

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -2,7 +2,15 @@ import exportParser from '../exportParser.js';
 import {
   getSettings,
 } from '../iterateJsdoc.js';
-import jsdocUtils from '../jsdocUtils.js';
+import {
+  exemptSpeciaMethods,
+  isConstructor,
+  getFunctionParameterNames,
+  hasReturnValue,
+  getIndent,
+  getContextObject,
+  enforcedContexts,
+} from '../jsdocUtils.js';
 import {
   getDecorator,
   getJSDocComment,
@@ -381,7 +389,7 @@ export default {
 
       // For those who have options configured against ANY constructors (or
       //  setters or getters) being reported
-      if (jsdocUtils.exemptSpeciaMethods(
+      if (exemptSpeciaMethods(
         {
           description: '',
           inlineTags: [],
@@ -405,10 +413,10 @@ export default {
 
         // Avoid reporting  param-less, return-less constructor methods (when
         //  `exemptEmptyConstructors` option is set)
-        exemptEmptyConstructors && jsdocUtils.isConstructor(node)
+        exemptEmptyConstructors && isConstructor(node)
       ) {
-        const functionParameterNames = jsdocUtils.getFunctionParameterNames(node);
-        if (!functionParameterNames.length && !jsdocUtils.hasReturnValue(node)) {
+        const functionParameterNames = getFunctionParameterNames(node);
+        if (!functionParameterNames.length && !hasReturnValue(node)) {
           return;
         }
       }
@@ -427,7 +435,7 @@ export default {
           baseNode = decorator;
         }
 
-        const indent = jsdocUtils.getIndent({
+        const indent = getIndent({
           text: sourceCode.getText(
             /** @type {import('eslint').Rule.Node} */ (baseNode),
             /** @type {import('eslint').AST.SourceLocation} */
@@ -516,8 +524,8 @@ export default {
     };
 
     return {
-      ...jsdocUtils.getContextObject(
-        jsdocUtils.enforcedContexts(context, [], settings),
+      ...getContextObject(
+        enforcedContexts(context, [], settings),
         checkJsDoc,
       ),
       ArrowFunctionExpression (node) {

--- a/test/jsdocUtils.js
+++ b/test/jsdocUtils.js
@@ -1,4 +1,4 @@
-import jsdocUtils from '../src/jsdocUtils.js';
+import * as jsdocUtils from '../src/jsdocUtils.js';
 import {
   expect,
 } from 'chai';
@@ -8,26 +8,26 @@ import {
  */
 
 describe('jsdocUtils', () => {
-  describe('getPreferredTagName()', () => {
+  describe('getPreferredTagNameSimple()', () => {
     context('no preferences', () => {
       context('alias name', () => {
         it('returns the primary tag name', () => {
-          expect(jsdocUtils.getPreferredTagName(/** @type {BadArgument} */ ({}), 'jsdoc', 'return')).to.equal('returns');
+          expect(jsdocUtils.getPreferredTagNameSimple(/** @type {BadArgument} */ ({}), 'jsdoc', 'return')).to.equal('returns');
         });
         it('works with the constructor tag', () => {
-          expect(jsdocUtils.getPreferredTagName(/** @type {BadArgument} */ ({}), 'jsdoc', 'constructor')).to.equal('class');
+          expect(jsdocUtils.getPreferredTagNameSimple(/** @type {BadArgument} */ ({}), 'jsdoc', 'constructor')).to.equal('class');
         });
       });
       it('works with tags that clash with prototype properties', () => {
-        expect(jsdocUtils.getPreferredTagName(/** @type {BadArgument} */ ({}), 'jsdoc', 'toString')).to.equal('toString');
+        expect(jsdocUtils.getPreferredTagNameSimple(/** @type {BadArgument} */ ({}), 'jsdoc', 'toString')).to.equal('toString');
       });
       it('returns the primary tag name', () => {
-        expect(jsdocUtils.getPreferredTagName(/** @type {BadArgument} */ ({}), 'jsdoc', 'returns')).to.equal('returns');
+        expect(jsdocUtils.getPreferredTagNameSimple(/** @type {BadArgument} */ ({}), 'jsdoc', 'returns')).to.equal('returns');
       });
     });
     context('with preferences', () => {
       it('returns the preferred tag name', () => {
-        expect(jsdocUtils.getPreferredTagName(/** @type {BadArgument} */ ({}), 'jsdoc', 'return', /** @type {BadArgument} */ ({
+        expect(jsdocUtils.getPreferredTagNameSimple(/** @type {BadArgument} */ ({}), 'jsdoc', 'return', /** @type {BadArgument} */ ({
           returns: 'return',
         }))).to.equal('return');
       });


### PR DESCRIPTION
refactor: make exports named and move utils to own file for reuse