### PR TITLE
fix: use `v` flag in regexes; match emojis for sentence terminator

### DIFF
--- a/.README/rules/check-examples.md
+++ b/.README/rules/check-examples.md
@@ -37,7 +37,7 @@ syntax highlighting). The following options determine whether a given
   exists or matches, the whole matching expression will be used.
   An example might be ````"^```(?:js|javascript)([\\s\\S]*)```\s*$"````
   to only match explicitly fenced JavaScript blocks. Defaults to only
-  using the `u` flag, so to add your own flags, encapsulate your
+  using the `v` flag, so to add your own flags, encapsulate your
   expression as a string, but like a literal, e.g., ````/```js.*```/gi````.
   Note that specifying a global regular expression (i.e., with `g`) will
   allow independent linting of matched blocks within a single `@example`.
@@ -45,7 +45,7 @@ syntax highlighting). The following options determine whether a given
   non-lintable examples (has priority over `exampleCodeRegex`). An example
   might be ```"^`"``` to avoid linting fenced blocks which may indicate
   a non-JavaScript language. See `exampleCodeRegex` on how to add flags
-  if the default `u` is not sufficient.
+  if the default `v` is not sufficient.
 
 If neither is in use, all examples will be matched. Note also that even if
 `captionRequired` is not set, any initial `<caption>` will be stripped out

--- a/.README/rules/check-values.md
+++ b/.README/rules/check-values.md
@@ -34,16 +34,16 @@ If present as an array, will be used in place of SPDX identifiers.
 
 ### `licensePattern`
 
-A string to be converted into a `RegExp` (with `u` flag) and whose first
+A string to be converted into a `RegExp` (with `v` flag) and whose first
 parenthetical grouping, if present, will match the portion of the license
 description to check (if no grouping is present, then the whole portion
-matched will be used). Defaults to `/([^\n\r]*)/gu`, i.e., the SPDX expression
+matched will be used). Defaults to `/([^\n\r]*)/gv`, i.e., the SPDX expression
 is expected before any line breaks.
 
 Note that the `/` delimiters are optional, but necessary to add flags.
 
-Defaults to using the `u` flag, so to add your own flags, encapsulate
-your expression as a string, but like a literal, e.g., `/^mit$/ui`.
+Defaults to using the `v` flag, so to add your own flags, encapsulate
+your expression as a string, but like a literal, e.g., `/^mit$/vi`.
 
 ### `numericOnlyVariation`
 

--- a/.README/rules/match-description.md
+++ b/.README/rules/match-description.md
@@ -8,7 +8,7 @@ The default is this basic expression to match English sentences (Support
 for Unicode upper case may be added in a future version when it can be handled
 by our supported Node versions):
 
-``^\n?([A-Z`\\d_][\\s\\S]*[.?!`]\\s*)?$``
+``^\n?([A-Z`\\d_][\\s\\S]*[.?!`\\p{RGI_Emoji}]\\s*)?$``
 
 Applies by default to the jsdoc block description and to the following tags:
 
@@ -19,9 +19,9 @@ Applies by default to the jsdoc block description and to the following tags:
 
 In addition, the `tags` option (see below) may be used to match other tags.
 
-The default (and all regex options) defaults to using (only) the `u` flag, so
+The default (and all regex options) defaults to using (only) the `v` flag, so
 to add your own flags, encapsulate your expression as a string, but like a
-literal, e.g., `/[A-Z].*\\./ui`.
+literal, e.g., `/[A-Z].*\\./vi`.
 
 Note that `/` delimiters are optional, but necessary to add flags (besides
 `u`).

