### PR TITLE
fix(`no-types`, `require-example`, `implements-on-classes`): allow `any` to match function variable declarations

### DIFF
--- a/docs/rules/no-types.md
+++ b/docs/rules/no-types.md
@@ -149,6 +149,24 @@ class Example {
   x: number;
 }
 // Message: Types are not permitted on @property in the supplied context.
+
+/**
+ * Returns a Promise...
+ *
+ * @param {number} ms - The number of ...
+ */
+const sleep = (ms: number): Promise<unknown> => {};
+// "jsdoc/no-types": ["error"|"warn", {"contexts":["any"]}]
+// Message: Types are not permitted on @param.
+
+/**
+ * Returns a Promise...
+ *
+ * @param {number} ms - The number of ...
+ */
+export const sleep = (ms: number): Promise<unknown> => {};
+// "jsdoc/no-types": ["error"|"warn", {"contexts":["any"]}]
+// Message: Types are not permitted on @param.
 ````
 
 

--- a/docs/rules/require-example.md
+++ b/docs/rules/require-example.md
@@ -234,6 +234,15 @@ function quux (someParam) {
 }
 // "jsdoc/require-example": ["error"|"warn", {"enableFixer":false}]
 // Message: Missing JSDoc @example declaration.
+
+/**
+ * Returns a Promise...
+ *
+ * @param {number} ms - The number of ...
+ */
+const sleep = (ms: number): Promise<unknown> => {};
+// "jsdoc/require-example": ["error"|"warn", {"contexts":["any"]}]
+// Message: Missing JSDoc @example declaration.
 ````
 
 

--- a/src/rules/implementsOnClasses.js
+++ b/src/rules/implementsOnClasses.js
@@ -4,7 +4,7 @@ export default iterateJsdoc(({
   report,
   utils,
 }) => {
-  const iteratingFunction = utils.isIteratingFunction();
+  const iteratingFunction = utils.isIteratingFunctionOrVariable();
 
   if (iteratingFunction) {
     if (utils.hasATag([

--- a/src/rules/noTypes.js
+++ b/src/rules/noTypes.js
@@ -14,7 +14,7 @@ export default iterateJsdoc(({
   node,
   utils,
 }) => {
-  if (!utils.isIteratingFunction() && !utils.isVirtualFunction()) {
+  if (!utils.isIteratingFunctionOrVariable() && !utils.isVirtualFunction()) {
     return;
   }
 

--- a/src/rules/requireExample.js
+++ b/src/rules/requireExample.js
@@ -24,7 +24,7 @@ export default iterateJsdoc(({
   });
 
   if (!functionExamples.length) {
-    if (exemptNoArguments && utils.isIteratingFunction() &&
+    if (exemptNoArguments && utils.isIteratingFunctionOrVariable() &&
       !utils.hasParams()
     ) {
       return;

--- a/test/rules/assertions/noTypes.js
+++ b/test/rules/assertions/noTypes.js
@@ -286,6 +286,74 @@ export default /** @type {import('../index.js').TestCases} */ ({
         }
       `,
     },
+    {
+      code: `
+        /**
+         * Returns a Promise...
+         *
+         * @param {number} ms - The number of ...
+         */
+        const sleep = (ms: number): Promise<unknown> => {};
+      `,
+      errors: [
+        {
+          line: 5,
+          message: 'Types are not permitted on @param.',
+        },
+      ],
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      options: [
+        {
+          contexts: [
+            'any',
+          ],
+        },
+      ],
+      output: `
+        /**
+         * Returns a Promise...
+         *
+         * @param ms - The number of ...
+         */
+        const sleep = (ms: number): Promise<unknown> => {};
+      `,
+    },
+    {
+      code: `
+        /**
+         * Returns a Promise...
+         *
+         * @param {number} ms - The number of ...
+         */
+        export const sleep = (ms: number): Promise<unknown> => {};
+      `,
+      errors: [
+        {
+          line: 5,
+          message: 'Types are not permitted on @param.',
+        },
+      ],
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      options: [
+        {
+          contexts: [
+            'any',
+          ],
+        },
+      ],
+      output: `
+        /**
+         * Returns a Promise...
+         *
+         * @param ms - The number of ...
+         */
+        export const sleep = (ms: number): Promise<unknown> => {};
+      `,
+    },
   ],
   valid: [
     {

--- a/test/rules/assertions/requireExample.js
+++ b/test/rules/assertions/requireExample.js
@@ -1,3 +1,7 @@
+import {
+  parser as typescriptEslintParser,
+} from 'typescript-eslint';
+
 export default /** @type {import('../index.js').TestCases} */ ({
   invalid: [
     {
@@ -377,6 +381,41 @@ function quux () {
         },
       ],
       output: null,
+    },
+    {
+      code: `
+        /**
+         * Returns a Promise...
+         *
+         * @param {number} ms - The number of ...
+         */
+        const sleep = (ms: number): Promise<unknown> => {};
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @example declaration.',
+        },
+      ],
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      options: [
+        {
+          contexts: [
+            'any',
+          ],
+        },
+      ],
+      output: `
+        /**
+         * Returns a Promise...
+         *
+         * @param {number} ms - The number of ...
+         * @example
+         */
+        const sleep = (ms: number): Promise<unknown> => {};
+      `,
     },
   ],
   valid: [


### PR DESCRIPTION
fix(`no-types`, `require-example`, `implements-on-classes`): allow `any` to match function variable declarations; fixes #1446