### PR TITLE
feat(getJsdocProcessorPlugin): allow `exampleCodeRegex` and `rejectExampleCodeRegex` to be RegExp objects

### DIFF
--- a/src/getJsdocProcessorPlugin.js
+++ b/src/getJsdocProcessorPlugin.js
@@ -90,8 +90,8 @@ const getLinesCols = (text) => {
  * @property {string} [matchingFileNameDefaults] See docs
  * @property {string} [matchingFileNameParams] See docs
  * @property {string} [matchingFileNameProperties] See docs
- * @property {string} [exampleCodeRegex] See docs
- * @property {string} [rejectExampleCodeRegex] See docs
+ * @property {string|RegExp} [exampleCodeRegex] See docs
+ * @property {string|RegExp} [rejectExampleCodeRegex] See docs
  * @property {string[]} [allowedLanguagesToProcess] See docs
  * @property {"script"|"module"} [sourceType] See docs
  * @property {import('eslint').Linter.ESTreeParser|import('eslint').Linter.NonESTreeParser} [parser] See docs
@@ -129,11 +129,15 @@ export const getJsdocProcessorPlugin = (options = {}) => {
   let rejectExampleCodeRegExp;
 
   if (exampleCodeRegex) {
-    exampleCodeRegExp = getRegexFromString(exampleCodeRegex);
+    exampleCodeRegExp = typeof exampleCodeRegex === 'string' ?
+      getRegexFromString(exampleCodeRegex) :
+      exampleCodeRegex;
   }
 
   if (rejectExampleCodeRegex) {
-    rejectExampleCodeRegExp = getRegexFromString(rejectExampleCodeRegex);
+    rejectExampleCodeRegExp = typeof rejectExampleCodeRegex === 'string' ?
+      getRegexFromString(rejectExampleCodeRegex) :
+      rejectExampleCodeRegex;
   }
 
   /**
@@ -646,7 +650,8 @@ export const getJsdocProcessorPlugin = (options = {}) => {
 
           return [];
         },
-        supportsAutofix: true,
+        // Todo: Reenable
+        supportsAutofix: false,
       },
     },
   };

--- a/test/getJsdocProcessPlugin.js
+++ b/test/getJsdocProcessPlugin.js
@@ -92,6 +92,34 @@ describe('`getJsdocProcessorPlugin`', () => {
     });
   });
 
+  it('returns text and files with `exampleCodeRegex` (as RegExp)', () => {
+    const options = {
+      exampleCodeRegex: /```js([\s\S]*)```/u,
+    };
+    const filename = 'something.js';
+    const text = `
+    /**
+     * @example
+     * \`\`\`js
+     * doSth('a');
+     * \`\`\`
+     */
+    function doSth () {}
+    `;
+    check({
+      filename,
+      options,
+      result: [
+        text,
+        {
+          filename: 'something.md/*.js',
+          text: '\ndoSth(\'a\');\n',
+        },
+      ],
+      text,
+    });
+  });
+
   it('returns text and files with `exampleCodeRegex` (no parentheses)', () => {
     const options = {
       exampleCodeRegex: '// begin[\\s\\S]*// end',
@@ -216,6 +244,39 @@ describe('`getJsdocProcessorPlugin`', () => {
   it('returns text and files (with `rejectExampleCodeRegex`)', () => {
     const options = {
       rejectExampleCodeRegex: '^\\s*<.*>\\s*$',
+    };
+    const filename = 'something.js';
+    const text = `
+      /**
+       * @example <b>Not JavaScript</b>
+       */
+      function quux () {
+
+      }
+      /**
+       * @example quux2();
+       */
+      function quux2 () {
+
+      }
+    `;
+    check({
+      filename,
+      options,
+      result: [
+        text,
+        {
+          filename: 'something.md/*.js',
+          text: 'quux2();',
+        },
+      ],
+      text,
+    });
+  });
+
+  it('returns text and files (with `rejectExampleCodeRegex`) as RegExp', () => {
+    const options = {
+      rejectExampleCodeRegex: /^\s*<.*>\s*$/u,
     };
     const filename = 'something.js';
     const text = `


### PR DESCRIPTION
feat(getJsdocProcessorPlugin): allow `exampleCodeRegex` and `rejectExampleCodeRegex` to be RegExp objects

Also:
- fix(getJsdocProcessorPlugin): avoid auto-fix being triggered for example text while we still have no fixers applied