### PR TITLE
fix(`lines-before-block`): remove rule from recommended

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -169,7 +169,7 @@ const createRecommendedRuleset = (warnOrError, flatName) => {
       'jsdoc/implements-on-classes': warnOrError,
       'jsdoc/imports-as-dependencies': 'off',
       'jsdoc/informative-docs': 'off',
-      'jsdoc/lines-before-block': warnOrError,
+      'jsdoc/lines-before-block': 'off',
       'jsdoc/match-description': 'off',
       'jsdoc/match-name': 'off',
       'jsdoc/multiline-blocks': warnOrError,


### PR DESCRIPTION
fix(`lines-before-block`): remove rule from recommended

BREAKING CHANGE:

Have to selectively enable the `lines-before-block` rule to have it apply now.

The rule still has some issues to work out, so dropping from recommended for now.