### PR TITLE
fix(`check-template-names`, `require-template`): ensure template name  is based on what is within any brackets and preceding equal sign

### DIFF
--- a/docs/rules/check-template-names.md
+++ b/docs/rules/check-template-names.md
@@ -395,5 +395,21 @@ export class User {
   }
   methodToIgnore() {}
 }
+
+/**
+ * @template [ChannelDataType=undefined]
+ * @param {string} messageType - A key used for sending and receiving messages.
+ * @returns {MessageChannel<ChannelDataType>} A channel that can create messages of its
+ * own type.
+ */
+export function createMessageChannel(messageType) {
+  // Note: It should also infer the type if the new channel is returned
+  // directly rather than returned as a typed variable.
+
+  /** @type {MessageChannel<ChannelDataType>} */
+  const messageChannel = new MessageChannel(messageType);
+
+  return messageChannel;
+}
 ````
 

--- a/src/rules/checkTemplateNames.js
+++ b/src/rules/checkTemplateNames.js
@@ -70,10 +70,7 @@ export default iterateJsdoc(({
 
   const checkTemplateTags = () => {
     for (const tag of templateTags) {
-      const {
-        name,
-      } = tag;
-      const names = name.split(/,\s*/v);
+      const names = utils.parseClosureTemplateTag(tag);
       for (const nme of names) {
         if (!usedNames.has(nme)) {
           report(`@template ${nme} not in use`, null, tag);

--- a/src/rules/requireTemplate.js
+++ b/src/rules/requireTemplate.js
@@ -32,10 +32,7 @@ export default iterateJsdoc(({
 
   if (requireSeparateTemplates) {
     for (const tag of templateTags) {
-      const {
-        name,
-      } = tag;
-      const names = name.split(/,\s*/v);
+      const names = utils.parseClosureTemplateTag(tag);
       if (names.length > 1) {
         report(`Missing separate @template for ${names[1]}`, null, tag);
       }

--- a/test/rules/assertions/checkTemplateNames.js
+++ b/test/rules/assertions/checkTemplateNames.js
@@ -748,5 +748,24 @@ export default /** @type {import('../index.js').TestCases} */ ({
         }
       `,
     },
+    {
+      code: `
+        /**
+         * @template [ChannelDataType=undefined]
+         * @param {string} messageType - A key used for sending and receiving messages.
+         * @returns {MessageChannel<ChannelDataType>} A channel that can create messages of its
+         * own type.
+         */
+        export function createMessageChannel(messageType) {
+          // Note: It should also infer the type if the new channel is returned
+          // directly rather than returned as a typed variable.
+
+          /** @type {MessageChannel<ChannelDataType>} */
+          const messageChannel = new MessageChannel(messageType);
+
+          return messageChannel;
+        }
+      `,
+    },
   ],
 });


### PR DESCRIPTION
fix(`check-template-names`, `require-template`): ensure template name  is based on what is within any brackets and preceding equal sign; fixes #1466