### PR TITLE
fix: allow typedefs with no initial whitespace

### DIFF
--- a/docs/rules/no-undefined-types.md
+++ b/docs/rules/no-undefined-types.md
@@ -1020,5 +1020,14 @@ const otherFile = require('./other-file');
  * @param {otherFile.MyType} a
  */
 function f(a) {}
+
+/**@typedef {import('restify').Request} Request */
+/**@typedef {import('./types').helperError} helperError */
+
+/**
+ * @param {Request} b
+ * @param {helperError} c
+ */
+function a (b, c) {}
 ````
 

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -115,7 +115,7 @@ export default iterateJsdoc(({
   const allComments = sourceCode.getAllComments();
   const comments = allComments
     .filter((comment) => {
-      return (/^\*\s/v).test(comment.value);
+      return (/^\*(?!\*)/v).test(comment.value);
     })
     .map((commentNode) => {
       return parseComment(commentNode, '');

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -633,6 +633,24 @@ export default /** @type {import('../index.js').TestCases} */ ({
         },
       ],
     },
+    {
+      code: `
+          /*** @typedef {object} SomeType */
+          /**
+           * @param {SomeType} foo - Bar.
+           */
+          function quux(foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'The type \'SomeType\' is undefined.',
+        },
+      ],
+      ignoreReadme: true,
+    },
   ],
   valid: [
     {
@@ -1738,6 +1756,18 @@ export default /** @type {import('../index.js').TestCases} */ ({
          * @param {otherFile.MyType} a
          */
         function f(a) {}
+      `,
+    },
+    {
+      code: `
+      /**@typedef {import('restify').Request} Request */
+      /**@typedef {import('./types').helperError} helperError */
+
+      /**
+       * @param {Request} b
+       * @param {helperError} c
+       */
+      function a (b, c) {}
       `,
     },
   ],


### PR DESCRIPTION
fix: allow typedefs with no initial whitespace; fixes #1217

Also:
- test: add test for invalid typedef