### PR TITLE
fix(`check-param-names`): check against whitelist of acceptable function nodes so that non-function global contexts do not err

### DIFF
--- a/.README/rules/no-bad-blocks.md
+++ b/.README/rules/no-bad-blocks.md
@@ -6,7 +6,7 @@ This rule checks for multi-line-style comments which fail to meet the
 criteria of a JSDoc block, namely that it should begin with two and only two
 asterisks, but which appear to be intended as JSDoc blocks due to the presence
 of whitespace followed by whitespace or asterisks, and
-an at-sign (`@`) and some non-whitespace (as with a jsdoc block tag).
+an at-sign (`@`) and some non-whitespace (as with a JSDoc block tag).
 
 Exceptions are made for ESLint directive comments (which may use `@` in
 rule names).

--- a/.README/rules/text-escaping.md
+++ b/.README/rules/text-escaping.md
@@ -19,11 +19,13 @@ within it or your documentation.
 ### `escapeHTML`
 
 This option escapes all `<` and `&` characters (except those followed by
-whitespace which are treated as literals by Visual Studio Code).
+whitespace which are treated as literals by Visual Studio Code). Defaults to
+`false`.
 
 ### `escapeMarkdown`
 
 This option escapes the first backtick (`` ` ``) in a paired sequence.
+Defaults to `false`.
 
 ## Context and settings
 

--- a/.README/settings.md
+++ b/.README/settings.md
@@ -329,5 +329,9 @@ values are objects with the following optional properties:
 ### `contexts`
 
 `settings.jsdoc.contexts` can be used as the default for any rules
-with a `contexts` property option. See the "AST and Selectors" section
-for more on this format.
+with a `contexts` property option. **Please note**: This will replace any
+default contexts, including for function rules, so if, for example, you exclude
+`FunctionDeclaration` here, rules like `require-param` will not check
+function declarations.
+
+See the "AST and Selectors" section for more on this format.

--- a/docs/rules/check-param-names.md
+++ b/docs/rules/check-param-names.md
@@ -1119,5 +1119,15 @@ function quux (foo, bar) {
 export function fn(...[type, arg]: FnArgs): void {
   // ...
 }
+
+/**
+ * @param c c
+ * @param d d
+ */
+const inner = (c: number, d: string): void => {
+  console.log(c);
+  console.log(d);
+};
+// Settings: {"jsdoc":{"contexts":["VariableDeclaration"]}}
 ````
 

--- a/docs/rules/no-bad-blocks.md
+++ b/docs/rules/no-bad-blocks.md
@@ -8,7 +8,7 @@ This rule checks for multi-line-style comments which fail to meet the
 criteria of a JSDoc block, namely that it should begin with two and only two
 asterisks, but which appear to be intended as JSDoc blocks due to the presence
 of whitespace followed by whitespace or asterisks, and
-an at-sign (`@`) and some non-whitespace (as with a jsdoc block tag).
+an at-sign (`@`) and some non-whitespace (as with a JSDoc block tag).
 
 Exceptions are made for ESLint directive comments (which may use `@` in
 rule names).

--- a/docs/rules/require-param.md
+++ b/docs/rules/require-param.md
@@ -1804,5 +1804,14 @@ function a (b) {}
 function sumDestructure(this: unknown, { a, b }: { a: number, b: number }) {
   return a + b;
 }
+
+/**
+ *
+ */
+const inner = (c: number, d: string): void => {
+  console.log(c);
+  console.log(d);
+};
+// Settings: {"jsdoc":{"contexts":["VariableDeclaration"]}}
 ````
 

--- a/docs/rules/text-escaping.md
+++ b/docs/rules/text-escaping.md
@@ -34,13 +34,15 @@ within it or your documentation.
 ### <code>escapeHTML</code>
 
 This option escapes all `<` and `&` characters (except those followed by
-whitespace which are treated as literals by Visual Studio Code).
+whitespace which are treated as literals by Visual Studio Code). Defaults to
+`false`.
 
 <a name="user-content-text-escaping-options-escapemarkdown"></a>
 <a name="text-escaping-options-escapemarkdown"></a>
 ### <code>escapeMarkdown</code>
 
 This option escapes the first backtick (`` ` ``) in a paired sequence.
