### PR TITLE
docs: make rule docs reflect their recommended status correctly

### DIFF
--- a/docs/rules/check-access.md
+++ b/docs/rules/check-access.md
@@ -26,7 +26,7 @@ Also reports:
 |---|---|
 |Context|everywhere|
 |Tags|`@access`|
-|Recommended|false|
+|Recommended|true|
 |Settings||
 |Options||
 

--- a/docs/rules/lines-before-block.md
+++ b/docs/rules/lines-before-block.md
@@ -34,7 +34,7 @@ lines before the block will not be added).
 |---|---|
 |Context|everywhere|
 |Tags|N/A|
-|Recommended|true|
+|Recommended|false|
 |Settings||
 |Options|`excludedTags`, `ignoreSameLine`, `lines`|
 

--- a/docs/rules/no-defaults.md
+++ b/docs/rules/no-defaults.md
@@ -67,7 +67,7 @@ section of our README for more on the expected format.
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled|
 |Tags|`param`, `default`|
 |Aliases|`arg`, `argument`, `defaultvalue`|
-|Recommended|false|
+|Recommended|true|
 |Options|`contexts`, `noOptionalParamNames`|
 
 <a name="user-content-no-defaults-failing-examples"></a>

--- a/docs/rules/require-asterisk-prefix.md
+++ b/docs/rules/require-asterisk-prefix.md
@@ -53,6 +53,7 @@ which applies to the main jsdoc block description.
 |---|---|
 |Context|everywhere|
 |Tags|All or as limited by the `tags` option|
+|Recommended|false|
 |Options|string ("always", "never", "any") followed by object with `tags`|
 
 <a name="user-content-failing-examples"></a>

--- a/docs/rules/require-template.md
+++ b/docs/rules/require-template.md
@@ -48,7 +48,7 @@ Defaults to `false`.
 |---|---|
 |Context|everywhere|
 |Tags|`template`|
-|Recommended|true|
+|Recommended|false|
 |Settings||
 |Options|`requireSeparateTemplates`|
 

--- a/docs/rules/require-throws.md
+++ b/docs/rules/require-throws.md
@@ -48,7 +48,7 @@ on why TypeScript doesn't offer such a feature.
 | Context  | `ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`; others when `contexts` option enabled |
 | Tags     | `throws` |
 | Aliases  | `exception` |
-|Recommended|true|
+|Recommended|false|
 | Options  |`contexts`, `exemptedBy`|
 | Settings | `ignoreReplacesDocs`, `overrideReplacesDocs`, `augmentsExtendsReplacesDocs`, `implementsReplacesDocs` |
 


### PR DESCRIPTION
Currently the following rules have different recommended status than their respective status in the `README.md` recommended list: 
- `check-access`
- `lines-before-block`
- `no-defaults`
- `require-asterisk-prefix`
- `require-template`
- `require-throws`

This PR fixes that