### PR TITLE
fix(`type-formatting`): do not strip quotes for `objectFieldQuote` when not an ID; always allow unescaped digits

### DIFF
--- a/.README/rules/type-formatting.md
+++ b/.README/rules/type-formatting.md
@@ -26,7 +26,8 @@ Boolean value of whether to use a dot before the angled brackets of a generic (e
 
 Whether and how object field properties should be quoted (e.g., `{"a": string}`).
 Set to `single`, `double`, or `null`. Defaults to `null` (no quotes unless
-required due to whitespace within the field).
+required due to special characters within the field). Digits will be kept as is,
+regardless of setting (they can either represent a digit or a string digit).
 
 ### `propertyQuotes`
 

--- a/docs/rules/type-formatting.md
+++ b/docs/rules/type-formatting.md
@@ -38,7 +38,8 @@ Boolean value of whether to use a dot before the angled brackets of a generic (e
 
 Whether and how object field properties should be quoted (e.g., `{"a": string}`).
 Set to `single`, `double`, or `null`. Defaults to `null` (no quotes unless
-required due to whitespace within the field).
+required due to special characters within the field). Digits will be kept as is,
+regardless of setting (they can either represent a digit or a string digit).
 
 <a name="user-content-type-formatting-options-propertyquotes"></a>
 <a name="type-formatting-options-propertyquotes"></a>
@@ -318,6 +319,20 @@ The following patterns are not considered problems:
 /**
  * @param {{"a bc": string}} quotedKeyParam
  */
+
+/**
+ * @param {{55: string}} quotedKeyParam
+ */
+
+/**
+ * @param {{"a-b-c": string}} quotedKeyParam
+ */
+// "jsdoc/type-formatting": ["error"|"warn", {"objectFieldQuote":null}]
+
+/**
+ * @param {{55: string}} quotedKeyParam
+ */
+// "jsdoc/type-formatting": ["error"|"warn", {"objectFieldQuote":"double"}]
 
 /**
  * @param {ab.cd.ef} cfg

--- a/src/bin/generateRule.js
+++ b/src/bin/generateRule.js
@@ -40,7 +40,6 @@ const recommended = options.includes('--recommended');
   }
 
   const ruleNamesPath = './test/rules/ruleNames.json';
-  // @ts-expect-error Older types?
   const ruleNames = JSON.parse(await fs.readFile(
     ruleNamesPath,
   ));

--- a/src/getJsdocProcessorPlugin.js
+++ b/src/getJsdocProcessorPlugin.js
@@ -30,8 +30,7 @@ import {
 const {
   version,
 } = JSON.parse(
-  // @ts-expect-error `Buffer` is ok for `JSON.parse`
-  readFileSync(join(import.meta.dirname, '../package.json')),
+  readFileSync(join(import.meta.dirname, '../package.json'), 'utf8'),
 );
 
 // const zeroBasedLineIndexAdjust = -1;

--- a/src/rules/importsAsDependencies.js
+++ b/src/rules/importsAsDependencies.js
@@ -22,8 +22,7 @@ let deps;
 const setDeps = function () {
   try {
     const pkg = JSON.parse(
-      // @ts-expect-error It's ok
-      readFileSync(join(process.cwd(), './package.json')),
+      readFileSync(join(process.cwd(), './package.json'), 'utf8'),
     );
     deps = new Set([
       ...(pkg.dependencies ?
@@ -98,8 +97,7 @@ export default iterateJsdoc(({
           let pkg;
           try {
             pkg = JSON.parse(
-              // @ts-expect-error It's ok
-              readFileSync(join(process.cwd(), 'node_modules', mod, './package.json')),
+              readFileSync(join(process.cwd(), 'node_modules', mod, './package.json'), 'utf8'),
             );
           } catch {
             // Ignore

--- a/src/rules/typeFormatting.js
+++ b/src/rules/typeFormatting.js
@@ -250,8 +250,15 @@ export default iterateJsdoc(({
         case 'JsdocTypeObjectField': {
           const typeNode = /** @type {import('jsdoc-type-pratt-parser').ObjectFieldResult} */ (nde);
           if ((objectFieldQuote ||
-            (typeof typeNode.key === 'string' && !(/\s/v).test(typeNode.key))) &&
-            typeNode.meta.quote !== (objectFieldQuote ?? undefined)
+            (typeof typeNode.key === 'string' &&
+              (
+                (/^\p{ID_Start}\p{ID_Continue}*$/v).test(typeNode.key) ||
+                (/^(\d+(\.\d*)?|\.\d+)([eE][\-+]?\d+)?$/v).test(typeNode.key)
+              )
+            )) &&
+            typeNode.meta.quote !== (objectFieldQuote ?? undefined) &&
+            (typeof typeNode.key !== 'string' ||
+                !(/^(\d+(\.\d*)?|\.\d+)([eE][\-+]?\d+)?$/v).test(typeNode.key))
           ) {
             typeNode.meta.quote = objectFieldQuote ?? undefined;
             errorMessage = `Inconsistent object field quotes ${objectFieldQuote}`;

--- a/test/rules/assertions/typeFormatting.js
+++ b/test/rules/assertions/typeFormatting.js
@@ -717,6 +717,37 @@ export default {
     {
       code: `
         /**
+         * @param {{55: string}} quotedKeyParam
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @param {{"a-b-c": string}} quotedKeyParam
+         */
+      `,
+      options: [
+        {
+          objectFieldQuote: null,
+        },
+      ],
+    },
+    {
+      code: `
+        /**
+         * @param {{55: string}} quotedKeyParam
+         */
+      `,
+      options: [
+        {
+          objectFieldQuote: 'double',
+        },
+      ],
+    },
+    {
+      code: `
+        /**
          * @param {ab.cd.ef} cfg
          */
       `,


### PR DESCRIPTION
fix(`type-formatting`): do not strip quotes for `objectFieldQuote` when not an ID; always allow unescaped digits

Also:
- refactor: avoid suppressing type errors
