### PR TITLE
fix(`valid-types`): try parsing whole item before splitting into commas

### DIFF
--- a/docs/rules/valid-types.md
+++ b/docs/rules/valid-types.md
@@ -888,5 +888,19 @@ function quux() {
 /**
  * @returns {@link SomeType}
  */
+
+/**
+ * @template {string} Selector
+ * @template {keyof GlobalEventHandlersEventMap} TEventType
+ * @template {Element} [TElement=import('typed-query-selector/parser').ParseSelector<Selector, HTMLElement>]
+ * @param {Selector} selector
+ * @param {TEventType} type
+ * @param {import('delegate-it').DelegateEventHandler<GlobalEventHandlersEventMap[TEventType], TElement>} callback
+ * @param {Omit<AddEventListenerOptions, 'once' | 'signal'>} [options]
+ * @returns {void}
+ */
+export function onGlobalEvent (selector, type, callback, options) {
+  delegate(document, selector, type, callback, options)
+}
 ````
 

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -358,8 +358,15 @@ export default iterateJsdoc(({
 
     if (hasNameOrNamepathPosition) {
       if (mode !== 'jsdoc' && tag.tag === 'template') {
-        for (const namepath of utils.parseClosureTemplateTag(tag)) {
-          validNamepathParsing(namepath);
+        if (!tryParsePathIgnoreError(
+          // May be an issue with the commas of
+          //   `utils.parseClosureTemplateTag`, so first try a raw
+          //   value; we really need a proper parser instead, however.
+          tag.name.trim().replace(/^\[?(?<name>.*?)=.*$/v, '$<name>'),
+        )) {
+          for (const namepath of utils.parseClosureTemplateTag(tag)) {
+            validNamepathParsing(namepath);
+          }
         }
       } else {
         validNamepathParsing(tag.name, tag.tag);

--- a/test/rules/assertions/validTypes.js
+++ b/test/rules/assertions/validTypes.js
@@ -1869,5 +1869,22 @@ export default /** @type {import('../index.js').TestCases} */ ({
          */
       `,
     },
+    {
+      code: `
+        /**
+         * @template {string} Selector
+         * @template {keyof GlobalEventHandlersEventMap} TEventType
+         * @template {Element} [TElement=import('typed-query-selector/parser').ParseSelector<Selector, HTMLElement>]
+         * @param {Selector} selector
+         * @param {TEventType} type
+         * @param {import('delegate-it').DelegateEventHandler<GlobalEventHandlersEventMap[TEventType], TElement>} callback
+         * @param {Omit<AddEventListenerOptions, 'once' | 'signal'>} [options]
+         * @returns {void}
+         */
+        export function onGlobalEvent (selector, type, callback, options) {
+          delegate(document, selector, type, callback, options)
+        }
+      `,
+    },
   ],
 });


### PR DESCRIPTION
fix(`valid-types`): try parsing whole item before splitting into commas; fixes #1464