### PR TITLE
feat(`check-types`): deprecate `unifyParentAndChildTypeChecks` option in favor of new `unifyParentAndChildTypeChecks` preferredTypes[preferredType] setting

### DIFF
--- a/.README/rules/check-types.md
+++ b/.README/rules/check-types.md
@@ -57,7 +57,10 @@ RegExp
     `*` is only a child type. Note that there is no detection of parent
     and child type together, e.g., you cannot specify preferences for
     `string[]` specifically as distinct from say `number[]`, but you can
-    target both with `[]` or the child types `number` or `string`.
+    target both with `[]` or the child types `number` or `string`. If
+    `unifyParentAndChildTypeChecks` is set instead on `preferredTypes`,
+    then that value will be used instead. Note that the latter is the
+    preferred approach.
 
 If a value is present both as a key and as a value, neither the key nor the
 value will be reported. Thus one can use this fact to allow both `object`

--- a/.README/settings.md
+++ b/.README/settings.md
@@ -265,6 +265,8 @@ The format of the configuration is as follows:
       - `false` (for forbidding the type)
     - an optional key `skipRootChecking` (for `check-types`) to allow for this
       type in the context of a root (i.e., a parent object of some child type)
+    - an optional key `unifyParentAndChildTypeChecks` to override the
+      `jsdoc/check-types` option of the same name.
 
 Note that the preferred types indicated as targets in
 `settings.jsdoc.preferredTypes` map will be assumed to be defined by

--- a/docs/rules/check-types.md
+++ b/docs/rules/check-types.md
@@ -68,7 +68,10 @@ RegExp
     `*` is only a child type. Note that there is no detection of parent
     and child type together, e.g., you cannot specify preferences for
     `string[]` specifically as distinct from say `number[]`, but you can
-    target both with `[]` or the child types `number` or `string`.
+    target both with `[]` or the child types `number` or `string`. If
+    `unifyParentAndChildTypeChecks` is set instead on `preferredTypes`,
+    then that value will be used instead. Note that the latter is the
+    preferred approach.
 
 If a value is present both as a key and as a value, neither the key nor the
 value will be reported. Thus one can use this fact to allow both `object`
@@ -846,6 +849,29 @@ function abc(param) {
 function a () {}
 // Settings: {"jsdoc":{"preferredTypes":{"object":{"skipRootChecking":true}}}}
 // Message: Invalid JSDoc @param "b" type "object".
+
+/**
+ * @typedef {Object<string, number>} foo
+ */
+function a () {}
+// Settings: {"jsdoc":{"preferredTypes":{"Object":{"replacement":"object","unifyParentAndChildTypeChecks":true}}}}
+// Message: Invalid JSDoc @typedef "foo" type "Object"; prefer: "object".
+
+/**
+ * @typedef {Object} foo
+ */
+function a () {}
+// Settings: {"jsdoc":{"preferredTypes":{"Object":{"replacement":"object","unifyParentAndChildTypeChecks":true}}}}
+// Message: Invalid JSDoc @typedef "foo" type "Object"; prefer: "object".
+
+/**
+ * @param {object.<string>} foo
+ */
+function quux (foo) {
+
+}
+// Settings: {"jsdoc":{"mode":"typescript","preferredTypes":{"Object":"object","object.<>":{"replacement":"Object<>","unifyParentAndChildTypeChecks":true},"Object.<>":"Object<>","object<>":"Object<>"}}}
+// Message: Invalid JSDoc @param "foo" type "object"; prefer: "Object<>".
 ````
 
 
@@ -1185,5 +1211,11 @@ function a () {}
 function quux () {}
 // Settings: {"jsdoc":{"preferredTypes":{"[]":{"message":"Do not use *[], use Array<*> instead","replacement":"Array"}}}}
 // "jsdoc/check-types": ["error"|"warn", {"unifyParentAndChildTypeChecks":true}]
+
+/**
+ * @typedef {object} foo
+ */
+function a () {}
+// Settings: {"jsdoc":{"preferredTypes":{"Object":{"replacement":"object","unifyParentAndChildTypeChecks":true}}}}
 ````
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -290,6 +290,8 @@ The format of the configuration is as follows:
       - `false` (for forbidding the type)
     - an optional key `skipRootChecking` (for `check-types`) to allow for this
       type in the context of a root (i.e., a parent object of some child type)
+    - an optional key `unifyParentAndChildTypeChecks` to override the
+      `jsdoc/check-types` option of the same name.
 
 Note that the preferred types indicated as targets in
 `settings.jsdoc.preferredTypes` map will be assumed to be defined by

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -1726,6 +1726,7 @@ const getUtils = (
  *     message: string,
  *     replacement?: false|string
  *     skipRootChecking?: boolean
+ *     unifyParentAndChildTypeChecks?: boolean
  *   }
  * }} PreferredTypes
  */

