### PR TITLE
fix(`check-values`): workaround `parse-imports-exports` bug in handling trailing whitespace

### DIFF
--- a/docs/rules/check-values.md
+++ b/docs/rules/check-values.md
@@ -430,5 +430,10 @@ function quux (foo) {
 /**
  * @import * as Linters from "eslint"
  */
+
+/** @import { ReactNode } from 'react' */
+
+/** @type {ReactNode} */
+export const TEST = null
 ````
 

--- a/src/rules/checkValues.js
+++ b/src/rules/checkValues.js
@@ -174,7 +174,7 @@ export default iterateJsdoc(({
         ? `${typePart}${name} ${description}`
         : `${typePart}${name}`);
 
-      const importsExports = parseImportsExports(imprt);
+      const importsExports = parseImportsExports(imprt.trim());
 
       if (importsExports.errors) {
         report(

--- a/test/rules/assertions/checkValues.js
+++ b/test/rules/assertions/checkValues.js
@@ -631,5 +631,13 @@ export default /** @type {import('../index.js').TestCases} */ ({
          */
       `,
     },
+    {
+      code: `
+      /** @import { ReactNode } from 'react' */
+
+      /** @type {ReactNode} */
+      export const TEST = null
+      `,
+    },
   ],
 });


### PR DESCRIPTION
fix(`check-values`): workaround `parse-imports-exports` bug in handling trailing whitespace; fixes #1373 .