### PR TITLE
fix(`check-template-names`): checks class body for comments where template names used

### DIFF
--- a/docs/rules/check-template-names.md
+++ b/docs/rules/check-template-names.md
@@ -372,5 +372,28 @@ export function mapGroupBy(array, callbackFn) {
  * @function
  * @param {[D, V | undefined]} someParam
  */
+
+/**
+ * @template {string} U
+ */
+export class User {
+  /**
+   * @type {U}
+   */
+  name;
+}
+
+/**
+ * @template {string} U
+ */
+export class User {
+  /**
+   * @param {U} name
+   */
+  constructor(name) {
+    this.name = name;
+  }
+  methodToIgnore() {}
+}
 ````
 

--- a/test/rules/assertions/checkTemplateNames.js
+++ b/test/rules/assertions/checkTemplateNames.js
@@ -716,5 +716,37 @@ export default /** @type {import('../index.js').TestCases} */ ({
          */
       `,
     },
+    {
+      code: `
+        /**
+         * @template {string} U
+         */
+        export class User {
+          /**
+           * @type {U}
+           */
+          name;
+        }
+      `,
+      languageOptions: {
+        ecmaVersion: 2_022,
+      },
+    },
+    {
+      code: `
+        /**
+         * @template {string} U
+         */
+        export class User {
+          /**
+           * @param {U} name
+           */
+          constructor(name) {
+            this.name = name;
+          }
+          methodToIgnore() {}
+        }
+      `,
+    },
   ],
 });


### PR DESCRIPTION
fix(`check-template-names`): checks class body for comments where template names used; fixes #1354