### PR TITLE
fix(`no-undefined-types`): Add `Intl` to global types and ensure arbitrary properties of globals can be addressed

### DIFF
--- a/docs/rules/no-undefined-types.md
+++ b/docs/rules/no-undefined-types.md
@@ -989,5 +989,12 @@ class SomeClass {
  * {@link SomeClass.someMethod}
  * @returns something
  */
+
+/**
+ * The internationalized collator object that will be used.
+ * Intl.Collator(null, {numeric: true, sensitivity: 'base'}) is used by default;.
+ *
+ * @member {Intl.Collator}
+ */
 ````
 

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -17,7 +17,7 @@ const extraTypes = [
   'number', 'bigint', 'NaN', 'Infinity',
   'any', '*', 'never', 'unknown', 'const',
   'this', 'true', 'false',
-  'Array', 'Object', 'RegExp', 'Date', 'Function',
+  'Array', 'Object', 'RegExp', 'Date', 'Function', 'Intl',
 ];
 
 const typescriptGlobals = [
@@ -471,6 +471,7 @@ export default iterateJsdoc(({
           //  check their properties which may or may not exist
           !imports.includes(val) && !globals.includes(val) &&
           !importTags.includes(val) &&
+          !extraTypes.includes(val) &&
           !typedefDeclarations.includes(val) &&
           currNode && 'right' in currNode &&
           currNode.right?.type === 'JsdocTypeProperty') {

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -1719,5 +1719,15 @@ export default /** @type {import('../index.js').TestCases} */ ({
          */
       `,
     },
+    {
+      code: `
+        /**
+         * The internationalized collator object that will be used.
+         * Intl.Collator(null, {numeric: true, sensitivity: 'base'}) is used by default;.
+         *
+         * @member {Intl.Collator}
+         */
+      `,
+    },
   ],
 });


### PR DESCRIPTION
fix(`no-undefined-types`): Add `Intl` to global types and ensure arbitrary properties of globals can be addressed; fixes #1423