### PR TITLE
fix(`no-undefined-types`): liberalize checks to reallow for unknown properties on imports and defined globals

### DIFF
--- a/docs/rules/no-undefined-types.md
+++ b/docs/rules/no-undefined-types.md
@@ -919,5 +919,26 @@ class Foo {
     return "bar";
   }
 }
+
+/* globals SomeGlobal, AnotherGlobal */
+import * as Ably from "ably"
+import Testing, { another as Another, stillMore as StillMore } from "testing"
+
+export class Code {
+    /** @type {Ably.Realtime} */
+    static #client
+
+    /** @type {Testing.SomeMethod} */
+    static #test
+
+    /** @type {Another.AnotherMethod} */
+    static #test2
+
+    /** @type {StillMore.AnotherMethod} */
+    static #test3
+
+    /** @type {AnotherGlobal.AnotherMethod} */
+    static #test4
+}
 ````
 

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -1624,5 +1624,32 @@ export default /** @type {import('../index.js').TestCases} */ ({
         ecmaVersion: 2_022,
       },
     },
+    {
+      code: `
+        /* globals SomeGlobal, AnotherGlobal */
+        import * as Ably from "ably"
+        import Testing, { another as Another, stillMore as StillMore } from "testing"
+
+        export class Code {
+            /** @type {Ably.Realtime} */
+            static #client
+
+            /** @type {Testing.SomeMethod} */
+            static #test
+
+            /** @type {Another.AnotherMethod} */
+            static #test2
+
+            /** @type {StillMore.AnotherMethod} */
+            static #test3
+
+            /** @type {AnotherGlobal.AnotherMethod} */
+            static #test4
+        }
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+    },
   ],
 });


### PR DESCRIPTION
fix(`no-undefined-types`): liberalize checks to reallow for unknown properties on imports and defined globals; fixes #1412