### PR TITLE
ci: update permissions; remove credentials

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -1,6 +1,8 @@
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     name: Lint
     steps:
       - uses: pnpm/action-setup@v4
@@ -10,9 +12,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: setup node.js
         uses: actions/setup-node@v4
         with:
+          check-latest: true
           node-version: '20'
       - run: pnpm install
       - run: pnpm build
@@ -20,6 +24,8 @@ jobs:
     timeout-minutes: 10
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     name: Test (Node.js ${{ matrix.node_js_version }})
     steps:
       - uses: pnpm/action-setup@v4
@@ -29,9 +35,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: setup node.js
         uses: actions/setup-node@v4
         with:
+          check-latest: true
           node-version: '${{ matrix.node_js_version }}'
       - run: pnpm install
       - run: pnpm test
@@ -45,6 +53,8 @@ jobs:
           - '22'
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     name: Build
     steps:
       - uses: pnpm/action-setup@v4
@@ -54,14 +64,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: setup node.js
         uses: actions/setup-node@v4
         with:
+          check-latest: true
           node-version: '20'
       - run: pnpm install
       - run: pnpm build
     timeout-minutes: 10
 name: Lint, test and build
+permissions:
+  contents: read
 on:
   pull_request:
     branches:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,6 +2,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: read
+      id-token: write
     name: Release
     steps:
       - uses: pnpm/action-setup@v4
@@ -11,9 +14,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: setup node.js
         uses: actions/setup-node@v4
         with:
+          check-latest: true
           node-version: "20"
       - run: pnpm install
       - run: pnpm build
@@ -22,6 +27,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 name: Build and release
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
This PR:

-   Removes Git credentials after checkout as a security precaution by setting `persist-credentials` to false. They are not used after the initial checkout, and this stops them from accidentally leaking through a script; [see related GitHub security post](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) and [related actions/checkout issue](https://github.com/actions/checkout/issues/485)
-   Declares the minimum permissions for the workflows to run at the workflow level in feature.yaml and at the job level in main.yaml, following principle of least privilege; see [related GitHub security post](https://securitylab.github.com/research/github-actions-building-blocks/)