### PR TITLE
feat(`type-formatting`): add `property`, `this`, `throws`, and `yields` tags

### DIFF
--- a/.README/rules/type-formatting.md
+++ b/.README/rules/type-formatting.md
@@ -78,7 +78,7 @@ Determines the spacing to add to unions (`|`). Defaults to a single space (`" "`
 |||
 |---|---|
 |Context|everywhere|
-|Tags|`param`, `returns`, `type`, `typedef`|
+|Tags|`param`, `property`, `returns`, `this`, `throws`, `type`, `typedef`, `yields`|
 |Recommended|false|
 |Settings|`mode`|
 |Options|`arrayBrackets`, `enableFixer`, `genericDot`, `objectFieldIndent`, `objectFieldQuote`, `objectFieldSeparator`, `objectFieldSeparatorTrailingPunctuation`, `propertyQuotes`, `separatorForSingleObjectField`, `stringQuotes`, `typeBracketSpacing`, `unionSpacing`|

--- a/docs/rules/type-formatting.md
+++ b/docs/rules/type-formatting.md
@@ -106,7 +106,7 @@ Determines the spacing to add to unions (`|`). Defaults to a single space (`" "`
 |||
 |---|---|
 |Context|everywhere|
-|Tags|`param`, `returns`, `type`, `typedef`|
+|Tags|`param`, `property`, `returns`, `this`, `throws`, `type`, `typedef`, `yields`|
 |Recommended|false|
 |Settings|`mode`|
 |Options|`arrayBrackets`, `enableFixer`, `genericDot`, `objectFieldIndent`, `objectFieldQuote`, `objectFieldSeparator`, `objectFieldSeparatorTrailingPunctuation`, `propertyQuotes`, `separatorForSingleObjectField`, `stringQuotes`, `typeBracketSpacing`, `unionSpacing`|

--- a/src/rules/typeFormatting.js
+++ b/src/rules/typeFormatting.js
@@ -326,9 +326,13 @@ export default iterateJsdoc(({
 
   const tags = utils.getPresentTags([
     'param',
+    'property',
     'returns',
+    'this',
+    'throws',
     'type',
     'typedef',
+    'yields',
   ]);
   for (const tag of tags) {
     if (tag.type) {


### PR DESCRIPTION
feat(`type-formatting`): add `property`, `this`, `throws`, and `yields` tags

Also:
- docs(type-formatting): clarify