### PR TITLE
Add missing config type(s)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ import validTypes from './rules/validTypes.js';
 import { getJsdocProcessorPlugin } from './getJsdocProcessorPlugin.js';
 
 /**
- * @typedef {"recommended" | "stylistic" | "contents" | "logical"} ConfigGroups
+ * @typedef {"recommended" | "stylistic" | "contents" | "logical" | "requirements"} ConfigGroups
  * @typedef {"" | "-typescript" | "-typescript-flavor"} ConfigVariants
  * @typedef {"" | "-error"} ErrorLevelVariants
  * @type {import('eslint').ESLint.Plugin & {


### PR DESCRIPTION
The "requirements" group of configurations is missing from the type definition.