### PR TITLE
fix: npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,8 +5,14 @@ test
 *.log
 CONTRIBUTING.md
 tsconfig*.json
+pnpm-workspace.yaml
+eslint.config.js
 *.d.ts
 *.d.ts.map
 !dist/index.d.ts
 !dist/index.d.ts.map
+!dist/getJsdocProcessorPlugin.d.ts
+!dist/getJsdocProcessorPlugin.d.ts.map
+!dist/iterateJsdoc.d.ts
+!dist/iterateJsdoc.d.ts.map
 docs


### PR DESCRIPTION
Fixes #1432.

I think it'd make more sense to use `files` instead here, but 🤷‍♂️