### PR TITLE
fix(`reject-any-type`, `reject-function-type`): prevent object replacement as with `check-types`

### DIFF
--- a/src/buildRejectOrPreferRuleDefinition.js
+++ b/src/buildRejectOrPreferRuleDefinition.js
@@ -147,7 +147,8 @@ export const buildRejectOrPreferRuleDefinition = ({
           structuredTags: {},
         } : settings;
 
-      const injectObjectPreferredTypes = !('Object' in preferredTypesOriginal ||
+      const injectObjectPreferredTypes = !overrideSettings &&
+        !('Object' in preferredTypesOriginal ||
         'object' in preferredTypesOriginal ||
         'object.<>' in preferredTypesOriginal ||
         'Object.<>' in preferredTypesOriginal ||


### PR DESCRIPTION
fix(`reject-any-type`, `reject-function-type`): prevent object replacement as with `check-types`; fixes #1538