### PR TITLE
fix(requireParam): update return type to include foundIndex and tagLineCount

### DIFF
--- a/docs/rules/require-param.md
+++ b/docs/rules/require-param.md
@@ -1275,6 +1275,25 @@ function quux (foo, bar, baz) {
   return foo + bar + baz;
 }
 // Message: Missing JSDoc @param "bar" declaration.
+
+/**
+ * @example
+ * ```ts
+ * app.use(checkResourceOwnership({ entryPoint: 'seller_product' }));
+ * ```
+ *
+ * @example
+ * ```ts
+ * app.use(checkResourceOwnership({ entryPoint: 'service_zone' }));
+ * ```
+ *
+ * @param options - configuration
+ * @param options.entryPoint
+ * @param options.filterField
+ * @param options.paramIdField
+ */
+export const checkResourceOwnership = ({ entryPoint, filterField, paramIdField, resourceId = () => '' }) => {};
+// Message: Missing JSDoc @param "options.resourceId" declaration.
 ````
 
 

--- a/docs/rules/require-param.md
+++ b/docs/rules/require-param.md
@@ -1265,6 +1265,16 @@ function quux ({
 }
 // "jsdoc/require-param": ["error"|"warn", {"interfaceExemptsParamsCheck":true}]
 // Message: Missing JSDoc @param "root0" declaration.
+
+/**
+ * @param foo
+ * @param baz
+ * @returns {number}
+ */
+function quux (foo, bar, baz) {
+  return foo + bar + baz;
+}
+// Message: Missing JSDoc @param "bar" declaration.
 ````
 
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "http://gajus.com"
   },
   "dependencies": {
-    "@es-joy/jsdoccomment": "~0.61.0",
+    "@es-joy/jsdoccomment": "~0.62.0",
     "are-docs-informative": "^0.0.2",
     "comment-parser": "1.4.1",
     "debug": "^4.4.3",
@@ -58,7 +58,7 @@
     "glob": "^11.0.3",
     "globals": "^16.4.0",
     "husky": "^9.1.7",
-    "jsdoc-type-pratt-parser": "^5.8.0",
+    "jsdoc-type-pratt-parser": "^5.9.0",
     "json-schema": "^0.4.0",
     "json-schema-to-typescript": "^15.0.4",
     "lint-staged": "^16.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@es-joy/jsdoccomment':
-        specifier: ~0.61.0
-        version: 0.61.0
+        specifier: ~0.62.0
+        version: 0.62.0
       are-docs-informative:
         specifier: ^0.0.2
         version: 0.0.2
@@ -163,8 +163,8 @@ importers:
         specifier: ^9.1.7
         version: 9.1.7
       jsdoc-type-pratt-parser:
-        specifier: ^5.8.0
-        version: 5.8.0
+        specifier: ^5.9.0
+        version: 5.9.0
       json-schema:
         specifier: ^0.4.0
         version: 0.4.0
@@ -802,8 +802,8 @@ packages:
     resolution: {integrity: sha512-c6EW+aA1w2rjqOMjbL93nZlwxp6c1Ln06vTYs5FjRRhmJXK8V/OrSXdT+pUr4aRYgjCgu8/OkiZr0tzeVrRSbw==}
     engines: {node: '>=20.11.0'}
 
-  '@es-joy/jsdoccomment@0.61.0':
-    resolution: {integrity: sha512-8DBk2LXau86fQBj7f9zx3MKqoAYgomxeoLgvHFa+OMhGYz6L9n/jbqa52wLHnbU6JzcSXu2OGuuTFOOMD4NpRg==}
+  '@es-joy/jsdoccomment@0.62.0':
+    resolution: {integrity: sha512-yWi6sm7INEwnfS7IJvE0dU+RTrwzLPFcY7e7eGpu/l5Q9lWfQ2ROwZ0qVnc242jw2TUPsfHX3XMIISkGBv57RQ==}
     engines: {node: '>=20.11.0'}
 
   '@eslint-community/eslint-utils@4.8.0':
@@ -3392,8 +3392,8 @@ packages:
     resolution: {integrity: sha512-DYYlVP1fe4QBMh2xTIs20/YeTz2GYVbWAEZweHSZD+qQ/Cx2d5RShuhhsdk64eTjNq0FeVnteP/qVOgaywSRbg==}
     engines: {node: '>=12.0.0'}
 
-  jsdoc-type-pratt-parser@5.8.0:
-    resolution: {integrity: sha512-YLmlPdkn1G34K/8NgSFL3D1D/HqQ9WgQOW816Q+6uMLvAO5QohdmG4qkuiseqnRXVAAN9RYtbCKyMSfwcU8wRw==}
+  jsdoc-type-pratt-parser@5.9.0:
+    resolution: {integrity: sha512-G1+QGbmN5EZ53DN3yKF6jax0FXeVEX4mgIx1K4YrsWhtXRaySR9cTZqB43ISxKAEna2LBG/I7NSl9wV//l1XPA==}
     engines: {node: '>=12.0.0'}
 
   jsdom@6.5.1:
@@ -5941,13 +5941,13 @@ snapshots:
       esquery: 1.6.0
       jsdoc-type-pratt-parser: 5.1.1
 
-  '@es-joy/jsdoccomment@0.61.0':
+  '@es-joy/jsdoccomment@0.62.0':
     dependencies:
       '@types/estree': 1.0.8
       '@typescript-eslint/types': 8.44.1
       comment-parser: 1.4.1
       esquery: 1.6.0
-      jsdoc-type-pratt-parser: 5.8.0
+      jsdoc-type-pratt-parser: 5.9.0
 
   '@eslint-community/eslint-utils@4.8.0(eslint@9.36.0(jiti@2.5.1))':
     dependencies:
@@ -8990,7 +8990,7 @@ snapshots:
 
   jsdoc-type-pratt-parser@5.1.1: {}
 
-  jsdoc-type-pratt-parser@5.8.0: {}
+  jsdoc-type-pratt-parser@5.9.0: {}
 
   jsdom@6.5.1:
     dependencies:

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -175,7 +175,10 @@ export default iterateJsdoc(({
    *   newAdd?: boolean
    * })[]} jsdocTags
    * @param {import('../iterateJsdoc.js').Integer} indexAtFunctionParams
-   * @returns {import('../iterateJsdoc.js').Integer}
+   * @returns {{
+   *   foundIndex: import('../iterateJsdoc.js').Integer,
+   *   tagLineCount: import('../iterateJsdoc.js').Integer,
+   * }}
    */
   const findExpectedIndex = (jsdocTags, indexAtFunctionParams) => {
     const remainingRoots = functionParameterNames.slice(indexAtFunctionParams || 0);
@@ -225,7 +228,10 @@ export default iterateJsdoc(({
       }
     }
 
-    return tagLineCount;
+    return {
+      foundIndex,
+      tagLineCount,
+    };
   };
 
   let [
@@ -486,8 +492,22 @@ export default iterateJsdoc(({
     if (remove) {
       createTokens(functionParameterIdx, offset + functionParameterIdx, 1);
     } else {
-      const expectedIdx = findExpectedIndex(jsdoc.tags, functionParameterIdx);
-      createTokens(expectedIdx, offset + expectedIdx, 0);
+      const {
+        foundIndex,
+        tagLineCount: expectedIdx,
+      } =
+        findExpectedIndex(jsdoc.tags, functionParameterIdx);
+
+      const firstParamLine = jsdoc.source.findIndex(({
+        tokens,
+      }) => {
+        return tokens.tag === `@${preferredTagName}`;
+      });
+      const baseOffset = foundIndex > -1 || firstParamLine === -1 ?
+        offset :
+        firstParamLine;
+
+      createTokens(expectedIdx, baseOffset + expectedIdx, 0);
     }
   };
 

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -2697,6 +2697,53 @@ export default /** @type {import('../index.js').TestCases} */ ({
           }
       `,
     },
+    {
+      code: `
+        /**
+         * @example
+         * \`\`\`ts
+         * app.use(checkResourceOwnership({ entryPoint: 'seller_product' }));
+         * \`\`\`
+         *
+         * @example
+         * \`\`\`ts
+         * app.use(checkResourceOwnership({ entryPoint: 'service_zone' }));
+         * \`\`\`
+         *
+         * @param options - configuration
+         * @param options.entryPoint
+         * @param options.filterField
+         * @param options.paramIdField
+         */
+        export const checkResourceOwnership = ({ entryPoint, filterField, paramIdField, resourceId = () => '' }) => {};
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @param "options.resourceId" declaration.',
+        },
+      ],
+      output: `
+        /**
+         * @example
+         * \`\`\`ts
+         * app.use(checkResourceOwnership({ entryPoint: 'seller_product' }));
+         * \`\`\`
+         *
+         * @example
+         * \`\`\`ts
+         * app.use(checkResourceOwnership({ entryPoint: 'service_zone' }));
+         * \`\`\`
+         *
+         * @param options - configuration
+         * @param options.entryPoint
+         * @param options.filterField
+         * @param options.paramIdField
+         * @param options.resourceId
+         */
+        export const checkResourceOwnership = ({ entryPoint, filterField, paramIdField, resourceId = () => '' }) => {};
+      `,
+    },
   ],
   valid: [
     {

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -2668,6 +2668,35 @@ export default /** @type {import('../index.js').TestCases} */ ({
           }
       `,
     },
+    {
+      code: `
+          /**
+           * @param foo
+           * @param baz
+           * @returns {number}
+           */
+          function quux (foo, bar, baz) {
+            return foo + bar + baz;
+          }
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Missing JSDoc @param "bar" declaration.',
+        },
+      ],
+      output: `
+          /**
+           * @param foo
+           * @param bar
+           * @param baz
+           * @returns {number}
+           */
+          function quux (foo, bar, baz) {
+            return foo + bar + baz;
+          }
+      `,
+    },
   ],
   valid: [
     {


### PR DESCRIPTION
Update the return type of the `findExpectedIndex` function to include `foundIndex` and `tagLineCount`. Adjust the logic in the calling function to utilize the new return structure, ensuring proper handling of expected indices and offsets.

Fixes #1530