### PR TITLE
fix: revert "fix: require node v22"

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '20.11.0'
       - run: pnpm install
       - run: pnpm build
       - run: pnpm lint
@@ -40,6 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         node_js_version:
+          - '20.11.0'
           - '22'
   build:
     runs-on: ubuntu-latest
@@ -55,7 +56,7 @@ jobs:
       - name: setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '20.11.0'
       - run: pnpm install
       - run: pnpm build
     timeout-minutes: 10

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "typescript-eslint": "^8.33.0"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=20.11.0"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
Fixes #1398

This reverts commit f85ffc6186162c8a600ecf9106565461884146a9. to allow Node v20.11.0+