### PR TITLE
fix(`match-name`): revert to prior correct behavior of ignoring optional and default code surrounding name

### DIFF
--- a/docs/rules/match-name.md
+++ b/docs/rules/match-name.md
@@ -251,6 +251,6 @@ class A {
  * @typedef {object} Test
  * @property {T} test
  */
-// "jsdoc/match-name": ["error"|"warn", {"match":[{"allowName":"/^\\[?[A-Z]{1}(=.*\\])$/","message":"The name should be a single capital letter.","tags":["template"]}]}]
+// "jsdoc/match-name": ["error"|"warn", {"match":[{"allowName":"/^[A-Z]{1}$/","message":"The name should be a single capital letter.","tags":["template"]}]}]
 ````
 

--- a/src/rules/matchName.js
+++ b/src/rules/matchName.js
@@ -38,8 +38,9 @@ export default iterateJsdoc(({
 
   let reported = false;
   for (const tag of applicableTags) {
-    const allowed = !allowNameRegex || allowNameRegex.test(tag.name);
-    const disallowed = disallowNameRegex && disallowNameRegex.test(tag.name);
+    const tagName = tag.name.replace(/^\[/u, '').replace(/(=.*)?\]$/u, '');
+    const allowed = !allowNameRegex || allowNameRegex.test(tagName);
+    const disallowed = disallowNameRegex && disallowNameRegex.test(tagName);
     const hasRegex = allowNameRegex || disallowNameRegex;
     if (hasRegex && allowed && !disallowed) {
       continue;
@@ -66,10 +67,10 @@ export default iterateJsdoc(({
     if (!message) {
       if (hasRegex) {
         message = disallowed ?
-          `Only allowing names not matching \`${disallowNameRegex}\` but found "${tag.name}".` :
-          `Only allowing names matching \`${allowNameRegex}\` but found "${tag.name}".`;
+          `Only allowing names not matching \`${disallowNameRegex}\` but found "${tagName}".` :
+          `Only allowing names matching \`${allowNameRegex}\` but found "${tagName}".`;
       } else {
-        message = `Prohibited context for "${tag.name}".`;
+        message = `Prohibited context for "${tagName}".`;
       }
     }
 
@@ -86,7 +87,7 @@ export default iterateJsdoc(({
         // Could also supply `context`, `comment`, `tags`
         allowName,
         disallowName,
-        name: tag.name,
+        name: tagName,
       },
     );
     if (!hasRegex) {

--- a/test/rules/assertions/matchName.js
+++ b/test/rules/assertions/matchName.js
@@ -553,7 +553,7 @@ export default {
       `,
       options: [{
         match: [{
-          allowName: "/^\\[?[A-Z]{1}(=.*\\])$/",
+          allowName: "/^[A-Z]{1}$/",
           message: "The name should be a single capital letter.",
           tags: ["template"],
         }],


### PR DESCRIPTION
fix(`match-name`): revert to prior correct behavior of ignoring optional and default code surrounding name