### PR TITLE
fix(`lines-before-block`): Switch to a whitelist of punctuators

### DIFF
--- a/docs/rules/lines-before-block.md
+++ b/docs/rules/lines-before-block.md
@@ -131,6 +131,30 @@ const values = [
 // "jsdoc/lines-before-block": ["error"|"warn", {"checkBlockStarts":true}]
 // Message: Required 1 line(s) before JSDoc block
 
+const values = [
+  value1,
+  /**
+   * Description.
+   */
+  value2
+];
+// Message: Required 1 line(s) before JSDoc block
+
+const values = [
+  value1,
+  value2
+]
+/**
+ * Description.
+ */
+// Message: Required 1 line(s) before JSDoc block
+
+const value = 123
+/**
+ * Description.
+ */
+// Message: Required 1 line(s) before JSDoc block
+
 type UnionDocumentation =
   /** Description. */
   | { someProp: number }

--- a/src/rules/linesBeforeBlock.js
+++ b/src/rules/linesBeforeBlock.js
@@ -1,11 +1,11 @@
 import iterateJsdoc from '../iterateJsdoc.js';
 
 /**
- * `;` ends a previous statement, `}` ends a previous block, `|` is seen the middle of a union, and
- * `&` is seen in the middle of an intersection. All other punctuators are for things like arrays,
- * functions, type aliases, and so on that shouldn't require a line before it.
+ * Punctuators that begin a logical group should not require a line before it skipped. Specifically
+ * `[` starts an array, `{` starts an object or block, `(` starts a grouping, and `=` starts a
+ * declaration (like a variable or a type alias).
  */
-const lintedPunctuators = new Set([';', '}', '|', '&']);
+const startPunctuators = new Set(['[', '{', '(', '=']);
 
 export default iterateJsdoc(({
   context,
@@ -31,7 +31,7 @@ export default iterateJsdoc(({
     !tokenBefore || (
       tokenBefore.type === 'Punctuator' &&
       !checkBlockStarts &&
-      !lintedPunctuators.has(tokenBefore.value)
+      startPunctuators.has(tokenBefore.value)
     )
   ) {
     return;

--- a/test/rules/assertions/linesBeforeBlock.js
+++ b/test/rules/assertions/linesBeforeBlock.js
@@ -269,6 +269,82 @@ export default /** @type {import('../index.js').TestCases} */ ({
     },
     {
       code: `
+        const values = [
+          value1,
+          /**
+           * Description.
+           */
+          value2
+        ];
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Required 1 line(s) before JSDoc block'
+        }
+      ],
+      output: `
+        const values = [
+          value1,
+
+          /**
+           * Description.
+           */
+          value2
+        ];
+      `,
+    },
+    {
+      code: `
+        const values = [
+          value1,
+          value2
+        ]
+        /**
+         * Description.
+         */
+      `,
+      errors: [
+        {
+          line: 6,
+          message: 'Required 1 line(s) before JSDoc block'
+        }
+      ],
+      output: `
+        const values = [
+          value1,
+          value2
+        ]
+
+        /**
+         * Description.
+         */
+      `,
+    },
+    {
+      // This test is interesting due to the lack of semicolons.
+      code: `
+        const value = 123
+        /**
+         * Description.
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Required 1 line(s) before JSDoc block'
+        }
+      ],
+      output: `
+        const value = 123
+
+        /**
+         * Description.
+         */
+      `,
+    },
+    {
+      code: `
         type UnionDocumentation =
           /** Description. */
           | { someProp: number }


### PR DESCRIPTION
A follow up to #1383. Sorry for another PR in quick succession along the same lines. However I was thinking about the solution and I wasn't happy with having to maintain a list of punctuators that are checked. Specifically I began to feel like the default should be checking. I also added some more tests to cover some interesting cases I thought of.