### PR TITLE
fix(`require-hyphen-before-param-description`): inject hyphen at proper place with multiline type

### DIFF
--- a/docs/rules/require-hyphen-before-param-description.md
+++ b/docs/rules/require-hyphen-before-param-description.md
@@ -193,6 +193,15 @@ function quux () {
  */
 // "jsdoc/require-hyphen-before-param-description": ["error"|"warn", "always",{"tags":{"*":"never","property":"always"}}]
 // Message: There must be no hyphen before @returns description.
+
+/**
+ * @param {(
+ *  | string
+ *  | number
+ * )} input The input value
+ */
+function test(input) {}
+// Message: There must be a hyphen before @param description.
 ````
 
 

--- a/src/rules/requireHyphenBeforeParamDescription.js
+++ b/src/rules/requireHyphenBeforeParamDescription.js
@@ -33,38 +33,39 @@ export default iterateJsdoc(({
     }
 
     const startsWithHyphen = (/^\s*-/u).test(desc);
+    let lines = 0;
+    for (const {
+      tokens,
+    } of jsdocTag.source) {
+      if (tokens.description) {
+        break;
+      }
+
+      lines++;
+    }
+
     if (always) {
       if (!startsWithHyphen) {
-        report(`There must be a hyphen before @${targetTagName} description.`, (fixer) => {
-          const lineIndex = /** @type {import('../iterateJsdoc.js').Integer} */ (
-            jsdocTag.line
-          );
-          const sourceLines = sourceCode.getText(jsdocNode).split('\n');
-
-          // Get start index of description, accounting for multi-line descriptions
-          const description = desc.split('\n')[0];
-          const descriptionIndex = sourceLines[lineIndex].lastIndexOf(description);
-
-          const replacementLine = sourceLines[lineIndex]
-            .slice(0, descriptionIndex) + '- ' + description;
-          sourceLines.splice(lineIndex, 1, replacementLine);
-          const replacement = sourceLines.join('\n');
-
-          return fixer.replaceText(jsdocNode, replacement);
-        }, jsdocTag);
+        utils.reportJSDoc(
+          `There must be a hyphen before @${targetTagName} description.`,
+          {
+            line: jsdocTag.source[0].number + lines,
+          },
+          () => {
+            for (const {
+              tokens,
+            } of jsdocTag.source) {
+              if (tokens.description) {
+                tokens.description = tokens.description.replace(
+                  /^(\s*)/u, '$1- ',
+                );
+                break;
+              }
+            }
+          }
+        );
       }
     } else if (startsWithHyphen) {
-      let lines = 0;
-      for (const {
-        tokens,
-      } of jsdocTag.source) {
-        if (tokens.description) {
-          break;
-        }
-
-        lines++;
-      }
-
       utils.reportJSDoc(
         `There must be no hyphen before @${targetTagName} description.`,
         {

--- a/test/rules/assertions/requireHyphenBeforeParamDescription.js
+++ b/test/rules/assertions/requireHyphenBeforeParamDescription.js
@@ -447,6 +447,32 @@ export default {
        */
       `,
     },
+    {
+      code: `
+        /**
+         * @param {(
+         *  | string
+         *  | number
+         * )} input The input value
+         */
+        function test(input) {}
+      `,
+      errors: [
+        {
+          line: 6,
+          message: 'There must be a hyphen before @param description.',
+        },
+      ],
+      output: `
+        /**
+         * @param {(
+         *  | string
+         *  | number
+         * )} input - The input value
+         */
+        function test(input) {}
+      `,
+    },
   ],
   valid: [
     {


### PR DESCRIPTION
fix(`require-hyphen-before-param-description`): inject hyphen at proper place with multiline type