### PR TITLE
 fix(`valid-types`): fix parsing of expressions like `@returns {@link SomeType}`

### DIFF
--- a/docs/rules/valid-types.md
+++ b/docs/rules/valid-types.md
@@ -884,5 +884,9 @@ function quux() {
 /**
  * @import { TestOne, TestTwo } from "./types"
  */
+
+/**
+ * @returns {@link SomeType}
+ */
 ````
 

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -291,6 +291,14 @@ export default iterateJsdoc(({
       continue;
     }
 
+    // Documentation like `@returns {@link SomeType}` is technically ambiguous. Specifically it
+    // could either be intepreted as a type `"@link SomeType"` or a description `"{@link SomeType}"`.
+    // However this is a good heuristic.
+    if (tag.type.trim().startsWith('@')) {
+      tag.description = `{${tag.type}} ${tag.description}`;
+      tag.type = '';
+    }
+
     const mightHaveTypePosition = utils.tagMightHaveTypePosition(tag.tag, otherModeMaps);
     if (mightHaveTypePosition !== true && tag.type) {
       const modeInfo = mightHaveTypePosition === false ? '' : ` in "${mode}" mode`;

--- a/test/rules/assertions/validTypes.js
+++ b/test/rules/assertions/validTypes.js
@@ -1859,6 +1859,13 @@ export default /** @type {import('../index.js').TestCases} */ ({
          * @import { TestOne, TestTwo } from "./types"
          */
       `,
+    },
+    {
+      code: `
+        /**
+         * @returns {@link SomeType}
+         */
+      `,
     }
   ],
 });


### PR DESCRIPTION
Fixed #1381.

I looked at a handful of ways to do this:
- Hook into `@es-joy/jsdoccoment`'s `parseComment` function. Specifically I was hoping to wrap the type parsing logic. This seemed like the most elegant option but it fell flat. While this is technically possible I would have to hardcode that `getTransformer` returns the type parser at index `1` in order to wrap it and make it aware of this edge case.
- Rerun the parser with `noTypes` set to include the tag. While possible it'd mean rerunning parsing from scratch. I'm okay with switching to this approach if you'd like.
- What I actually did, which is to move `tag.type` to `tag.description` if it looks like a JSDoc tag. The type parser expects the type to be formatted as exactly `{type}` and whitespace is preserved so the conversion back is currently lossless. However even if the parser were to change to parse out more forms (e.g. ` {type}`), I reason that it doesn't really matter because `description` isn't even checked in the rest of `valid-types`.