### PR TITLE
feat(`require-hyphen-before-param-description`): ensure template will be properly stringified

### DIFF
--- a/docs/rules/match-name.md
+++ b/docs/rules/match-name.md
@@ -251,6 +251,6 @@ class A {
  * @typedef {object} Test
  * @property {T} test
  */
-// "jsdoc/match-name": ["error"|"warn", {"match":[{"allowName":"/^[A-Z]{1}$/","message":"The name should be a single capital letter.","tags":["template"]}]}]
+// "jsdoc/match-name": ["error"|"warn", {"match":[{"allowName":"/^\\[?[A-Z]{1}(=.*\\])$/","message":"The name should be a single capital letter.","tags":["template"]}]}]
 ````
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "http://gajus.com"
   },
   "dependencies": {
-    "@es-joy/jsdoccomment": "~0.48.0",
+    "@es-joy/jsdoccomment": "~0.49.0",
     "are-docs-informative": "^0.0.2",
     "comment-parser": "1.4.1",
     "debug": "^4.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@es-joy/jsdoccomment':
-        specifier: ~0.48.0
-        version: 0.48.0
+        specifier: ~0.49.0
+        version: 0.49.0
       are-docs-informative:
         specifier: ^0.0.2
         version: 0.0.2
@@ -983,8 +983,8 @@ packages:
     resolution: {integrity: sha512-C3Axuq1xd/9VqFZpW4YAzOx5O9q/LP46uIQy/iNDpHG3fmPa6TBtvfglMCs3RBiBxAIi0Go97r8+jvTt55XMyQ==}
     engines: {node: '>=16'}
 
-  '@es-joy/jsdoccomment@0.48.0':
-    resolution: {integrity: sha512-G6QUWIcC+KvSwXNsJyDTHvqUdNoAVJPPgkc3+Uk4WBKqZvoXhlvazOgm9aL0HwihJLQf0l+tOE2UFzXBqCqgDw==}
+  '@es-joy/jsdoccomment@0.49.0':
+    resolution: {integrity: sha512-xjZTSFgECpb9Ohuk5yMX5RhUEbfeQcuOp8IF60e+wyzWEF0M5xeSgqsfLtvPEX8BIyOX9saZqzuGPmZ8oWc+5Q==}
     engines: {node: '>=16'}
 
   '@eslint-community/eslint-utils@4.4.0':
@@ -6400,7 +6400,7 @@ snapshots:
       esquery: 1.6.0
       jsdoc-type-pratt-parser: 4.0.0
 
-  '@es-joy/jsdoccomment@0.48.0':
+  '@es-joy/jsdoccomment@0.49.0':
     dependencies:
       comment-parser: 1.4.1
       esquery: 1.6.0

--- a/test/rules/assertions/matchName.js
+++ b/test/rules/assertions/matchName.js
@@ -553,7 +553,7 @@ export default {
       `,
       options: [{
         match: [{
-          allowName: "/^[A-Z]{1}$/",
+          allowName: "/^\\[?[A-Z]{1}(=.*\\])$/",
           message: "The name should be a single capital letter.",
           tags: ["template"],
         }],

--- a/test/rules/assertions/requireHyphenBeforeParamDescription.js
+++ b/test/rules/assertions/requireHyphenBeforeParamDescription.js
@@ -473,6 +473,29 @@ export default {
         function test(input) {}
       `,
     },
+    {
+      code: `
+        /**
+         * @template [O=unknown]
+         * @param {string} name The name of the thing.
+         */
+        function test(name) {}
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'There must be a hyphen before @param description.',
+        },
+      ],
+      ignoreReadme: true,
+      output: `
+        /**
+         * @template [O=unknown]
+         * @param {string} name - The name of the thing.
+         */
+        function test(name) {}
+      `,
+    },
   ],
   valid: [
     {


### PR DESCRIPTION
feat(`require-hyphen-before-param-description`): ensure template will be properly stringified; fixes #1326

Note that `match-name` will now have to take into account any optional brackets and default in `allowName`