### PR TITLE
fix(`no-undefined-types`): workaround `parse-imports-exports` bug in handling trailing whitespace

### DIFF
--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -151,7 +151,7 @@ export default iterateJsdoc(({
       ? `${typePart}${name} ${description}`
       : `${typePart}${name}`);
 
-    const importsExports = parseImportsExports(imprt);
+    const importsExports = parseImportsExports(imprt.trim());
 
     const types = [];
     const namedImports = Object.values(importsExports.namedImports || {})[0]?.[0];


### PR DESCRIPTION
fix(`no-undefined-types`): workaround `parse-imports-exports` bug in handling trailing whitespace; fixes #1373