--- a/.README/rules/require-param.md
+++ b/.README/rules/require-param.md
@@ -307,7 +307,7 @@ export const bboxToObj = function ({x, y, width, height}) {
 ```
 
 By default `checkTypesPattern` is set to
-`/^(?:[oO]bject|[aA]rray|PlainObject|Generic(?:Object|Array))$/u`,
+`/^(?:[oO]bject|[aA]rray|PlainObject|Generic(?:Object|Array))$/v`,
 meaning that destructuring will be required only if the type of the `@param`
 (the text between curly brackets) is a match for "Object" or "Array" (with or
 without initial caps), "PlainObject", or "GenericObject", "GenericArray" (or
@@ -317,8 +317,8 @@ parameters.
 
 Note that the `/` delimiters are optional, but necessary to add flags.
 
-Defaults to using (only) the `u` flag, so to add your own flags, encapsulate
-your expression as a string, but like a literal, e.g., `/^object$/ui`.
+Defaults to using (only) the `v` flag, so to add your own flags, encapsulate
+your expression as a string, but like a literal, e.g., `/^object$/vi`.
 
 You could set this regular expression to a more expansive list, or you
 could restrict it such that even types matching those strings would not

--- a/docs/rules/check-examples.md
+++ b/docs/rules/check-examples.md
@@ -56,7 +56,7 @@ syntax highlighting). The following options determine whether a given
   exists or matches, the whole matching expression will be used.
   An example might be ````"^```(?:js|javascript)([\\s\\S]*)```\s*$"````
   to only match explicitly fenced JavaScript blocks. Defaults to only
-  using the `u` flag, so to add your own flags, encapsulate your
+  using the `v` flag, so to add your own flags, encapsulate your
   expression as a string, but like a literal, e.g., ````/```js.*```/gi````.
   Note that specifying a global regular expression (i.e., with `g`) will
   allow independent linting of matched blocks within a single `@example`.
@@ -64,7 +64,7 @@ syntax highlighting). The following options determine whether a given
   non-lintable examples (has priority over `exampleCodeRegex`). An example
   might be ```"^`"``` to avoid linting fenced blocks which may indicate
   a non-JavaScript language. See `exampleCodeRegex` on how to add flags
-  if the default `u` is not sufficient.
+  if the default `v` is not sufficient.
 
 If neither is in use, all examples will be matched. Note also that even if
 `captionRequired` is not set, any initial `<caption>` will be stripped out

--- a/docs/rules/check-values.md
+++ b/docs/rules/check-values.md
@@ -52,16 +52,16 @@ If present as an array, will be used in place of SPDX identifiers.
 <a name="check-values-options-licensepattern"></a>
 ### <code>licensePattern</code>
 
-A string to be converted into a `RegExp` (with `u` flag) and whose first
+A string to be converted into a `RegExp` (with `v` flag) and whose first
 parenthetical grouping, if present, will match the portion of the license
 description to check (if no grouping is present, then the whole portion
-matched will be used). Defaults to `/([^\n\r]*)/gu`, i.e., the SPDX expression
+matched will be used). Defaults to `/([^\n\r]*)/gv`, i.e., the SPDX expression
 is expected before any line breaks.
 
 Note that the `/` delimiters are optional, but necessary to add flags.
 
-Defaults to using the `u` flag, so to add your own flags, encapsulate
-your expression as a string, but like a literal, e.g., `/^mit$/ui`.
+Defaults to using the `v` flag, so to add your own flags, encapsulate
+your expression as a string, but like a literal, e.g., `/^mit$/vi`.
 
 <a name="user-content-check-values-options-numericonlyvariation"></a>
 <a name="check-values-options-numericonlyvariation"></a>

--- a/docs/rules/match-description.md
+++ b/docs/rules/match-description.md
@@ -20,7 +20,7 @@ The default is this basic expression to match English sentences (Support
 for Unicode upper case may be added in a future version when it can be handled
 by our supported Node versions):
 
-``^\n?([A-Z`\\d_][\\s\\S]*[.?!`]\\s*)?$``
+``^\n?([A-Z`\\d_][\\s\\S]*[.?!`\\p{RGI_Emoji}]\\s*)?$``
 
 Applies by default to the jsdoc block description and to the following tags:
 
@@ -31,9 +31,9 @@ Applies by default to the jsdoc block description and to the following tags:
 
 In addition, the `tags` option (see below) may be used to match other tags.
 
-The default (and all regex options) defaults to using (only) the `u` flag, so
+The default (and all regex options) defaults to using (only) the `v` flag, so
 to add your own flags, encapsulate your expression as a string, but like a
-literal, e.g., `/[A-Z].*\\./ui`.
+literal, e.g., `/[A-Z].*\\./vi`.
 
 Note that `/` delimiters are optional, but necessary to add flags (besides
 `u`).
@@ -970,7 +970,7 @@ function quux (foo) {
  * - the `loadScript` option is set to `true`.
  * @param enabled `true` to enable, `false` to disable. Default: `true`.
  */
-// "jsdoc/match-description": ["error"|"warn", {"contexts":["any"],"mainDescription":"/^[A-Z`-].*\\.$/us","matchDescription":"^([A-Z`-].*(\\.|:)|-\\s.*)$","tags":{"param":true,"returns":true}}]
+// "jsdoc/match-description": ["error"|"warn", {"contexts":["any"],"mainDescription":"/^[A-Z`\\-].*\\.$/vs","matchDescription":"^([A-Z`\\-].*(\\.|:)|-\\s.*)$","tags":{"param":true,"returns":true}}]
 
 /**
  * @constructor
@@ -998,5 +998,10 @@ function foo(): void;
 function quux () {
 }
 // "jsdoc/match-description": ["error"|"warn", {"nonemptyTags":false}]
+
+/**
+ * Example text. 🙂
+ */
+export const example = () => { };
 ````
 

--- a/docs/rules/match-name.md
+++ b/docs/rules/match-name.md
@@ -183,7 +183,7 @@ function quux () {}
  * @template
  */
 // "jsdoc/match-name": ["error"|"warn", {"match":[{"disallowName":"/^$/","tags":["template"]}]}]
-// Message: Only allowing names not matching `/^$/u` but found "".
+// Message: Only allowing names not matching `/^$/v` but found "".
 ````
 
 

--- a/docs/rules/require-param.md
+++ b/docs/rules/require-param.md
@@ -362,7 +362,7 @@ export const bboxToObj = function ({x, y, width, height}) {
 ```
 
 By default `checkTypesPattern` is set to
-`/^(?:[oO]bject|[aA]rray|PlainObject|Generic(?:Object|Array))$/u`,
+`/^(?:[oO]bject|[aA]rray|PlainObject|Generic(?:Object|Array))$/v`,
 meaning that destructuring will be required only if the type of the `@param`
 (the text between curly brackets) is a match for "Object" or "Array" (with or
 without initial caps), "PlainObject", or "GenericObject", "GenericArray" (or
@@ -372,8 +372,8 @@ parameters.
 
 Note that the `/` delimiters are optional, but necessary to add flags.
 
-Defaults to using (only) the `u` flag, so to add your own flags, encapsulate
-your expression as a string, but like a literal, e.g., `/^object$/ui`.
+Defaults to using (only) the `v` flag, so to add your own flags, encapsulate
+your expression as a string, but like a literal, e.g., `/^object$/vi`.
 
 You could set this regular expression to a more expansive list, or you
 could restrict it such that even types matching those strings would not

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,6 +39,12 @@ export default [
       'linebreak-style': 0,
       'no-inline-comments': 0,
       'prefer-named-capture-group': 0,
+      'require-unicode-regexp': [
+        'error',
+        {
+          requireFlag: 'v',
+        },
+      ],
       'unicorn/import-index': 0,
       'unicorn/no-array-reduce': 0,
       'unicorn/no-unsafe-regex': 0,

--- a/src/alignTransform.js
+++ b/src/alignTransform.js
@@ -308,7 +308,7 @@ const alignTransform = ({
     }
 
     const postHyphenSpacing = customSpacings?.postHyphen ?? 1;
-    const hyphenSpacing = /^\s*-\s+/u;
+    const hyphenSpacing = /^\s*-\s+/v;
     tokens.description = tokens.description.replace(
       hyphenSpacing, '-' + ''.padStart(postHyphenSpacing, ' '),
     );

--- a/src/bin/generateDocs.js
+++ b/src/bin/generateDocs.js
@@ -16,10 +16,10 @@ const dirname = import.meta.dirname;
  * @returns {string}
  */
 const trimCode = (code) => {
-  let lines = code.replace(/^\n/u, '').trimEnd().split('\n');
+  let lines = code.replace(/^\n/v, '').trimEnd().split('\n');
 
-  const firsLineIndentation = lines[0].match(/^\s+/u);
-  const lastLineIndentation = lines[lines.length - 1].match(/^\s+/u);
+  const firsLineIndentation = lines[0].match(/^\s+/v);
+  const lastLineIndentation = lines[lines.length - 1].match(/^\s+/v);
 
   const firstIndentSize = firsLineIndentation ? firsLineIndentation[0].length : 0;
   const lastIndentSize = lastLineIndentation ? lastLineIndentation[0].length : 0;
@@ -117,7 +117,7 @@ const getSomeBranch = () => {
   const gitConfig = fs.readFileSync(path.join(dirname, '../../.git/config')).toString();
   const [
     , branch,
-  ] = /\[branch "([^"]+)"\]/u.exec(gitConfig) || [];
+  ] = /\[branch "([^"]+)"\]/v.exec(gitConfig) || [];
 
   return branch;
 };
@@ -164,7 +164,7 @@ const generateDocs = async () => {
 
   return docContents.map((docContent) => {
     return docContent.replaceAll(
-      /<!-- assertions-(passing|failing) ([a-z]+?) -->/gui,
+      /<!-- assertions-(passing|failing) ([a-z]+?) -->/gvi,
       /**
        * @param {string} _assertionsBlock
        * @param {string} passingFailing
@@ -218,8 +218,8 @@ const getDocPaths = () => {
       return fs.readdirSync(innerBasePath).map((innerDocFile) => {
         return path.join(writeInnerBasePath, innerDocFile);
       }).sort((a, b) => {
-        const newA = a.replace(/\.md/u, '');
-        const newB = b.replace(/\.md/u, '');
+        const newA = a.replace(/\.md/v, '');
+        const newB = b.replace(/\.md/v, '');
         return newA < newB ? -1 : (newB > newA ? 1 : 0);
       });
     }

--- a/src/bin/generateOptions.mjs
+++ b/src/bin/generateOptions.mjs
@@ -27,7 +27,7 @@ for (const file of dirContents) {
   const fileContents = await readFile(join(rulesDir, file), 'utf8');
   // console.log('file', file);
   const ast = parse(fileContents, {
-    ecmaVersion: 2_022,
+    ecmaVersion: 2_024,
     sourceType: 'module',
   });
   const results = esquery.query(
@@ -69,11 +69,11 @@ for (const file of dirContents) {
 
     const hyphenatedRule = decamelize(file, {
       separator: '-',
-    }).replace(/\.js$/u, '.md');
+    }).replace(/\.js$/v, '.md');
     const docPath = join('.README/rules', hyphenatedRule);
 
     const ruleDocs = (await readFile(docPath, 'utf8'))
-      .replace(/(\|\s*Options\s*\|)([^|]*)(\|)?/u, `$1${
+      .replace(/(\|\s*Options\s*\|)([^\|]*)(\|)?/v, `$1${
         initial +
         Object.keys(obj.properties).map((key) => {
           return `\`${key}\``;

--- a/src/bin/generateRule.js
+++ b/src/bin/generateRule.js
@@ -33,7 +33,7 @@ const recommended = options.includes('--recommended');
     return;
   }
 
-  if ((/[A-Z]/u).test(ruleName)) {
+  if ((/[A-Z]/v).test(ruleName)) {
     console.error('Please ensure the rule has no capital letters');
 
     return;
@@ -241,7 +241,7 @@ export default iterateJsdoc(({
   // await replaceInOrder({
   //   checkName: 'README',
   //   newLine: `{"gitdown": "include", "file": "./rules/${ruleName}.md"}`,
-  //   oldRegex: /\n\{"gitdown": "include", "file": ".\/rules\/(?<oldRule>[^.]*).md"\}/gu,
+  //   oldRegex: /\n\{"gitdown": "include", "file": ".\/rules\/(?<oldRule>[^.]*).md"\}/gv,
   //   path: './.README/README.md',
   // });
 
@@ -249,21 +249,21 @@ export default iterateJsdoc(({
     checkName: 'index import',
     newLine: `import ${camelCasedRuleName} from './rules/${camelCasedRuleName}.js';`,
     oldIsCamel: true,
-    oldRegex: /\nimport (?<oldRule>[^ ]*) from '.\/rules\/\1\.js';/gu,
+    oldRegex: /\nimport (?<oldRule>[^ ]*) from '.\/rules\/\1\.js';/gv,
     path: './src/index.js',
   });
 
   await replaceInOrder({
     checkName: 'index recommended',
     newLine: `${' '.repeat(6)}'jsdoc/${ruleName}': ${recommended ? 'warnOrError' : '\'off\''},`,
-    oldRegex: /\n\s{6}'jsdoc\/(?<oldRule>[^']*)': .*?,/gu,
+    oldRegex: /\n\s{6}'jsdoc\/(?<oldRule>[^']*)': .*?,/gv,
     path: './src/index.js',
   });
 
   await replaceInOrder({
     checkName: 'index rules',
     newLine: `${' '.repeat(4)}'${ruleName}': ${camelCasedRuleName},`,
-    oldRegex: /\n\s{4}'(?<oldRule>[^']*)': [^,]*,/gu,
+    oldRegex: /\n\s{4}'(?<oldRule>[^']*)': [^,]*,/gv,
     path: './src/index.js',
   });
 

--- a/src/getJsdocProcessorPlugin.js
+++ b/src/getJsdocProcessorPlugin.js
@@ -30,14 +30,14 @@ const preTagSpaceLength = 1;
 // If a space is present, we should ignore it
 const firstLinePrefixLength = preTagSpaceLength;
 
-const hasCaptionRegex = /^\s*<caption>([\s\S]*?)<\/caption>/u;
+const hasCaptionRegex = /^\s*<caption>([\s\S]*?)<\/caption>/v;
 
 /**
  * @param {string} str
  * @returns {string}
  */
 const escapeStringRegexp = (str) => {
-  return str.replaceAll(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+  return str.replaceAll(/[.*+?^$\{\}\(\)\|\[\]\\]/gv, '\\$&');
 };
 
 /**
@@ -46,7 +46,7 @@ const escapeStringRegexp = (str) => {
  * @returns {import('./iterateJsdoc.js').Integer}
  */
 const countChars = (str, ch) => {
-  return (str.match(new RegExp(escapeStringRegexp(ch), 'gu')) || []).length;
+  return (str.match(new RegExp(escapeStringRegexp(ch), 'gv')) || []).length;
 };
 
 /**
@@ -221,7 +221,7 @@ export const getJsdocProcessorPlugin = (options = {}) => {
         string,
       }) {
         const src = paddedIndent ?
-          string.replaceAll(new RegExp(`(^|\n) {${paddedIndent}}(?!$)`, 'gu'), '\n') :
+          string.replaceAll(new RegExp(`(^|\n) {${paddedIndent}}(?!$)`, 'gv'), '\n') :
           string;
 
         // Programmatic ESLint API: https://eslint.org/docs/developer-guide/nodejs-api
@@ -274,7 +274,7 @@ export const getJsdocProcessorPlugin = (options = {}) => {
       let defaultFileName;
       if (!filename) {
         if (typeof jsFileName === 'string' && jsFileName.includes('.')) {
-          defaultFileName = jsFileName.replace(/\.[^.]*$/u, `.${ext}`);
+          defaultFileName = jsFileName.replace(/\.[^.]*$/v, `.${ext}`);
         } else {
           defaultFileName = `dummy.${ext}`;
         }
@@ -376,7 +376,7 @@ export const getJsdocProcessorPlugin = (options = {}) => {
 
       // If `allowedLanguagesToProcess` is falsy, all languages should be processed.
       if (allowedLanguagesToProcess) {
-        const matches = (/^\s*```(?<language>\S+)([\s\S]*)```\s*$/u).exec(source);
+        const matches = (/^\s*```(?<language>\S+)([\s\S]*)```\s*$/v).exec(source);
         if (matches?.groups && !allowedLanguagesToProcess.includes(
           matches.groups.language.toLowerCase(),
         )) {
@@ -602,7 +602,7 @@ export const getJsdocProcessorPlugin = (options = {}) => {
                */
               (ast).comments
             ).filter((comment) => {
-              return (/^\*\s/u).test(comment.value);
+              return (/^\*\s/v).test(comment.value);
             }).map((comment) => {
               const [
                 start,
@@ -615,7 +615,7 @@ export const getJsdocProcessorPlugin = (options = {}) => {
                 cols,
               ] = getLinesCols(textToStart);
 
-              // const lines = [...textToStart.matchAll(/\n/gu)].length
+              // const lines = [...textToStart.matchAll(/\n/gv)].length
               // const lastLinePos = textToStart.lastIndexOf('\n');
               // const cols = lastLinePos === -1
               //   ? 0

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -756,7 +756,7 @@ const getUtils = (
         const text = sourceCode.getText();
         const lastLineBreakPos = text.slice(
           0, jsdocNode.range[0],
-        ).search(/\n[ \t]*$/u);
+        ).search(/\n[ \t]*$/v);
         if (lastLineBreakPos > -1) {
           return fixer.removeRange([
             lastLineBreakPos, jsdocNode.range[1],
@@ -764,7 +764,7 @@ const getUtils = (
         }
 
         return fixer.removeRange(
-          (/\s/u).test(text.charAt(jsdocNode.range[1])) ?
+          (/\s/v).test(text.charAt(jsdocNode.range[1])) ?
             [
               jsdocNode.range[0], jsdocNode.range[1] + 1,
             ] :
@@ -2118,7 +2118,7 @@ const iterateAllJsdocs = (iterator, ruleConfig, contexts, additiveCommentContext
     const utils = getBasicUtils(context, /** @type {Settings} */ (settings));
     for (const jsdocNode of jsdocNodes) {
       const jsdocNde = /** @type {unknown} */ (jsdocNode);
-      if (!(/^\/\*\*\s/u).test(sourceCode.getText(
+      if (!(/^\/\*\*\s/v).test(sourceCode.getText(
         /** @type {import('estree').Node} */
         (jsdocNde),
       ))) {

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -647,12 +647,12 @@ const getPreferredTagNameSimple = (
         value,
       ]) => {
         return [
-          key.replace(/^tag /u, ''), value,
+          key.replace(/^tag /v, ''), value,
         ];
       }),
   );
 
-  if (Object.prototype.hasOwnProperty.call(tagPreferenceFixed, name)) {
+  if (Object.hasOwn(tagPreferenceFixed, name)) {
     return tagPreferenceFixed[name];
   }
 
@@ -1480,7 +1480,7 @@ const hasThrowValue = (node, innerFunction) => {
  */
 /*
 const isInlineTag = (tag) => {
-  return /^(@link|@linkcode|@linkplain|@tutorial) /u.test(tag);
+  return /^(@link|@linkcode|@linkplain|@tutorial) /v.test(tag);
 };
 */
 
@@ -1495,7 +1495,7 @@ const parseClosureTemplateTag = (tag) => {
   return tag.name
     .split(',')
     .map((type) => {
-      return type.trim().replace(/^\[?(?<name>.*?)=.*$/u, '$<name>');
+      return type.trim().replace(/^\[?(?<name>.*?)=.*$/v, '$<name>');
     });
 };
 
@@ -1649,7 +1649,7 @@ const getTagsByType = (context, mode, tags) => {
  * @returns {string}
  */
 const getIndent = (sourceCode) => {
-  return (sourceCode.text.match(/^\n*([ \t]+)/u)?.[1] ?? '') + ' ';
+  return (sourceCode.text.match(/^\n*([ \t]+)/v)?.[1] ?? '') + ' ';
 };
 
 /**
@@ -1789,7 +1789,7 @@ const exemptSpeciaMethods = (jsdoc, node, context, schema) => {
  * @returns {string}
  */
 const dropPathSegmentQuotes = (str) => {
-  return str.replaceAll(/\.(['"])(.*)\1/gu, '.$2');
+  return str.replaceAll(/\.(['"])(.*)\1/gv, '.$2');
 };
 
 /**
@@ -1822,8 +1822,8 @@ const pathDoesNotBeginWith = (name, otherPathName) => {
  * @returns {RegExp}
  */
 const getRegexFromString = (regexString, requiredFlags) => {
-  const match = regexString.match(/^\/(.*)\/([gimyus]*)$/us);
-  let flags = 'u';
+  const match = regexString.match(/^\/(.*)\/([gimyvus]*)$/vs);
+  let flags = 'v';
   let regex = regexString;
   if (match) {
     [
@@ -1831,7 +1831,7 @@ const getRegexFromString = (regexString, requiredFlags) => {
       flags,
     ] = match;
     if (!flags) {
-      flags = 'u';
+      flags = 'v';
     }
   }
 

--- a/src/rules/checkAlignment.js
+++ b/src/rules/checkAlignment.js
@@ -5,7 +5,7 @@ import iterateJsdoc from '../iterateJsdoc.js';
  * @returns {string}
  */
 const trimStart = (string) => {
-  return string.replace(/^\s+/u, '');
+  return string.replace(/^\s+/v, '');
 };
 
 export default iterateJsdoc(({

--- a/src/rules/checkExamples.js
+++ b/src/rules/checkExamples.js
@@ -16,14 +16,14 @@ const preTagSpaceLength = 1;
 // If a space is present, we should ignore it
 const firstLinePrefixLength = preTagSpaceLength;
 
-const hasCaptionRegex = /^\s*<caption>([\s\S]*?)<\/caption>/u;
+const hasCaptionRegex = /^\s*<caption>([\s\S]*?)<\/caption>/v;
 
 /**
  * @param {string} str
  * @returns {string}
  */
 const escapeStringRegexp = (str) => {
-  return str.replaceAll(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+  return str.replaceAll(/[.*+?^$\{\}\(\)\|\[\]\\]/gv, '\\$&');
 };
 
 /**
@@ -32,7 +32,7 @@ const escapeStringRegexp = (str) => {
  * @returns {import('../iterateJsdoc.js').Integer}
  */
 const countChars = (str, ch) => {
-  return (str.match(new RegExp(escapeStringRegexp(ch), 'gu')) || []).length;
+  return (str.match(new RegExp(escapeStringRegexp(ch), 'gv')) || []).length;
 };
 
 /** @type {import('eslint').Linter.RulesRecord} */
@@ -244,7 +244,7 @@ export default iterateJsdoc(({
       const cliConfigStr = JSON.stringify(cliConfig);
 
       const src = paddedIndent ?
-        string.replaceAll(new RegExp(`(^|\n) {${paddedIndent}}(?!$)`, 'gu'), '\n') :
+        string.replaceAll(new RegExp(`(^|\n) {${paddedIndent}}(?!$)`, 'gv'), '\n') :
         string;
 
       // Programmatic ESLint API: https://eslint.org/docs/developer-guide/nodejs-api
@@ -345,7 +345,7 @@ export default iterateJsdoc(({
     if (!filename) {
       const jsFileName = context.getFilename();
       if (typeof jsFileName === 'string' && jsFileName.includes('.')) {
-        defaultFileName = jsFileName.replace(/\.[^.]*$/u, `.${ext}`);
+        defaultFileName = jsFileName.replace(/\.[^.]*$/v, `.${ext}`);
       } else {
         defaultFileName = `dummy.${ext}`;
       }

--- a/src/rules/checkIndentation.js
+++ b/src/rules/checkIndentation.js
@@ -6,10 +6,10 @@ import iterateJsdoc from '../iterateJsdoc.js';
  * @returns {string}
  */
 const maskExcludedContent = (str, excludeTags) => {
-  const regContent = new RegExp(`([ \\t]+\\*)[ \\t]@(?:${excludeTags.join('|')})(?=[ \\n])([\\w|\\W]*?\\n)(?=[ \\t]*\\*(?:[ \\t]*@\\w+\\s|\\/))`, 'gu');
+  const regContent = new RegExp(`([ \\t]+\\*)[ \\t]@(?:${excludeTags.join('|')})(?=[ \\n])([\\w\\|\\W]*?\\n)(?=[ \\t]*\\*(?:[ \\t]*@\\w+\\s|\\/))`, 'gv');
 
   return str.replace(regContent, (_match, margin, code) => {
-    return (margin + '\n').repeat(code.match(/\n/gu).length);
+    return (margin + '\n').repeat(code.match(/\n/gv).length);
   });
 };
 
@@ -18,10 +18,10 @@ const maskExcludedContent = (str, excludeTags) => {
  * @returns {string}
  */
 const maskCodeBlocks = (str) => {
-  const regContent = /([ \t]+\*)[ \t]```[^\n]*?([\w|\W]*?\n)(?=[ \t]*\*(?:[ \t]*(?:```|@\w+\s)|\/))/gu;
+  const regContent = /([ \t]+\*)[ \t]```[^\n]*?([\w\|\W]*?\n)(?=[ \t]*\*(?:[ \t]*(?:```|@\w+\s)|\/))/gv;
 
   return str.replaceAll(regContent, (_match, margin, code) => {
-    return (margin + '\n').repeat(code.match(/\n/gu).length);
+    return (margin + '\n').repeat(code.match(/\n/gv).length);
   });
 };
 
@@ -38,12 +38,12 @@ export default iterateJsdoc(({
     ],
   } = options;
 
-  const reg = /^(?:\/?\**|[ \t]*)\*[ \t]{2}/gmu;
+  const reg = /^(?:\/?\**|[ \t]*)\*[ \t]{2}/gmv;
   const textWithoutCodeBlocks = maskCodeBlocks(sourceCode.getText(jsdocNode));
   const text = excludeTags.length ? maskExcludedContent(textWithoutCodeBlocks, excludeTags) : textWithoutCodeBlocks;
 
   if (reg.test(text)) {
-    const lineBreaks = text.slice(0, reg.lastIndex).match(/\n/gu) || [];
+    const lineBreaks = text.slice(0, reg.lastIndex).match(/\n/gv) || [];
     report('There must be no indentation.', null, {
       line: lineBreaks.length,
     });

--- a/src/rules/checkLineAlignment.js
+++ b/src/rules/checkLineAlignment.js
@@ -93,8 +93,8 @@ const checkNotAlignedPerTag = (utils, tag, customSpacings) => {
   };
 
   const postHyphenSpacing = customSpacings?.postHyphen ?? 1;
-  const exactHyphenSpacing = new RegExp(`^\\s*-\\s{${postHyphenSpacing},${postHyphenSpacing}}(?!\\s)`, 'u');
-  const hasNoHyphen = !(/^\s*-(?!$)(?=\s)/u).test(tokens.description);
+  const exactHyphenSpacing = new RegExp(`^\\s*-\\s{${postHyphenSpacing},${postHyphenSpacing}}(?!\\s)`, 'v');
+  const hasNoHyphen = !(/^\s*-(?!$)(?=\s)/v).test(tokens.description);
   const hasExactHyphenSpacing = exactHyphenSpacing.test(
     tokens.description,
   );
@@ -144,7 +144,7 @@ const checkNotAlignedPerTag = (utils, tag, customSpacings) => {
     }
 
     if (!hasExactHyphenSpacing) {
-      const hyphenSpacing = /^\s*-\s+/u;
+      const hyphenSpacing = /^\s*-\s+/v;
       tokens.description = tokens.description.replace(
         hyphenSpacing, '-' + ''.padStart(postHyphenSpacing, ' '),
       );

--- a/src/rules/checkTagNames.js
+++ b/src/rules/checkTagNames.js
@@ -267,7 +267,7 @@ export default iterateJsdoc(({
       if (preferredTagName !== tagName) {
         report(message, (fixer) => {
           const replacement = sourceCode.getText(jsdocNode).replace(
-            new RegExp(`@${escapeStringRegexp(tagName)}\\b`, 'u'),
+            new RegExp(`@${escapeStringRegexp(tagName)}\\b`, 'v'),
             `@${preferredTagName}`,
           );
 

--- a/src/rules/checkTemplateNames.js
+++ b/src/rules/checkTemplateNames.js
@@ -73,7 +73,7 @@ export default iterateJsdoc(({
       const {
         name,
       } = tag;
-      const names = name.split(/,\s*/u);
+      const names = name.split(/,\s*/v);
       for (const nme of names) {
         if (!usedNames.has(nme)) {
           report(`@template ${nme} not in use`, null, tag);

--- a/src/rules/checkTypes.js
+++ b/src/rules/checkTypes.js
@@ -43,7 +43,7 @@ const adjustNames = (type, preferred, isGenericMatch, typeNodeName, node, parent
       parentMeta.dot = false;
       ret = 'Array';
     } else {
-      const dotBracketEnd = preferred.match(/\.(?:<>)?$/u);
+      const dotBracketEnd = preferred.match(/\.(?:<>)?$/v);
       if (dotBracketEnd) {
         parentMeta.brackets = 'angle';
         parentMeta.dot = true;
@@ -69,7 +69,7 @@ const adjustNames = (type, preferred, isGenericMatch, typeNodeName, node, parent
 
   /** @type {import('jsdoc-type-pratt-parser').NameResult} */ (
     node
-  ).value = ret.replace(/(?:\.|<>|\.<>|\[\])$/u, '');
+  ).value = ret.replace(/(?:\.|<>|\.<>|\[\])$/v, '');
 
   // For bare pseudo-types like `<>`
   if (!ret) {

--- a/src/rules/checkValues.js
+++ b/src/rules/checkValues.js
@@ -29,7 +29,7 @@ export default iterateJsdoc(({
   const {
     allowedAuthors = null,
     allowedLicenses = null,
-    licensePattern = '/([^\n\r]*)/gu',
+    licensePattern = '/([^\n\r]*)/gv',
     numericOnlyVariation = false,
   } = options;
 

--- a/src/rules/emptyTags.js
+++ b/src/rules/emptyTags.js
@@ -53,7 +53,7 @@ export default iterateJsdoc(({
     const content = tag.name || tag.description || tag.type;
     if (content.trim() && (
       // Allow for JSDoc-block final asterisks
-      key !== emptyTags.length - 1 || !(/^\s*\*+$/u).test(content)
+      key !== emptyTags.length - 1 || !(/^\s*\*+$/v).test(content)
     )) {
       const fix = () => {
         // By time of call in fixer, `tag` will have `line` added

--- a/src/rules/importsAsDependencies.js
+++ b/src/rules/importsAsDependencies.js
@@ -83,10 +83,10 @@ export default iterateJsdoc(({
 
       if (nde.type === 'JsdocTypeImport') {
         let mod = nde.element.value.replace(
-          /^(@[^/]+\/[^/]+|[^/]+).*$/u, '$1',
+          /^(@[^\/]+\/[^\/]+|[^\/]+).*$/v, '$1',
         );
 
-        if ((/^[./]/u).test(mod)) {
+        if ((/^[.\/]/v).test(mod)) {
           return;
         }
 

--- a/src/rules/linesBeforeBlock.js
+++ b/src/rules/linesBeforeBlock.js
@@ -68,7 +68,7 @@ export default iterateJsdoc(({
         // @ts-expect-error Should be a comment
         indent = /** @type {import('estree').Comment} */ (
           jsdocNode
-        ).value.match(/^\*\n([\t ]*) \*/u)?.[1]?.slice(spaceDiff);
+        ).value.match(/^\*\n([\t ]*) \*/v)?.[1]?.slice(spaceDiff);
         if (!indent) {
           /** @type {import('eslint').AST.Token|import('estree').Comment|undefined} */
           let tokenPrior = tokenBefore;

--- a/src/rules/matchDescription.js
+++ b/src/rules/matchDescription.js
@@ -2,7 +2,7 @@ import iterateJsdoc from '../iterateJsdoc.js';
 
 // If supporting Node >= 10, we could loosen the default to this for the
 //   initial letter: \\p{Upper}
-const matchDescriptionDefault = '^\n?([A-Z`\\d_][\\s\\S]*[.?!`]\\s*)?$';
+const matchDescriptionDefault = '^\n?([A-Z`\\d_][\\s\\S]*[.?!`\\p{RGI_Emoji}]\\s*)?$';
 
 /**
  * @param {string} value
@@ -43,7 +43,7 @@ export default iterateJsdoc(({
     }
 
     if (mainDescriptionMatch === false && (
-      !tag || !Object.prototype.hasOwnProperty.call(tags, tag.tag))
+      !tag || !Object.hasOwn(tags, tag.tag))
     ) {
       return;
     }
@@ -114,7 +114,7 @@ export default iterateJsdoc(({
       utils.forEachPreferredTag(tag, (matchingJsdocTag, targetTagName) => {
         const desc = (matchingJsdocTag.name + ' ' + utils.getTagDescription(matchingJsdocTag)).trim();
 
-        if (hasNoTag(targetTagName) && !(/.+/u).test(desc)) {
+        if (hasNoTag(targetTagName) && !(/.+/v).test(desc)) {
           report(
             'JSDoc description must not be empty.',
             null,
@@ -150,7 +150,7 @@ export default iterateJsdoc(({
   tagsWithNames.some((tag) => {
     const desc = /** @type {string} */ (
       utils.getTagDescription(tag)
-    ).replace(/^[- ]*/u, '')
+    ).replace(/^[\- ]*/v, '')
       .trim();
 
     return validateDescription(desc, tag);

--- a/src/rules/matchName.js
+++ b/src/rules/matchName.js
@@ -38,7 +38,7 @@ export default iterateJsdoc(({
 
   let reported = false;
   for (const tag of applicableTags) {
-    const tagName = tag.name.replace(/^\[/u, '').replace(/(=.*)?\]$/u, '');
+    const tagName = tag.name.replace(/^\[/v, '').replace(/(=.*)?\]$/v, '');
     const allowed = !allowNameRegex || allowNameRegex.test(tagName);
     const disallowed = disallowNameRegex && disallowNameRegex.test(tagName);
     const hasRegex = allowNameRegex || disallowNameRegex;

--- a/src/rules/noBadBlocks.js
+++ b/src/rules/noBadBlocks.js
@@ -5,8 +5,8 @@ import {
 
 // Neither a single nor 3+ asterisks are valid jsdoc per
 //  https://jsdoc.app/about-getting-started.html#adding-documentation-comments-to-your-code
-const commentRegexp = /^\/\*(?!\*)/u;
-const extraAsteriskCommentRegexp = /^\/\*{3,}/u;
+const commentRegexp = /^\/\*(?!\*)/v;
+const extraAsteriskCommentRegexp = /^\/\*{3,}/v;
 
 export default iterateJsdoc(({
   allComments,

--- a/src/rules/noBlankBlockDescriptions.js
+++ b/src/rules/noBlankBlockDescriptions.js
@@ -1,7 +1,7 @@
 import iterateJsdoc from '../iterateJsdoc.js';
 
-const anyWhitespaceLines = /^\s*$/u;
-const atLeastTwoLinesWhitespace = /^[ \t]*\n[ \t]*\n\s*$/u;
+const anyWhitespaceLines = /^\s*$/v;
+const atLeastTwoLinesWhitespace = /^[ \t]*\n[ \t]*\n\s*$/v;
 
 export default iterateJsdoc(({
   jsdoc,

--- a/src/rules/noDefaults.js
+++ b/src/rules/noDefaults.js
@@ -14,13 +14,13 @@ export default iterateJsdoc(({
     if (noOptionalParamNames && tag.optional) {
       utils.reportJSDoc(`Optional param names are not permitted on @${tag.tag}.`, tag, () => {
         utils.changeTag(tag, {
-          name: tag.name.replace(/([^=]*)(=.+)?/u, '$1'),
+          name: tag.name.replace(/([^=]*)(=.+)?/v, '$1'),
         });
       });
     } else if (tag.default) {
       utils.reportJSDoc(`Defaults are not permitted on @${tag.tag}.`, tag, () => {
         utils.changeTag(tag, {
-          name: tag.name.replace(/([^=]*)(=.+)?/u, '[$1]'),
+          name: tag.name.replace(/([^=]*)(=.+)?/v, '[$1]'),
         });
       });
     }

--- a/src/rules/noMultiAsterisks.js
+++ b/src/rules/noMultiAsterisks.js
@@ -1,13 +1,13 @@
 import iterateJsdoc from '../iterateJsdoc.js';
 
-const middleAsterisksBlockWS = /^([\t ]|\*(?!\*))+/u;
-const middleAsterisksNoBlockWS = /^\*+/u;
+const middleAsterisksBlockWS = /^([\t ]|\*(?!\*))+/v;
+const middleAsterisksNoBlockWS = /^\*+/v;
 
-const endAsterisksSingleLineBlockWS = /\*((?:\*|(?: |\t))*)\*$/u;
-const endAsterisksMultipleLineBlockWS = /((?:\*|(?: |\t))*)\*$/u;
+const endAsterisksSingleLineBlockWS = /\*((?:\*|(?: |\t))*)\*$/v;
+const endAsterisksMultipleLineBlockWS = /((?:\*|(?: |\t))*)\*$/v;
 
-const endAsterisksSingleLineNoBlockWS = /\*(\**)\*$/u;
-const endAsterisksMultipleLineNoBlockWS = /(\**)\*$/u;
+const endAsterisksSingleLineNoBlockWS = /\*(\**)\*$/v;
+const endAsterisksMultipleLineNoBlockWS = /(\**)\*$/v;
 
 export default iterateJsdoc(({
   context,

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -50,7 +50,7 @@ const typescriptGlobals = [
  * @returns {undefined|string|false}
  */
 const stripPseudoTypes = (str) => {
-  return str && str.replace(/(?:\.|<>|\.<>|\[\])$/u, '');
+  return str && str.replace(/(?:\.|<>|\.<>|\[\])$/v, '');
 };
 
 export default iterateJsdoc(({
@@ -115,7 +115,7 @@ export default iterateJsdoc(({
   const allComments = sourceCode.getAllComments();
   const comments = allComments
     .filter((comment) => {
-      return (/^\*\s/u).test(comment.value);
+      return (/^\*\s/v).test(comment.value);
     })
     .map((commentNode) => {
       return parseComment(commentNode, '');
@@ -123,9 +123,9 @@ export default iterateJsdoc(({
 
   const globals = allComments
     .filter((comment) => {
-      return (/^\s*globals/u).test(comment.value);
+      return (/^\s*globals/v).test(comment.value);
     }).flatMap((commentNode) => {
-      return commentNode.value.replace(/^\s*globals/u, '').trim().split(/,\s*/u);
+      return commentNode.value.replace(/^\s*globals/v, '').trim().split(/,\s*/v);
     }).concat(Object.keys(context.languageOptions.globals ?? []));
 
   const typedefDeclarations = comments

--- a/src/rules/requireDescriptionCompleteSentence.js
+++ b/src/rules/requireDescriptionCompleteSentence.js
@@ -14,7 +14,7 @@ const otherDescriptiveTags = new Set([
  * @returns {string[]}
  */
 const extractParagraphs = (text) => {
-  return text.split(/(?<![;:])\n\n+/u);
+  return text.split(/(?<![;:])\n\n+/v);
 };
 
 /**
@@ -25,12 +25,12 @@ const extractParagraphs = (text) => {
 const extractSentences = (text, abbreviationsRegex) => {
   const txt = text
     // Remove all {} tags.
-    .replaceAll(/(?<!^)\{[\s\S]*?\}\s*/gu, '')
+    .replaceAll(/(?<!^)\{[\s\S]*?\}\s*/gv, '')
 
     // Remove custom abbreviations
     .replace(abbreviationsRegex, '');
 
-  const sentenceEndGrouping = /([.?!])(?:\s+|$)/ug;
+  const sentenceEndGrouping = /([.?!])(?:\s+|$)/gv;
 
   const puncts = [
     ...txt.matchAll(sentenceEndGrouping),
@@ -39,11 +39,11 @@ const extractSentences = (text, abbreviationsRegex) => {
   });
 
   return txt
-    .split(/[.?!](?:\s+|$)/u)
+    .split(/[.?!](?:\s+|$)/v)
 
     // Re-add the dot.
     .map((sentence, idx) => {
-      return !puncts[idx] && /^\s*$/u.test(sentence) ? sentence : `${sentence}${puncts[idx] || ''}`;
+      return !puncts[idx] && /^\s*$/v.test(sentence) ? sentence : `${sentence}${puncts[idx] || ''}`;
     });
 };
 
@@ -58,11 +58,11 @@ const isNewLinePrecededByAPeriod = (text) => {
   const lines = text.split('\n');
 
   return !lines.some((line) => {
-    if (lastLineEndsSentence === false && /^[A-Z][a-z]/u.test(line)) {
+    if (lastLineEndsSentence === false && /^[A-Z][a-z]/v.test(line)) {
       return true;
     }
 
-    lastLineEndsSentence = /[.:?!|]$/u.test(line);
+    lastLineEndsSentence = /[.:?!\|]$/v.test(line);
 
     return false;
   });
@@ -108,11 +108,11 @@ const validateDescription = (
   description, reportOrig, jsdocNode, abbreviationsRegex,
   sourceCode, tag, newlineBeforeCapsAssumesBadSentenceEnd,
 ) => {
-  if (!description || (/^\n+$/u).test(description)) {
+  if (!description || (/^\n+$/v).test(description)) {
     return false;
   }
 
-  const descriptionNoHeadings = description.replaceAll(/^\s*#[^\n]*(\n|$)/gmu, '');
+  const descriptionNoHeadings = description.replaceAll(/^\s*#[^\n]*(\n|$)/gmv, '');
 
   const paragraphs = extractParagraphs(descriptionNoHeadings).filter(Boolean);
 
@@ -122,28 +122,28 @@ const validateDescription = (
     const fix = /** @type {import('eslint').Rule.ReportFixer} */ (fixer) => {
       let text = sourceCode.getText(jsdocNode);
 
-      if (!/[.:?!]$/u.test(paragraph)) {
+      if (!/[.:?!]$/v.test(paragraph)) {
         const line = paragraph.split('\n').findLast(Boolean);
         text = text.replace(new RegExp(`${escapeStringRegexp(
           /** @type {string} */
           (line),
-        )}$`, 'mu'), `${line}.`);
+        )}$`, 'mv'), `${line}.`);
       }
 
       for (const sentence of sentences.filter((sentence_) => {
-        return !(/^\s*$/u).test(sentence_) && !isCapitalized(sentence_) &&
+        return !(/^\s*$/v).test(sentence_) && !isCapitalized(sentence_) &&
           !isTable(sentence_);
       })) {
         const beginning = sentence.split('\n')[0];
 
         if ('tag' in tag && tag.tag) {
-          const reg = new RegExp(`(@${escapeStringRegexp(tag.tag)}.*)${escapeStringRegexp(beginning)}`, 'u');
+          const reg = new RegExp(`(@${escapeStringRegexp(tag.tag)}.*)${escapeStringRegexp(beginning)}`, 'v');
 
           text = text.replace(reg, (_$0, $1) => {
             return $1 + capitalize(beginning);
           });
         } else {
-          text = text.replace(new RegExp('((?:[.?!]|\\*|\\})\\s*)' + escapeStringRegexp(beginning), 'u'), '$1' + capitalize(beginning));
+          text = text.replace(new RegExp('((?:[.?!]|\\*|\\})\\s*)' + escapeStringRegexp(beginning), 'v'), '$1' + capitalize(beginning));
         }
       }
 
@@ -181,20 +181,20 @@ const validateDescription = (
     };
 
     if (sentences.some((sentence) => {
-      return (/^[.?!]$/u).test(sentence);
+      return (/^[.?!]$/v).test(sentence);
     })) {
       report('Sentences must be more than punctuation.', null, tag);
     }
 
     if (sentences.some((sentence) => {
-      return !(/^\s*$/u).test(sentence) && !isCapitalized(sentence) && !isTable(sentence);
+      return !(/^\s*$/v).test(sentence) && !isCapitalized(sentence) && !isTable(sentence);
     })) {
       report('Sentences should start with an uppercase character.', fix, tag);
     }
 
     const paragraphNoAbbreviations = paragraph.replace(abbreviationsRegex, '');
 
-    if (!/(?:[.?!|]|```)\s*$/u.test(paragraphNoAbbreviations)) {
+    if (!/(?:[.?!\|]|```)\s*$/v.test(paragraphNoAbbreviations)) {
       report('Sentences must end with a period.', fix, tag);
       return true;
     }
@@ -224,8 +224,8 @@ export default iterateJsdoc(({
 
   const abbreviationsRegex = abbreviations.length ?
     new RegExp('\\b' + abbreviations.map((abbreviation) => {
-      return escapeStringRegexp(abbreviation.replaceAll(/\.$/ug, '') + '.');
-    }).join('|') + '(?:$|\\s)', 'gu') :
+      return escapeStringRegexp(abbreviation.replaceAll(/\.$/gv, '') + '.');
+    }).join('|') + '(?:$|\\s)', 'gv') :
     '';
 
   let {
@@ -233,7 +233,7 @@ export default iterateJsdoc(({
   } = utils.getDescription();
 
   const indices = [
-    ...description.matchAll(/```[\s\S]*```/gu),
+    ...description.matchAll(/```[\s\S]*```/gv),
   ].map((match) => {
     const {
       index,
@@ -289,7 +289,7 @@ export default iterateJsdoc(({
   tagsWithNames.some((tag) => {
     const desc = /** @type {string} */ (
       utils.getTagDescription(tag)
-    ).replace(/^- /u, '').trimEnd();
+    ).replace(/^- /v, '').trimEnd();
 
     return validateDescription(desc, report, jsdocNode, abbreviationsRegex, sourceCode, tag, newlineBeforeCapsAssumesBadSentenceEnd);
   });

--- a/src/rules/requireHyphenBeforeParamDescription.js
+++ b/src/rules/requireHyphenBeforeParamDescription.js
@@ -29,7 +29,7 @@ export default iterateJsdoc(({
       return;
     }
 
-    const startsWithHyphen = (/^\s*-/u).test(desc);
+    const startsWithHyphen = (/^\s*-/v).test(desc);
     let lines = 0;
     for (const {
       tokens,
@@ -54,7 +54,7 @@ export default iterateJsdoc(({
             } of jsdocTag.source) {
               if (tokens.description) {
                 tokens.description = tokens.description.replace(
-                  /^(\s*)/u, '$1- ',
+                  /^(\s*)/v, '$1- ',
                 );
                 break;
               }
@@ -74,7 +74,7 @@ export default iterateJsdoc(({
           } of jsdocTag.source) {
             if (tokens.description) {
               tokens.description = tokens.description.replace(
-                /^\s*-\s*/u, '',
+                /^\s*-\s*/v, '',
               );
               break;
             }

--- a/src/rules/requireJsdoc.js
+++ b/src/rules/requireJsdoc.js
@@ -444,7 +444,7 @@ export default {
          */
         const underMinLine = (count) => {
           return count !== undefined && count >
-            (sourceCode.getText(node).match(/\n/gu)?.length ?? 0) + 1;
+            (sourceCode.getText(node).match(/\n/gv)?.length ?? 0) + 1;
         };
 
         if (underMinLine(minLineCount)) {

--- a/src/rules/requireReturnsCheck.js
+++ b/src/rules/requireReturnsCheck.js
@@ -81,7 +81,7 @@ export default iterateJsdoc(({
   const type = tag.type.trim();
 
   // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions
-  if (/asserts\s/u.test(type)) {
+  if (/asserts\s/v.test(type)) {
     return;
   }
 

--- a/src/rules/requireTemplate.js
+++ b/src/rules/requireTemplate.js
@@ -31,7 +31,7 @@ export default iterateJsdoc(({
       const {
         name,
       } = tag;
-      const names = name.split(/,\s*/u);
+      const names = name.split(/,\s*/v);
       if (names.length > 1) {
         report(`Missing separate @template for ${names[1]}`, null, tag);
       }
@@ -126,7 +126,7 @@ export default iterateJsdoc(({
         type,
         value,
       } = /** @type {import('jsdoc-type-pratt-parser').NameResult} */ (nde);
-      if (type === 'JsdocTypeName' && (/^[A-Z]$/u).test(value)) {
+      if (type === 'JsdocTypeName' && (/^[A-Z]$/v).test(value)) {
         usedNames.add(value);
         if (!usedNameToTag.has(value)) {
           usedNameToTag.set(value, potentialTag);

--- a/src/rules/tagLines.js
+++ b/src/rules/tagLines.js
@@ -228,11 +228,11 @@ export default iterateJsdoc(({
       description,
       lastDescriptionLine,
     } = utils.getDescription();
-    if (!(/\S/u).test(description)) {
+    if (!(/\S/v).test(description)) {
       return;
     }
 
-    const trailingLines = description.match(/\n+$/u)?.[0]?.length;
+    const trailingLines = description.match(/\n+$/v)?.[0]?.length;
     const trailingDiff = (trailingLines ?? 0) - startLines;
     if (trailingDiff > 0) {
       utils.reportJSDoc(

--- a/src/rules/textEscaping.js
+++ b/src/rules/textEscaping.js
@@ -2,15 +2,15 @@ import iterateJsdoc from '../iterateJsdoc.js';
 
 // We could disallow raw gt, quot, and apos, but allow for parity; but we do
 //  not allow hex or decimal character references
-const htmlRegex = /(<|&(?!(?:amp|lt|gt|quot|apos);))(?=\S)/u;
-const markdownRegex = /(?<!\\)(`+)([^`]+)\1(?!`)/u;
+const htmlRegex = /(<|&(?!(?:amp|lt|gt|quot|apos);))(?=\S)/v;
+const markdownRegex = /(?<!\\)(`+)([^`]+)\1(?!`)/v;
 
 /**
  * @param {string} desc
  * @returns {string}
  */
 const htmlReplacer = (desc) => {
-  return desc.replaceAll(new RegExp(htmlRegex, 'gu'), (_) => {
+  return desc.replaceAll(new RegExp(htmlRegex, 'gv'), (_) => {
     if (_ === '<') {
       return '&lt;';
     }
@@ -24,7 +24,7 @@ const htmlReplacer = (desc) => {
  * @returns {string}
  */
 const markdownReplacer = (desc) => {
-  return desc.replaceAll(new RegExp(markdownRegex, 'gu'), (_, backticks, encapsed) => {
+  return desc.replaceAll(new RegExp(markdownRegex, 'gv'), (_, backticks, encapsed) => {
     const bookend = '`'.repeat(backticks.length);
     return `\\${bookend}${encapsed}${bookend}`;
   });

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -17,7 +17,7 @@ const jsdocTypePrattKeywords = new Set([
   'typeof',
 ]);
 
-const asExpression = /as\s+/u;
+const asExpression = /as\s+/v;
 
 const suppressTypes = new Set([
   // https://github.com/google/closure-compiler/wiki/@suppress-annotations

--- a/test/getJsdocProcessPlugin.js
+++ b/test/getJsdocProcessPlugin.js
@@ -94,7 +94,7 @@ describe('`getJsdocProcessorPlugin`', () => {
 
   it('returns text and files with `exampleCodeRegex` (as RegExp)', () => {
     const options = {
-      exampleCodeRegex: /```js([\s\S]*)```/u,
+      exampleCodeRegex: /```js([\s\S]*)```/v,
     };
     const filename = 'something.js';
     const text = `
@@ -276,7 +276,7 @@ describe('`getJsdocProcessorPlugin`', () => {
 
   it('returns text and files (with `rejectExampleCodeRegex`) as RegExp', () => {
     const options = {
-      rejectExampleCodeRegex: /^\s*<.*>\s*$/u,
+      rejectExampleCodeRegex: /^\s*<.*>\s*$/v,
     };
     const filename = 'something.js';
     const text = `

--- a/test/rules/assertions/checkTagNames.js
+++ b/test/rules/assertions/checkTagNames.js
@@ -28,7 +28,7 @@ const buildTagBlock = (tags) => {
  */
 const lineCount = (code) => {
   /* eslint-disable jsdoc/no-undefined-types -- TS */
-  return /** @type {RegExpMatchArray} */ (code.match(/\n/ug)).length;
+  return /** @type {RegExpMatchArray} */ (code.match(/\n/gv)).length;
   /* eslint-enable jsdoc/no-undefined-types -- TS */
 };
 

--- a/test/rules/assertions/matchDescription.js
+++ b/test/rules/assertions/matchDescription.js
@@ -1576,8 +1576,8 @@ export default /** @type {import('../index.js').TestCases} */ ({
           contexts: [
             'any',
           ],
-          mainDescription: '/^[A-Z`-].*\\.$/us',
-          matchDescription: '^([A-Z`-].*(\\.|:)|-\\s.*)$',
+          mainDescription: '/^[A-Z`\\-].*\\.$/vs',
+          matchDescription: '^([A-Z`\\-].*(\\.|:)|-\\s.*)$',
           tags: {
             param: true,
             returns: true,
@@ -1674,6 +1674,14 @@ export default /** @type {import('../index.js').TestCases} */ ({
           nonemptyTags: false,
         },
       ],
+    },
+    {
+      code: `
+        /**
+         * Example text. 🙂
+         */
+        export const example = () => { };
+      `,
     },
   ],
 });

--- a/test/rules/assertions/matchName.js
+++ b/test/rules/assertions/matchName.js
@@ -366,7 +366,7 @@ export default /** @type {import('../index.js').TestCases} */ ({
       errors: [
         {
           line: 3,
-          message: 'Only allowing names not matching `/^$/u` but found "".',
+          message: 'Only allowing names not matching `/^$/v` but found "".',
         },
       ],
       options: [

--- a/tsconfig-prod.json
+++ b/tsconfig-prod.json
@@ -11,7 +11,7 @@
     "declarationMap": true,
     "strict": true,
     "skipLibCheck": true,
-    "target": "es2018",
+    "target": "es2024",
     "outDir": "dist"
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "declarationMap": true,
     "strict": true,
     "skipLibCheck": true,
-    "target": "es2018",
+    "target": "es2024",
     "outDir": "dist"
   },
   "include": [


### PR DESCRIPTION
fix: use `v` flag in regexes; match emojis for sentence terminator; fixes #1433

BREAKING CHANGE:

Uses `v` flag instead of `u` flag by default for regular expressions