### PR TITLE
chore(package): fix repository url; add homepage and bugs urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gajus/eslint-plugin-jsdoc"
+    "url": "git+https://github.com/gajus/eslint-plugin-jsdoc.git"
   },
   "run-if-changed": {
     "package-lock.json": "npm run install-offline"

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "type": "git",
     "url": "git+https://github.com/gajus/eslint-plugin-jsdoc.git"
   },
+  "homepage": "https://github.com/gajus/eslint-plugin-jsdoc#readme",
   "run-if-changed": {
     "package-lock.json": "npm run install-offline"
   },

--- a/package.json
+++ b/package.json
@@ -137,6 +137,9 @@
     "url": "git+https://github.com/gajus/eslint-plugin-jsdoc.git"
   },
   "homepage": "https://github.com/gajus/eslint-plugin-jsdoc#readme",
+  "bugs": {
+    "url": "https://github.com/gajus/eslint-plugin-jsdoc/issues"
+  },
   "run-if-changed": {
     "package-lock.json": "npm run install-offline"
   },


### PR DESCRIPTION
The repository URL was fixed by simply running `npm pkg fix`, which is [what `npm publish` does prior to publishing](https://docs.npmjs.com/cli/v10/commands/npm-pkg#description).

The addition of the [`homepage`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#homepage) property allows for the URL to the repo to be correctly displayed when hovered over in VS Code when using a proxy registry like in Azure DevOps:

![image](https://github.com/user-attachments/assets/bff87971-81ad-4d2d-b3fa-e8996995fecb)

Compared to eslint-plugin-regexp, which [does have the homepage set](https://github.com/ota-meshi/eslint-plugin-regexp/blob/2d90a1aca863508647115c76a7b0c23b493eb0e0/package.json#L60):

![image](https://github.com/user-attachments/assets/43f6f798-75dc-4d6d-bc00-df886a08a98d)


The [`bugs`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#bugs) property was also added to allow for `npm bugs` to work. 
