### PR TITLE
fix(`type-formatting`): remove `propertyIndent` option

### DIFF
--- a/.README/rules/type-formatting.md
+++ b/.README/rules/type-formatting.md
@@ -89,7 +89,7 @@ Determines the spacing to add to unions (`|`). Defaults to a single space (`" "`
 |Tags|`param`, `property`, `returns`, `this`, `throws`, `type`, `typedef`, `yields`|
 |Recommended|false|
 |Settings|`mode`|
-|Options|`arrayBrackets`, `enableFixer`, `genericDot`, `objectFieldIndent`, `objectFieldQuote`, `objectFieldSeparator`, `objectFieldSeparatorOptionalLinebreak`, `objectFieldSeparatorTrailingPunctuation`, `propertyQuotes`, `separatorForSingleObjectField`, `stringQuotes`, `typeBracketSpacing`, `unionSpacing`|
+|Options|`arrayBrackets`, `enableFixer`, `genericDot`, `objectFieldIndent`, `objectFieldQuote`, `objectFieldSeparator`, `objectFieldSeparatorOptionalLinebreak`, `objectFieldSeparatorTrailingPunctuation`, `separatorForSingleObjectField`, `stringQuotes`, `typeBracketSpacing`, `unionSpacing`|
 
 ## Failing examples
 

--- a/docs/rules/type-formatting.md
+++ b/docs/rules/type-formatting.md
@@ -119,7 +119,7 @@ Determines the spacing to add to unions (`|`). Defaults to a single space (`" "`
 |Tags|`param`, `property`, `returns`, `this`, `throws`, `type`, `typedef`, `yields`|
 |Recommended|false|
 |Settings|`mode`|
-|Options|`arrayBrackets`, `enableFixer`, `genericDot`, `objectFieldIndent`, `objectFieldQuote`, `objectFieldSeparator`, `objectFieldSeparatorOptionalLinebreak`, `objectFieldSeparatorTrailingPunctuation`, `propertyQuotes`, `separatorForSingleObjectField`, `stringQuotes`, `typeBracketSpacing`, `unionSpacing`|
+|Options|`arrayBrackets`, `enableFixer`, `genericDot`, `objectFieldIndent`, `objectFieldQuote`, `objectFieldSeparator`, `objectFieldSeparatorOptionalLinebreak`, `objectFieldSeparatorTrailingPunctuation`, `separatorForSingleObjectField`, `stringQuotes`, `typeBracketSpacing`, `unionSpacing`|
 
 <a name="user-content-type-formatting-failing-examples"></a>
 <a name="type-formatting-failing-examples"></a>
@@ -205,12 +205,6 @@ The following patterns are considered problems:
 // Message: Inconsistent object field quotes null
 
 /**
- * @param {ab.cd.ef} cfg
- */
-// "jsdoc/type-formatting": ["error"|"warn", {"propertyQuotes":"double"}]
-// Message: Inconsistent double property quotes usage
-
-/**
  * @param {{a: string}} cfg A long
  *   description
  */
@@ -286,12 +280,6 @@ The following patterns are considered problems:
 // Message: Must have no initial spacing
 
 /**
- * @param {ab."cd".ef} cfg
- */
-// "jsdoc/type-formatting": ["error"|"warn", {"propertyQuotes":null}]
-// Message: Inconsistent null property quotes usage
-
-/**
  * @param {{a: string, b: number}} cfg
  */
 // "jsdoc/type-formatting": ["error"|"warn", {"objectFieldIndent":"  ","objectFieldSeparator":"semicolon-and-linebreak","objectFieldSeparatorOptionalLinebreak":true}]
@@ -357,16 +345,6 @@ The following patterns are not considered problems:
  * @param {{55: string}} quotedKeyParam
  */
 // "jsdoc/type-formatting": ["error"|"warn", {"objectFieldQuote":"double"}]
-
-/**
- * @param {ab.cd.ef} cfg
- */
-// "jsdoc/type-formatting": ["error"|"warn", {"propertyQuotes":null}]
-
-/**
- * @param {ab."cd ef".gh} cfg
- */
-// "jsdoc/type-formatting": ["error"|"warn", {"propertyQuotes":null}]
 
 /**
  * @param {ab | cd} cfg

--- a/src/rules/typeFormatting.js
+++ b/src/rules/typeFormatting.js
@@ -24,7 +24,7 @@ export default iterateJsdoc(({
     objectFieldSeparator = 'comma',
     objectFieldSeparatorOptionalLinebreak = true,
     objectFieldSeparatorTrailingPunctuation = false,
-    propertyQuotes = null,
+    // propertyQuotes = null,
     separatorForSingleObjectField = false,
     stringQuotes = 'single',
     typeBracketSpacing = '',
@@ -277,19 +277,20 @@ export default iterateJsdoc(({
           break;
         }
 
-        case 'JsdocTypeProperty': {
-          const typeNode = /** @type {import('jsdoc-type-pratt-parser').PropertyResult} */ (nde);
+        // Only suitable for namepaths (and would need changes); see https://github.com/gajus/eslint-plugin-jsdoc/issues/1524
+        // case 'JsdocTypeProperty': {
+        //   const typeNode = /** @type {import('jsdoc-type-pratt-parser').PropertyResult} */ (nde);
 
-          if ((propertyQuotes ||
-            (typeof typeNode.value === 'string' && !(/\s/v).test(typeNode.value))) &&
-            typeNode.meta.quote !== (propertyQuotes ?? undefined)
-          ) {
-            typeNode.meta.quote = propertyQuotes ?? undefined;
-            errorMessage = `Inconsistent ${propertyQuotes} property quotes usage`;
-          }
+        //   if ((propertyQuotes ||
+        //     (typeof typeNode.value === 'string' && !(/\s/v).test(typeNode.value))) &&
+        //     typeNode.meta.quote !== (propertyQuotes ?? undefined)
+        //   ) {
+        //     typeNode.meta.quote = propertyQuotes ?? undefined;
+        //     errorMessage = `Inconsistent ${propertyQuotes} property quotes usage`;
+        //   }
 
-          break;
-        }
+        //   break;
+        // }
 
         case 'JsdocTypeStringValue': {
           const typeNode = /** @type {import('jsdoc-type-pratt-parser').StringValueResult} */ (nde);
@@ -405,13 +406,13 @@ export default iterateJsdoc(({
           objectFieldSeparatorTrailingPunctuation: {
             type: 'boolean',
           },
-          propertyQuotes: {
-            enum: [
-              'double',
-              'single',
-              null,
-            ],
-          },
+          // propertyQuotes: {
+          //   enum: [
+          //     'double',
+          //     'single',
+          //     null,
+          //   ],
+          // },
           separatorForSingleObjectField: {
             type: 'boolean',
           },

--- a/test/rules/assertions/typeFormatting.js
+++ b/test/rules/assertions/typeFormatting.js
@@ -287,33 +287,33 @@ export default {
          */
       `,
     },
-    {
-      code: `
-        /**
-         * @param {ab.cd.ef} cfg
-         */
-      `,
-      errors: [
-        {
-          line: 3,
-          message: 'Inconsistent double property quotes usage',
-        },
-        {
-          line: 3,
-          message: 'Inconsistent double property quotes usage',
-        },
-      ],
-      options: [
-        {
-          propertyQuotes: 'double',
-        },
-      ],
-      output: `
-        /**
-         * @param {ab."cd"."ef"} cfg
-         */
-      `,
-    },
+    // {
+    //   code: `
+    //     /**
+    //      * @param {ab.cd.ef} cfg
+    //      */
+    //   `,
+    //   errors: [
+    //     {
+    //       line: 3,
+    //       message: 'Inconsistent double property quotes usage',
+    //     },
+    //     {
+    //       line: 3,
+    //       message: 'Inconsistent double property quotes usage',
+    //     },
+    //   ],
+    //   options: [
+    //     {
+    //       propertyQuotes: 'double',
+    //     },
+    //   ],
+    //   output: `
+    //     /**
+    //      * @param {ab."cd"."ef"} cfg
+    //      */
+    //   `,
+    // },
     {
       code: `
         /**
@@ -627,29 +627,29 @@ export default {
          */
       `,
     },
-    {
-      code: `
-        /**
-         * @param {ab."cd".ef} cfg
-         */
-      `,
-      errors: [
-        {
-          line: 3,
-          message: 'Inconsistent null property quotes usage',
-        },
-      ],
-      options: [
-        {
-          propertyQuotes: null,
-        },
-      ],
-      output: `
-        /**
-         * @param {ab.cd.ef} cfg
-         */
-      `,
-    },
+    // {
+    //   code: `
+    //     /**
+    //      * @param {ab."cd".ef} cfg
+    //      */
+    //   `,
+    //   errors: [
+    //     {
+    //       line: 3,
+    //       message: 'Inconsistent null property quotes usage',
+    //     },
+    //   ],
+    //   options: [
+    //     {
+    //       propertyQuotes: null,
+    //     },
+    //   ],
+    //   output: `
+    //     /**
+    //      * @param {ab.cd.ef} cfg
+    //      */
+    //   `,
+    // },
     {
       code: `
         /**
@@ -801,30 +801,30 @@ export default {
         },
       ],
     },
-    {
-      code: `
-        /**
-         * @param {ab.cd.ef} cfg
-         */
-      `,
-      options: [
-        {
-          propertyQuotes: null,
-        },
-      ],
-    },
-    {
-      code: `
-        /**
-         * @param {ab."cd ef".gh} cfg
-         */
-      `,
-      options: [
-        {
-          propertyQuotes: null,
-        },
-      ],
-    },
+    // {
+    //   code: `
+    //     /**
+    //      * @param {ab.cd.ef} cfg
+    //      */
+    //   `,
+    //   options: [
+    //     {
+    //       propertyQuotes: null,
+    //     },
+    //   ],
+    // },
+    // {
+    //   code: `
+    //     /**
+    //      * @param {ab."cd ef".gh} cfg
+    //      */
+    //   `,
+    //   options: [
+    //     {
+    //       propertyQuotes: null,
+    //     },
+    //   ],
+    // },
     {
       code: `
         /**


### PR DESCRIPTION
fix(`type-formatting`): remove `propertyIndent` option; fixes #1524

This option was particularly problematic in type contexts