### PR TITLE
fix(`extraRuleDefinitions.forbid` jsdoc function option): point default link to advanced page

### DIFF
--- a/.README/advanced.md
+++ b/.README/advanced.md
@@ -101,9 +101,10 @@ then be selectively enabled and optionally disabled on a case-by-case basis.
 
 For each `forbid` key, add the name of the context (this will be appended to
 `forbid-` to decide the name of the rule, so with "Any" as the key, the rule
-created will be `forbid-Any`). Then provide an optional `description` key
-(which will be used for the created rule's `meta.docs.description`) and the
-`contexts` array. See the `jsdoc/restricted-syntax` rule for more details.
+created will be `forbid-Any`). Then provide an optional `description` and
+`url` keys (which will be used for the created rule's `meta.docs`
+`description` and `url` properties) and the `contexts` array.
+See the `jsdoc/restricted-syntax` rule for more details.
 
 ```js
 import {jsdoc} from 'eslint-plugin-jsdoc';
@@ -121,7 +122,8 @@ export default [
               message: '`any` is not allowed; use a more specific type',
             },
           ],
-          descriptions: 'Testing here',
+          description: 'Forbids `any` usage',
+          url: 'https://example.com/docs-for-my-any-rule/'
         },
         Function: {
           contexts: [

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -121,9 +121,10 @@ then be selectively enabled and optionally disabled on a case-by-case basis.
 
 For each `forbid` key, add the name of the context (this will be appended to
 `forbid-` to decide the name of the rule, so with "Any" as the key, the rule
-created will be `forbid-Any`). Then provide an optional `description` key
-(which will be used for the created rule's `meta.docs.description`) and the
-`contexts` array. See the `jsdoc/restricted-syntax` rule for more details.
+created will be `forbid-Any`). Then provide an optional `description` and
+`url` keys (which will be used for the created rule's `meta.docs`
+`description` and `url` properties) and the `contexts` array.
+See the `jsdoc/restricted-syntax` rule for more details.
 
 ```js
 import {jsdoc} from 'eslint-plugin-jsdoc';
@@ -141,7 +142,8 @@ export default [
               message: '`any` is not allowed; use a more specific type',
             },
           ],
-          descriptions: 'Testing here',
+          description: 'Forbids `any` usage',
+          url: 'https://example.com/docs-for-my-any-rule/'
         },
         Function: {
           contexts: [

--- a/src/index-cjs.js
+++ b/src/index-cjs.js
@@ -118,7 +118,7 @@ export const buildForbidRuleDefinition = ({
     meta: {
       docs: {
         description: description ?? contextName ?? 'Reports when certain comment structures are present.',
-        url: url ?? 'https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/no-restricted-syntax.md#repos-sticky-header',
+        url: url ?? 'https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/advanced.md#user-content-advanced-creating-your-own-rules',
       },
       fixable: 'code',
       schema: [],

--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,7 @@ export const buildForbidRuleDefinition = ({
     meta: {
       docs: {
         description: description ?? contextName ?? 'Reports when certain comment structures are present.',
-        url: url ?? 'https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/no-restricted-syntax.md#repos-sticky-header',
+        url: url ?? 'https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/advanced.md#user-content-advanced-creating-your-own-rules',
       },
       fixable: 'code',
       schema: [],


### PR DESCRIPTION
fix(`extraRuleDefinitions.forbid` jsdoc function option): point default link to advanced page

Also:
- docs: document `url` and fix `description` property