### PR TITLE
fix(`no-undefined-types`): avoid eslint 8 error

### DIFF
--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -261,7 +261,12 @@ export default iterateJsdoc(({
     .concat(importTags)
     .concat(definedTypes)
     .concat(/** @type {string[]} */ (definedPreferredTypes))
-    .concat(...getValidRuntimeIdentifiers(node && sourceCode.getScope(node)))
+    .concat(...getValidRuntimeIdentifiers(node && (
+      (sourceCode.getScope &&
+      /* c8 ignore next 2 */
+      sourceCode.getScope(node)) ||
+      context.getScope()
+    )))
     .concat(
       settings.mode === 'jsdoc' ?
         [] :


### PR DESCRIPTION
fixes #1387