### PR TITLE
fix(`valid-types`): allow `extends` for namepath

### DIFF
--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -11,6 +11,7 @@ const inlineTags = new Set([
 ]);
 
 const jsdocTypePrattKeywords = new Set([
+  'extends',
   'import',
   'is',
   'readonly',


### PR DESCRIPTION
fix(`valid-types`): allow `extends` for namepath; fixes #1455