### PR TITLE
fix(`require-template`, `no-undefined-types`, `valid-types`): properly parse template tags with defaults

### DIFF
--- a/docs/rules/require-template.md
+++ b/docs/rules/require-template.md
@@ -354,5 +354,13 @@ export default class <NumType> {
  * @callback
  * @returns {[Something | undefined]}
  */
+
+/**
+ * @template {string | Buffer} [T=string, U=number]
+ * @typedef {object} Dirent
+ * @property {T} name name
+ * @property {U} aNumber number
+ * @property {string} parentPath path
+ */
 ````
 

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -1495,7 +1495,7 @@ const parseClosureTemplateTag = (tag) => {
   return tag.name
     .split(',')
     .map((type) => {
-      return type.trim().replace(/^\[(?<name>.*?)=.*\]$/u, '$<name>');
+      return type.trim().replace(/^\[?(?<name>.*?)=.*$/u, '$<name>');
     });
 };
 

--- a/src/rules/requireTemplate.js
+++ b/src/rules/requireTemplate.js
@@ -22,19 +22,19 @@ export default iterateJsdoc(({
 
   const usedNames = new Set();
   const templateTags = utils.getTags('template');
-  const templateNames = templateTags.flatMap(({
-    name,
-  }) => {
-    return name.split(/,\s*/u);
+  const templateNames = templateTags.flatMap((tag) => {
+    return utils.parseClosureTemplateTag(tag);
   });
 
-  for (const tag of templateTags) {
-    const {
-      name,
-    } = tag;
-    const names = name.split(/,\s*/u);
-    if (requireSeparateTemplates && names.length > 1) {
-      report(`Missing separate @template for ${names[1]}`, null, tag);
+  if (requireSeparateTemplates) {
+    for (const tag of templateTags) {
+      const {
+        name,
+      } = tag;
+      const names = name.split(/,\s*/u);
+      if (names.length > 1) {
+        report(`Missing separate @template for ${names[1]}`, null, tag);
+      }
     }
   }
 

--- a/test/rules/assertions/requireTemplate.js
+++ b/test/rules/assertions/requireTemplate.js
@@ -634,5 +634,16 @@ export default /** @type {import('../index.js').TestCases} */ ({
          */
       `,
     },
+    {
+      code: `
+        /**
+         * @template {string | Buffer} [T=string, U=number]
+         * @typedef {object} Dirent
+         * @property {T} name name
+         * @property {U} aNumber number
+         * @property {string} parentPath path
+         */
+      `,
+    },
   ],
 });


### PR DESCRIPTION
fix(`require-template`, `no-undefined-types`, `valid-types`): properly parse template tags with defaults; fixes #1418