### PR TITLE
fix(`require-returns-check`): allow infinite for loops to have only one branch to return

### DIFF
--- a/docs/rules/require-returns-check.md
+++ b/docs/rules/require-returns-check.md
@@ -992,5 +992,17 @@ function foo() {
     }
   }
 }
+
+/**
+ * @returns {number}
+ */
+function foo() {
+  for (;;) {
+    const n = Math.random();
+    if (n < 0.5) {
+      return n;
+    }
+  }
+}
 ````
 

--- a/src/utils/hasReturnValue.js
+++ b/src/utils/hasReturnValue.js
@@ -177,8 +177,13 @@ const allBrancheshaveReturnValues = (node, promFilter) => {
     }
 
     // Fallthrough
-  case 'LabeledStatement':
   case 'ForStatement':
+    if (node.test === null) {
+      // If this is an infinite loop, we assume only one branch
+      //   is needed to provide a return
+      return hasReturnValue(node.body, false, promFilter);
+    }
+  case 'LabeledStatement':
   case 'ForInStatement':
   case 'ForOfStatement':
   case 'WithStatement': {

--- a/test/rules/assertions/requireReturnsCheck.js
+++ b/test/rules/assertions/requireReturnsCheck.js
@@ -1558,5 +1558,20 @@ export default {
         }
       `,
     },
+    {
+      code: `
+        /**
+         * @returns {number}
+         */
+        function foo() {
+          for (;;) {
+            const n = Math.random();
+            if (n < 0.5) {
+              return n;
+            }
+          }
+        }
+      `,
+    },
   ],
 };


### PR DESCRIPTION
fix(`require-returns-check`): allow infinite for loops to have only one branch to return; fixes #1315