### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/src/rules/matchName.js
+++ b/src/rules/matchName.js
@@ -107,8 +107,8 @@ export default iterateJsdoc(({
         additionalProperties: false,
         properties: {
           match: {
-            additionalProperties: false,
             items: {
+              additionalProperties: false,
               properties: {
                 allowName: {
                   type: 'string',
@@ -123,6 +123,9 @@ export default iterateJsdoc(({
                   type: 'string',
                 },
                 message: {
+                  type: 'string',
+                },
+                replacement: {
                   type: 'string',
                 },
                 tags: {

--- a/src/rules/requireAsteriskPrefix.js
+++ b/src/rules/requireAsteriskPrefix.js
@@ -158,6 +158,7 @@ export default iterateJsdoc(({
         additionalProperties: false,
         properties: {
           tags: {
+            additionalProperties: false,
             properties: {
               always: {
                 items: {

--- a/src/rules/sortTags.js
+++ b/src/rules/sortTags.js
@@ -536,6 +536,7 @@ export default iterateJsdoc(({
           },
           tagSequence: {
             items: {
+              additionalProperties: false,
               properties: {
                 tags: {
                   items: {


### PR DESCRIPTION
Some rules, for example [match-name](https://github.com/gajus/eslint-plugin-jsdoc/blob/1f015ca70a13d055b4ebd2b8638b4be35abc05ba/src/rules/matchName.js#L112) currently allow extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in rules' schemas which currently allow them.