### PR TITLE
chore: enable pnpm shellEmulator

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,2 +1,1 @@
-
-npx run-if-changed
+run-if-changed

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,2 +1,1 @@
-
-npx run-if-changed
+run-if-changed

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,2 +1,1 @@
-
-npx run-if-changed
+run-if-changed

--- a/.husky/post-rewrite
+++ b/.husky/post-rewrite
@@ -1,2 +1,1 @@
-
-npx run-if-changed
+run-if-changed

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
-
-npx lint-staged
+lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,1 @@
-
-npm test && npm run build && npm run check-docs
+pnpm test && pnpm run build && pnpm run check-docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,12 +68,12 @@ can be ignored by being preceded by `/* c8 ignore next */` (including
 for warnings where the block is never passed over (i.e., the block is always
 entered)). If you want to test without coverage at all, you can use
 `pnpm test-no-cov`. To only test rules rather than other files, you
-can use `npm run test-index` (`pnpm` doesn't work with this script currently).
+can use `pnpm run test-index`.
 
 To test specific rules, you can supply a comma-separated list with the `--rule`
 flag passed to `test-index`, e.g., for `check-examples` and `require-example`:
 
-`npm run test-index --rule=check-examples,require-example`.
+`pnpm run test-index --rule=check-examples,require-example`.
 
 You can further limit this by providing `--invalid` and/or `--valid` flags
 with a comma-separated list of 0-based indexes that you wish to include (also
@@ -81,7 +81,7 @@ accepts negative offsets from the end, e.g., `-1` for the last item). For
 example, to check the first and third invalid tests of `check-examples`
 along with the second valid test, you can run:
 
-`npm run test-index --rule=require-example --invalid=0,2 --valid=1`.
+`pnpm run test-index --rule=require-example --invalid=0,2 --valid=1`.
 
 ## Requirements for PRs
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   ],
   "license": "BSD-3-Clause",
   "lint-staged": {
-    "*.js": "pnpm run lint-arg --fix"
+    "*.js": "eslint --fix"
   },
   "type": "module",
   "main": "./dist/index.cjs",
@@ -146,14 +146,13 @@
     "create-rule": "babel-node ./src/bin/generateRule.js",
     "create-options": "node ./src/bin/generateOptions.mjs",
     "install-offline": "pnpm install --prefer-offline --no-audit",
-    "lint": "pnpm run lint-arg -- .",
-    "lint-arg": "eslint",
-    "lint-fix": "pnpm run lint-arg --fix .",
+    "lint": "eslint",
+    "lint-fix": "eslint --fix",
     "prepare": "husky",
     "test-no-cov": "BABEL_ENV=test mocha",
     "test": "c8 pnpm run test-no-cov",
     "test-cov": "TIMING=1 c8 --reporter text pnpm run test-no-cov",
-    "test-index": "pnpm run test-no-cov -- test/rules/index.js"
+    "test-index": "pnpm run test-no-cov test/rules/index.js"
   },
   "version": "1.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "c8": "^10.1.3",
     "camelcase": "^8.0.0",
     "chai": "^5.2.0",
-    "cross-env": "^7.0.3",
     "decamelize": "^6.0.0",
     "eslint": "9.29.0",
     "eslint-config-canonical": "~44.9.5",
@@ -80,11 +79,7 @@
   ],
   "license": "BSD-3-Clause",
   "lint-staged": {
-    ".eslintignore": [
-      "npm run lint-fix",
-      "git add ."
-    ],
-    "*.js": "npm run lint-arg -- --fix"
+    "*.js": "pnpm run lint-arg --fix"
   },
   "type": "module",
   "main": "./dist/index.cjs",
@@ -140,25 +135,25 @@
     "url": "https://github.com/gajus/eslint-plugin-jsdoc/issues"
   },
   "run-if-changed": {
-    "package-lock.json": "npm run install-offline"
+    "package-lock.json": "pnpm run install-offline"
   },
   "scripts": {
     "tsc": "tsc",
     "tsc-build": "tsc -p tsconfig-prod.json",
-    "build": "rimraf ./dist && cross-env NODE_ENV=production babel ./src --out-file-extension .cjs --out-dir ./dist --copy-files --source-maps --ignore ./src/bin/*.js --no-copy-ignored && replace 'require\\(\"\\.(.*?)\\.[^.]*?\"\\)' 'require(\".$1.cjs\")' 'dist' -r --include=\"*.cjs\" && pnpm tsc-build",
+    "build": "rimraf ./dist && NODE_ENV=production babel ./src --out-file-extension .cjs --out-dir ./dist --copy-files --source-maps --ignore ./src/bin/*.js --no-copy-ignored && replace 'require\\(\"\\.(.*?)\\.[^.]*?\"\\)' 'require(\".$1.cjs\")' 'dist' -r --include=\"*.cjs\" && pnpm tsc-build",
     "check-docs": "babel-node ./src/bin/generateDocs.js --check",
-    "create-docs": "npm run create-options && babel-node ./src/bin/generateDocs.js",
+    "create-docs": "pnpm run create-options && babel-node ./src/bin/generateDocs.js",
     "create-rule": "babel-node ./src/bin/generateRule.js",
     "create-options": "node ./src/bin/generateOptions.mjs",
     "install-offline": "pnpm install --prefer-offline --no-audit",
-    "lint": "npm run lint-arg -- .",
+    "lint": "pnpm run lint-arg -- .",
     "lint-arg": "eslint",
-    "lint-fix": "npm run lint-arg -- --fix .",
+    "lint-fix": "pnpm run lint-arg --fix .",
     "prepare": "husky",
-    "test-no-cov": "cross-env BABEL_ENV=test mocha",
-    "test": "c8 npm run test-no-cov",
-    "test-cov": "cross-env TIMING=1 c8 --reporter text npm run test-no-cov",
-    "test-index": "npm run test-no-cov -- test/rules/index.js"
+    "test-no-cov": "BABEL_ENV=test mocha",
+    "test": "c8 pnpm run test-no-cov",
+    "test-cov": "TIMING=1 c8 --reporter text pnpm run test-no-cov",
+    "test-index": "pnpm run test-no-cov -- test/rules/index.js"
   },
   "version": "1.0.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,9 +135,6 @@ importers:
       chai:
         specifier: ^5.2.0
         version: 5.2.0
