### PR TITLE
docs: correct alphabetization of rules in example config block

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -143,10 +143,10 @@ Finally, enable all of the rules that you would like to use.
         "jsdoc/check-indentation": 1,
         "jsdoc/check-line-alignment": 1,
         "jsdoc/check-param-names": 1, // Recommended
-        "jsdoc/check-template-names": 1,
         "jsdoc/check-property-names": 1, // Recommended
         "jsdoc/check-syntax": 1,
         "jsdoc/check-tag-names": 1, // Recommended
+        "jsdoc/check-template-names": 1,
         "jsdoc/check-types": 1, // Recommended
         "jsdoc/check-values": 1, // Recommended
         "jsdoc/empty-tags": 1, // Recommended
@@ -169,22 +169,22 @@ Finally, enable all of the rules that you would like to use.
         "jsdoc/require-file-overview": 1,
         "jsdoc/require-hyphen-before-param-description": 1,
         "jsdoc/require-jsdoc": 1, // Recommended
-        "jsdoc/require-param": 1, // Recommended
         "jsdoc/require-param-description": 1, // Recommended
         "jsdoc/require-param-name": 1, // Recommended
         "jsdoc/require-param-type": 1, // Recommended
-        "jsdoc/require-property": 1, // Recommended
+        "jsdoc/require-param": 1, // Recommended
         "jsdoc/require-property-description": 1, // Recommended
         "jsdoc/require-property-name": 1, // Recommended
         "jsdoc/require-property-type": 1, // Recommended
-        "jsdoc/require-returns": 1, // Recommended
+        "jsdoc/require-property": 1, // Recommended
         "jsdoc/require-returns-check": 1, // Recommended
         "jsdoc/require-returns-description": 1, // Recommended
         "jsdoc/require-returns-type": 1, // Recommended
+        "jsdoc/require-returns": 1, // Recommended
         "jsdoc/require-template": 1,
         "jsdoc/require-throws": 1,
-        "jsdoc/require-yields": 1, // Recommended
         "jsdoc/require-yields-check": 1, // Recommended
+        "jsdoc/require-yields": 1, // Recommended
         "jsdoc/sort-tags": 1,
         "jsdoc/tag-lines": 1, // Recommended
         "jsdoc/valid-types": 1 // Recommended

--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ Finally, enable all of the rules that you would like to use.
         "jsdoc/check-indentation": 1,
         "jsdoc/check-line-alignment": 1,
         "jsdoc/check-param-names": 1, // Recommended
-        "jsdoc/check-template-names": 1,
         "jsdoc/check-property-names": 1, // Recommended
         "jsdoc/check-syntax": 1,
         "jsdoc/check-tag-names": 1, // Recommended
+        "jsdoc/check-template-names": 1,
         "jsdoc/check-types": 1, // Recommended
         "jsdoc/check-values": 1, // Recommended
         "jsdoc/empty-tags": 1, // Recommended
@@ -193,22 +193,22 @@ Finally, enable all of the rules that you would like to use.
         "jsdoc/require-file-overview": 1,
         "jsdoc/require-hyphen-before-param-description": 1,
         "jsdoc/require-jsdoc": 1, // Recommended
-        "jsdoc/require-param": 1, // Recommended
         "jsdoc/require-param-description": 1, // Recommended
         "jsdoc/require-param-name": 1, // Recommended
         "jsdoc/require-param-type": 1, // Recommended
-        "jsdoc/require-property": 1, // Recommended
+        "jsdoc/require-param": 1, // Recommended
         "jsdoc/require-property-description": 1, // Recommended
         "jsdoc/require-property-name": 1, // Recommended
         "jsdoc/require-property-type": 1, // Recommended
-        "jsdoc/require-returns": 1, // Recommended
+        "jsdoc/require-property": 1, // Recommended
         "jsdoc/require-returns-check": 1, // Recommended
         "jsdoc/require-returns-description": 1, // Recommended
         "jsdoc/require-returns-type": 1, // Recommended
+        "jsdoc/require-returns": 1, // Recommended
         "jsdoc/require-template": 1,
         "jsdoc/require-throws": 1,
-        "jsdoc/require-yields": 1, // Recommended
         "jsdoc/require-yields-check": 1, // Recommended
+        "jsdoc/require-yields": 1, // Recommended
         "jsdoc/sort-tags": 1,
         "jsdoc/tag-lines": 1, // Recommended
         "jsdoc/valid-types": 1 // Recommended


### PR DESCRIPTION
Small not-important touchup: I noticed a few rules weren't quite in the same order as the table later in the file. This alphabetizes them to be consistent.