### PR TITLE
fix(`no-undefined-types`): exempt global requires from undefined property checks

### DIFF
--- a/docs/rules/no-undefined-types.md
+++ b/docs/rules/no-undefined-types.md
@@ -996,5 +996,13 @@ class SomeClass {
  *
  * @member {Intl.Collator}
  */
+
+const otherFile = require('./other-file');
+
+/**
+ * A function
+ * @param {otherFile.MyType} a
+ */
+function f(a) {}
 ````
 

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -312,6 +312,19 @@ export default iterateJsdoc(({
                   return `${name}.${property}`;
                 }).filter(Boolean),
               ];
+            case 'VariableDeclarator':
+              if (/** @type {import('@typescript-eslint/types').TSESTree.Identifier} */ (
+                /** @type {import('@typescript-eslint/types').TSESTree.CallExpression} */ (
+                  globalItem?.init
+                )?.callee)?.name === 'require'
+              ) {
+                imports.push(/** @type {import('@typescript-eslint/types').TSESTree.Identifier} */ (
+                  globalItem.id
+                ).name);
+                break;
+              }
+
+              return [];
           }
 
           return [

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -1729,5 +1729,16 @@ export default /** @type {import('../index.js').TestCases} */ ({
          */
       `,
     },
+    {
+      code: `
+        const otherFile = require('./other-file');
+
+        /**
+         * A function
+         * @param {otherFile.MyType} a
+         */
+        function f(a) {}
+      `,
+    },
   ],
 });


### PR DESCRIPTION
fix(`no-undefined-types`): exempt global requires from undefined property checks; fixes #1425