### PR TITLE
ci: update github actions

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -7,11 +7,11 @@ jobs:
         with:
           version: latest
       - name: setup repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: setup node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
       - run: pnpm install
@@ -26,11 +26,11 @@ jobs:
         with:
           version: latest
       - name: setup repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: setup node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '${{ matrix.node_js_version }}'
       - run: pnpm install
@@ -51,11 +51,11 @@ jobs:
         with:
           version: latest
       - name: setup repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: setup node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
       - run: pnpm install

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,11 +8,11 @@ jobs:
         with:
           version: latest
       - name: setup repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: setup node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "20"
       - run: pnpm install


### PR DESCRIPTION
This PR bumps GitHub Actions to their latest major versions. Main change is they are now using Node 20 instead of 16, which was EOL as of April 2022:
   - Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
   - Releases for `actions/setup-node` can be [found here](https://github.com/actions/setup-node/releases)