-      cross-env:
-        specifier: ^7.0.3
-        version: 7.0.3
       decamelize:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1088,9 +1085,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
-
-  '@napi-rs/wasm-runtime@0.2.10':
-    resolution: {integrity: sha512-bCsCyeZEwVErsGmyPNSzwfwFn4OdxBj0mmv6hOFucB/k81Ojdu68RbZdxYsRQUPc9l6SU5F/cG+bXgWs3oUgsQ==}
 
   '@napi-rs/wasm-runtime@0.2.11':
     resolution: {integrity: sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==}
@@ -2225,11 +2219,6 @@ packages:
   create-eslint-index@1.0.0:
     resolution: {integrity: sha512-nXvJjnfDytOOaPOonX0h0a1ggMoqrhdekGeZkD6hkcWYvlCWhU719tKFVh8eU04CnMwu3uwe1JjwuUF2C3k2qg==}
     engines: {node: '>=4.0.0'}
-
-  cross-env@7.0.3:
-    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
-    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
-    hasBin: true
 
   cross-inspect@1.0.1:
     resolution: {integrity: sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==}
@@ -6944,13 +6933,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@napi-rs/wasm-runtime@0.2.10':
-    dependencies:
-      '@emnapi/core': 1.4.3
-      '@emnapi/runtime': 1.4.3
-      '@tybys/wasm-util': 0.9.0
-    optional: true
-
   '@napi-rs/wasm-runtime@0.2.11':
     dependencies:
       '@emnapi/core': 1.4.3
@@ -7589,7 +7571,7 @@ snapshots:
 
   '@unrs/resolver-binding-wasm32-wasi@1.7.8':
     dependencies:
-      '@napi-rs/wasm-runtime': 0.2.10
+      '@napi-rs/wasm-runtime': 0.2.11
     optional: true
 
   '@unrs/resolver-binding-wasm32-wasi@1.9.0':
@@ -8223,10 +8205,6 @@ snapshots:
   create-eslint-index@1.0.0:
     dependencies:
       lodash.get: 4.4.2
-
-  cross-env@7.0.3:
-    dependencies:
-      cross-spawn: 7.0.6
 
   cross-inspect@1.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 ignoredBuiltDependencies:
   - core-js
   - core-js-pure
+
+shellEmulator: true

--- a/src/bin/generateDocs.js
+++ b/src/bin/generateDocs.js
@@ -267,7 +267,7 @@ const assertDocsAreUpToDate = async () => {
     const isUpToDate = fs.readFileSync(docPath, 'utf8') === docContent;
 
     if (!isUpToDate) {
-      throw new Error('Docs are not up to date, please run `npm run create-docs` to update it.');
+      throw new Error('Docs are not up to date, please run `pnpm run create-docs` to update it.');
     }
   }
 };

--- a/src/bin/generateRule.js
+++ b/src/bin/generateRule.js
@@ -8,7 +8,7 @@ import fs from 'fs/promises';
 /**
  * @example
  * ```shell
- * npm run create-rule my-new-rule -- --recommended
+ * pnpm run create-rule my-new-rule -- --recommended
  * ```
  */
 import open from 'open-editor';


### PR DESCRIPTION
I started investigating #1432, but quickly hit Windows incompatibilities.

---

This fixes `pnpm build` on Windows.
Otherwise, the string escapes in the `build` script are misinterpreted.

After enabling `shellEmulator`, husky needed to be moved off npm. I can't repro the issues noted with pnpm over npm in CONTRIBUTING.

---

Also, gitdown doesn't work on Windows, [this glob](https://github.com/gajus/gitdown/blob/a323123bc1d8c8bb9f8c516406aefe5ddca80ff4/src/parser.js#L190) evals to windows backslashes when `glob` wants forward slashes; I have to use `git push --no-verify`.