--- a/src/rules.d.ts
+++ b/src/rules.d.ts
@@ -112,6 +112,9 @@ export interface Rules {
             types?: boolean | string[];
           }[];
           noDefaults?: boolean;
+          /**
+           * @deprecated Use the `preferredTypes[preferredType]` setting of the same name instead
+           */
           unifyParentAndChildTypeChecks?: boolean;
         }
       ];

--- a/test/rules/assertions/checkTypes.js
+++ b/test/rules/assertions/checkTypes.js
@@ -2371,6 +2371,104 @@ export default /** @type {import('../index.js').TestCases} */ ({
         },
       },
     },
+    {
+      code: `
+        /**
+         * @typedef {Object<string, number>} foo
+         */
+        function a () {}
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @typedef "foo" type "Object"; prefer: "object".',
+        },
+      ],
+      output: `
+        /**
+         * @typedef {object<string, number>} foo
+         */
+        function a () {}
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            Object: {
+              replacement: 'object',
+              unifyParentAndChildTypeChecks: true,
+            },
+          },
+        },
+      },
+    },
+    {
+      code: `
+        /**
+         * @typedef {Object} foo
+         */
+        function a () {}
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @typedef "foo" type "Object"; prefer: "object".',
+        },
+      ],
+      output: `
+        /**
+         * @typedef {object} foo
+         */
+        function a () {}
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            Object: {
+              replacement: 'object',
+              unifyParentAndChildTypeChecks: true,
+            },
+          },
+        },
+      },
+    },
+    {
+      code: `
+        /**
+         * @param {object.<string>} foo
+         */
+        function quux (foo) {
+
+        }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Invalid JSDoc @param "foo" type "object"; prefer: "Object<>".',
+        },
+      ],
+      output: `
+        /**
+         * @param {Object<string>} foo
+         */
+        function quux (foo) {
+
+        }
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'typescript',
+          preferredTypes: {
+            Object: 'object',
+            'object.<>': {
+              replacement: 'Object<>',
+              unifyParentAndChildTypeChecks: true,
+            },
+            'Object.<>': 'Object<>',
+            'object<>': 'Object<>',
+          },
+        },
+      },
+    },
   ],
   valid: [
     {
@@ -3074,6 +3172,24 @@ export default /** @type {import('../index.js').TestCases} */ ({
             '[]': {
               message: 'Do not use *[], use Array<*> instead',
               replacement: 'Array',
+            },
+          },
+        },
+      },
+    },
+    {
+      code: `
+        /**
+         * @typedef {object} foo
+         */
+        function a () {}
+      `,
+      settings: {
+        jsdoc: {
+          preferredTypes: {
+            Object: {
+              replacement: 'object',
+              unifyParentAndChildTypeChecks: true,
             },
           },
         },


### PR DESCRIPTION
feat(`check-types`): deprecate `unifyParentAndChildTypeChecks` option in favor of new `unifyParentAndChildTypeChecks` preferredTypes[preferredType] setting