### PR TITLE
fix(`text-escaping`): always allow content in example tags

### DIFF
--- a/.README/rules/text-escaping.md
+++ b/.README/rules/text-escaping.md
@@ -10,6 +10,8 @@ Markdown and you therefore do not wish for it to be accidentally interpreted
 as such by the likes of Visual Studio Code or if you wish to view it escaped
 within it or your documentation.
 
+`@example` tag content will not be checked.
+
 ## Fixer
 
 (TODO)

--- a/docs/rules/text-escaping.md
+++ b/docs/rules/text-escaping.md
@@ -19,6 +19,8 @@ Markdown and you therefore do not wish for it to be accidentally interpreted
 as such by the likes of Visual Studio Code or if you wish to view it escaped
 within it or your documentation.
 
+`@example` tag content will not be checked.
+
 <a name="user-content-text-escaping-fixer"></a>
 <a name="text-escaping-fixer"></a>
 ## Fixer
@@ -175,5 +177,21 @@ The following patterns are not considered problems:
  * to escape
  */
 // "jsdoc/text-escaping": ["error"|"warn", {"escapeHTML":true}]
+
+/**
+ * @example
+ * ```
+ * Some things to escape: <a> and &gt; and &#xabc; and `test`
+ * ```
+ */
+// "jsdoc/text-escaping": ["error"|"warn", {"escapeHTML":true}]
+
+/**
+ * @example
+ * ```
+ * Some things to escape: <a> and &gt; and &#xabc; and `test`
+ * ```
+ */
+// "jsdoc/text-escaping": ["error"|"warn", {"escapeMarkdown":true}]
 ````
 

--- a/src/rules/textEscaping.js
+++ b/src/rules/textEscaping.js
@@ -73,6 +73,9 @@ export default iterateJsdoc(({
     }
 
     for (const tag of jsdoc.tags) {
+      if (tag.tag === 'example') {
+        continue;
+      }
       if (/** @type {string[]} */ (
         utils.getTagDescription(tag, true)
       ).some((desc) => {
@@ -100,6 +103,9 @@ export default iterateJsdoc(({
   }
 
   for (const tag of jsdoc.tags) {
+    if (tag.tag === 'example') {
+      continue;
+    }
     if (/** @type {string[]} */ (
       utils.getTagDescription(tag, true)
     ).some((desc) => {

--- a/test/rules/assertions/textEscaping.js
+++ b/test/rules/assertions/textEscaping.js
@@ -316,5 +316,35 @@ export default /** @type {import('../index.js').TestCases} */ ({
         },
       ],
     },
+    {
+      code: `
+        /**
+         * @example
+         * \`\`\`
+         * Some things to escape: <a> and &gt; and &#xabc; and \`test\`
+         * \`\`\`
+         */
+      `,
+      options: [
+        {
+          escapeHTML: true,
+        },
+      ]
+    },
+    {
+      code: `
+        /**
+         * @example
+         * \`\`\`
+         * Some things to escape: <a> and &gt; and &#xabc; and \`test\`
+         * \`\`\`
+         */
+      `,
+      options: [
+        {
+          escapeMarkdown: true,
+        },
+      ]
+    },
   ],
 });


### PR DESCRIPTION
fix(`text-escaping`): always allow content in example tags; fixes #1360