### PR TITLE
fix(`examples` configs): disable `@typescript-eslint/no-unsed-vars`

### DIFF
--- a/.README/processors.md
+++ b/.README/processors.md
@@ -97,7 +97,7 @@ For defaults, a couple rules are enabled which are usually useful:
 
 ```js
 import {getJsdocProcessorPlugin} from 'eslint-plugin-jsdoc';
-import {
+import ts, {
   parser as typescriptEslintParser,
 } from 'typescript-eslint';
 
@@ -129,8 +129,10 @@ export default [
     },
     processor: 'examples/examples'
   },
+  // Apply your TypeScript config
+  ...ts.configs.recommended,
   {
-    // Target the blocks within TypeScript
+    // Target the @example blocks within TypeScript
     files: [
       // `**/*.ts` could also work if you want to share this config
       //   with other non-@example TypeScript
@@ -144,8 +146,13 @@ export default [
     rules: {
       // Add the rules you want to apply to @example here
       'no-extra-semi': 'error',
+
       // disable problematic rules here, e.g.,
       // ...jsdoc.configs.examples[1].rules
+
+      // Due to https://github.com/gajus/eslint-plugin-jsdoc/issues/1377 ,
+      //   `typescript-eslint` type-checked rules must currently be disbaled
+      ...ts.configs.disableTypeChecked.rules
     }
   }
 ];

--- a/.README/rules/check-examples.md
+++ b/.README/rules/check-examples.md
@@ -146,7 +146,7 @@ by decreasing precedence:
   use extra lines within examples just for easier illustration
   purposes.
 * `no-undef` - Many variables in examples will be `undefined`.
-* `no-unused-vars` - It is common to define variables for clarity without
+* `no-unused-vars` (and `@typescript-eslint/no-unused-vars`) - It is common to define variables for clarity without
   always using them within examples.
 * `padded-blocks` (and `@stylistic/padded-blocks`) - It can generally look
   nicer to pad a little even if one's code follows more stringency as far

--- a/docs/processors.md
+++ b/docs/processors.md
@@ -101,7 +101,7 @@ For defaults, a couple rules are enabled which are usually useful:
 
 ```js
 import {getJsdocProcessorPlugin} from 'eslint-plugin-jsdoc';
-import {
+import ts, {
   parser as typescriptEslintParser,
 } from 'typescript-eslint';
 
@@ -133,8 +133,10 @@ export default [
     },
     processor: 'examples/examples'
   },
+  // Apply your TypeScript config
+  ...ts.configs.recommended,
   {
-    // Target the blocks within TypeScript
+    // Target the @example blocks within TypeScript
     files: [
       // `**/*.ts` could also work if you want to share this config
       //   with other non-@example TypeScript
@@ -148,8 +150,13 @@ export default [
     rules: {
       // Add the rules you want to apply to @example here
       'no-extra-semi': 'error',
+
       // disable problematic rules here, e.g.,
       // ...jsdoc.configs.examples[1].rules
+
+      // Due to https://github.com/gajus/eslint-plugin-jsdoc/issues/1377 ,
+      //   `typescript-eslint` type-checked rules must currently be disbaled
+      ...ts.configs.disableTypeChecked.rules
     }
   }
 ];

--- a/docs/rules/check-examples.md
+++ b/docs/rules/check-examples.md
@@ -173,7 +173,7 @@ by decreasing precedence:
   use extra lines within examples just for easier illustration
   purposes.
 * `no-undef` - Many variables in examples will be `undefined`.
-* `no-unused-vars` - It is common to define variables for clarity without
+* `no-unused-vars` (and `@typescript-eslint/no-unused-vars`) - It is common to define variables for clarity without
   always using them within examples.
 * `padded-blocks` (and `@stylistic/padded-blocks`) - It can generally look
   nicer to pad a little even if one's code follows more stringency as far

--- a/src/index-cjs.js
+++ b/src/index-cjs.js
@@ -563,6 +563,8 @@ index.configs.examples = /** @type {import('eslint').Linter.Config[]} */ ([
       // Can generally look nicer to pad a little even if code imposes more stringency
       '@stylistic/padded-blocks': 0,
 
+      '@typescript-eslint/no-unused-vars': 0,
+
       // "always" newline rule at end unlikely in sample code
       'eol-last': 0,
 

--- a/src/index.js
+++ b/src/index.js
@@ -569,6 +569,8 @@ index.configs.examples = /** @type {import('eslint').Linter.Config[]} */ ([
       // Can generally look nicer to pad a little even if code imposes more stringency
       '@stylistic/padded-blocks': 0,
 
+      '@typescript-eslint/no-unused-vars': 0,
+
       // "always" newline rule at end unlikely in sample code
       'eol-last': 0,
 

--- a/src/rules/checkExamples.js
+++ b/src/rules/checkExamples.js
@@ -47,6 +47,8 @@ const defaultMdRules = {
   // Can generally look nicer to pad a little even if code imposes more stringency
   '@stylistic/padded-blocks': 0,
 
+  '@typescript-eslint/no-unused-vars': 0,
+
   // "always" newline rule at end unlikely in sample code
   'eol-last': 0,
 


### PR DESCRIPTION
fix(`examples` configs): disable `@typescript-eslint/no-unsed-vars`

Also:
- docs(processor): more on typescript usage