### PR TITLE
docs: use `ts` for TypeScript code blocks

### DIFF
--- a/docs/rules/check-template-names.md
+++ b/docs/rules/check-template-names.md
@@ -40,7 +40,7 @@ or
 
 The following patterns are considered problems:
 
-````js
+````ts
 /**
  * @template D
  * @template V
@@ -224,7 +224,7 @@ export default class <NumType> {
 
 The following patterns are not considered problems:
 
-````js
+````ts
 /**
  * @template D
  * @template V


### PR DESCRIPTION
Syntax highlighting of code blocks in the [`check-template-names`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/check-template-names.md) rule is bad because `js` is defined, but the code is TypeScript.