### PR TITLE
Ability to import iterateJsdoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,11 @@
       "types": "./dist/getJsdocProcessorPlugin.d.ts",
       "import": "./dist/getJsdocProcessorPlugin.cjs",
       "require": "./src/getJsdocProcessorPlugin.js"
+    },
+    "./iterateJsdoc.js": {
+      "types": "./dist/iterateJsdoc.d.ts",
+      "import": "./dist/iterateJsdoc.cjs",
+      "require": "./src/iterateJsdoc.js"
     }
   },
   "name": "eslint-plugin-jsdoc",


### PR DESCRIPTION
Since v48.0.0, `iterateJsdoc` cannot be imported anymore. This PR adds `iterateJsdoc` to the `exports` field of the package, in order for external libraries to use it (we use it to build custom JSDoc rules).

Thanks!