### PR TITLE
fix(`check-template-names`): stop restricting template names to single letters

### DIFF
--- a/src/rules/checkTemplateNames.js
+++ b/src/rules/checkTemplateNames.js
@@ -37,7 +37,7 @@ export default iterateJsdoc(({
         type,
         value,
       } = /** @type {import('jsdoc-type-pratt-parser').NameResult} */ (nde);
-      if (type === 'JsdocTypeName' && (/^[A-Z]$/).test(value)) {
+      if (type === 'JsdocTypeName') {
         usedNames.add(value);
       }
     });


### PR DESCRIPTION
fix(`check-template-names`): stop restricting template names to single letters; fixes #1352

Single letters in JSDoc blocks still expected for template names in `require-template` rule.