### PR TITLE
fix(`empty-tags`): allow for JSDoc-block final asterisks

### DIFF
--- a/docs/rules/empty-tags.md
+++ b/docs/rules/empty-tags.md
@@ -216,5 +216,10 @@ function quux () {
  * @returns {string[]} The array of nodes.
  */
 function quux () {}
+
+/** Application boot function.
+  @async
+  @private **/
+function quux () {}
 ````
 

--- a/src/rules/emptyTags.js
+++ b/src/rules/emptyTags.js
@@ -42,9 +42,12 @@ export default iterateJsdoc(({
       settings.mode !== 'closure' && emptyIfNotClosure.has(tagName);
   });
 
-  for (const tag of emptyTags) {
+  for (const [key, tag] of emptyTags.entries()) {
     const content = tag.name || tag.description || tag.type;
-    if (content.trim()) {
+    if (content.trim() && (
+      // Allow for JSDoc-block final asterisks
+      key !== emptyTags.length - 1 || !(/^\s*\*+$/u).test(content)
+    )) {
       const fix = () => {
         // By time of call in fixer, `tag` will have `line` added
         utils.setTag(

--- a/test/rules/assertions/emptyTags.js
+++ b/test/rules/assertions/emptyTags.js
@@ -308,5 +308,13 @@ export default /** @type {import('../index.js').TestCases} */ ({
       function quux () {}
       `,
     },
+    {
+      code: `
+      /** Application boot function.
+        @async
+        @private **/
+      function quux () {}
+      `,
+    },
   ],
 });


### PR DESCRIPTION
fix(`empty-tags`): allow for JSDoc-block final asterisks; fixes #670