### PR TITLE
fix(`no-undefined-types`): also allow globals defined on `languageOptions`

### DIFF
--- a/docs/rules/no-undefined-types.md
+++ b/docs/rules/no-undefined-types.md
@@ -939,6 +939,9 @@ export class Code {
 
     /** @type {AnotherGlobal.AnotherMethod} */
     static #test4
+
+    /** @type {AGlobal.AnotherMethod} */
+    static #test5
 }
 ````
 

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -126,7 +126,7 @@ export default iterateJsdoc(({
       return (/^\s*globals/u).test(comment.value);
     }).flatMap((commentNode) => {
       return commentNode.value.replace(/^\s*globals/u, '').trim().split(/,\s*/u);
-    });
+    }).concat(Object.keys(context.languageOptions.globals ?? []));
 
   const typedefDeclarations = comments
     .flatMap((doc) => {

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -1645,9 +1645,15 @@ export default /** @type {import('../index.js').TestCases} */ ({
 
             /** @type {AnotherGlobal.AnotherMethod} */
             static #test4
+
+            /** @type {AGlobal.AnotherMethod} */
+            static #test5
         }
       `,
       languageOptions: {
+        globals: {
+          AGlobal: 'readonly',
+        },
         parser: typescriptEslintParser,
       },
     },


### PR DESCRIPTION
fix(`no-undefined-types`): also allow globals defined on `languageOptions`