+Defaults to `false`.
 
 <a name="user-content-text-escaping-context-and-settings"></a>
 <a name="text-escaping-context-and-settings"></a>

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -358,5 +358,9 @@ values are objects with the following optional properties:
 ### <code>contexts</code>
 
 `settings.jsdoc.contexts` can be used as the default for any rules
-with a `contexts` property option. See the "AST and Selectors" section
-for more on this format.
+with a `contexts` property option. **Please note**: This will replace any
+default contexts, including for function rules, so if, for example, you exclude
+`FunctionDeclaration` here, rules like `require-param` will not check
+function declarations.
+
+See the "AST and Selectors" section for more on this format.

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -354,11 +354,18 @@ const validateParameterNamesDeep = (
   });
 };
 
+const allowedNodes = [
+  'ArrowFunctionExpression', 'FunctionDeclaration', 'FunctionExpression', 'TSDeclareFunction',
+    // Add this to above defaults
+    'TSMethodSignature'
+];
+
 export default iterateJsdoc(({
   context,
   jsdoc,
   report,
   utils,
+  node,
 }) => {
   const {
     allowExtraTrailingParamDocs,
@@ -370,6 +377,15 @@ export default iterateJsdoc(({
     disableExtraPropertyReporting = false,
     disableMissingParamChecks = false,
   } = context.options[0] || {};
+
+  // Although we might just remove global settings contexts from applying to
+  //   this rule (as they can cause problems with `getFunctionParameterNames`
+  //   checks if they are not functions but say variables), the user may
+  //   instead wish to narrow contexts in those settings, so this check
+  //   is still useful
+  if (!allowedNodes.includes(/** @type {import('estree').Node} */ (node).type)) {
+    return;
+  }
 
   const checkTypesRegex = utils.getRegexFromString(checkTypesPattern);
 
@@ -406,11 +422,7 @@ export default iterateJsdoc(({
     targetTagName, allowExtraTrailingParamDocs, jsdocParameterNamesDeep, jsdoc, report,
   );
 }, {
-  contextDefaults: [
-    'ArrowFunctionExpression', 'FunctionDeclaration', 'FunctionExpression', 'TSDeclareFunction',
-    // Add this to above defaults
-    'TSMethodSignature'
-  ],
+  contextDefaults: allowedNodes,
   meta: {
     docs: {
       description: 'Ensures that parameter names in JSDoc match those in the function declaration.',

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -2015,5 +2015,28 @@ export default {
         sourceType: 'module',
       },
     },
+    {
+      code: `
+        /**
+         * @param c c
+         * @param d d
+         */
+        const inner = (c: number, d: string): void => {
+          console.log(c);
+          console.log(d);
+        };
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+        sourceType: 'module',
+      },
+      settings: {
+        jsdoc: {
+          contexts: [
+            'VariableDeclaration',
+          ]
+        }
+      },
+    },
   ],
 };

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -3582,5 +3582,27 @@ export default {
         parser: typescriptEslintParser,
       },
     },
+    {
+      code: `
+        /**
+         *
+         */
+        const inner = (c: number, d: string): void => {
+          console.log(c);
+          console.log(d);
+        };
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+        sourceType: 'module',
+      },
+      settings: {
+        jsdoc: {
+          contexts: [
+            'VariableDeclaration',
+          ]
+        }
+      },
+    },
   ],
 };


### PR DESCRIPTION
fix(`check-param-names`): check against whitelist of acceptable function nodes so that non-function global contexts do not err; fixes #1303

Also adds warning in docs for use of global settings contexts.