### PR TITLE
fix(`prefer-import-tag`): handle other cases of comments before structures early in the document

### DIFF
--- a/docs/rules/prefer-import-tag.md
+++ b/docs/rules/prefer-import-tag.md
@@ -302,6 +302,19 @@ let foo;
 /** @type {import('foo')} */
 let foo;
 // Message: Inline `import()` found; prefer `@import`
+
+/** @type {import('foo').bar} */
+let foo;
+// Message: Inline `import()` found; prefer `@import`
+
+/** @type {import('foo').bar} */
+let foo;
+// "jsdoc/prefer-import-tag": ["error"|"warn", {"outputType":"named-import"}]
+// Message: Inline `import()` found; prefer `@import`
+
+/** @type {import('foo').default} */
+let foo;
+// Message: Inline `import()` found; prefer `@import`
 ````
 
 

--- a/src/rules/preferImportTag.js
+++ b/src/rules/preferImportTag.js
@@ -386,10 +386,15 @@ export default iterateJsdoc(({
           enableFixer ? (fixer) => {
             getFixer(element.value, [])();
 
-            const programNode = sourceCode.getNodeByRangeIndex(0);
+            const programNode = sourceCode.ast;
+            const commentNodes = sourceCode.getCommentsBefore(programNode);
+
             return fixer.insertTextBefore(
-              /** @type {import('estree').Program} */ (programNode),
-              `/** @import ${element.value} from '${element.value}'; */`,
+              // @ts-expect-error Ok
+              commentNodes[0] ?? programNode,
+              `/** @import ${element.value} from '${element.value}'; */${
+                commentNodes[0] ? '\n' + indent : ''
+              }`,
             );
           } : null,
         );
@@ -411,12 +416,18 @@ export default iterateJsdoc(({
             )();
           }
 
-          const programNode = sourceCode.getNodeByRangeIndex(0);
+          const programNode = sourceCode.ast;
+          const commentNodes = sourceCode.getCommentsBefore(programNode);
           return fixer.insertTextBefore(
-            /** @type {import('estree').Program} */ (programNode),
+            // @ts-expect-error Ok
+            commentNodes[0] ?? programNode,
             outputType === 'namespaced-import' ?
-              `/** @import * as ${element.value} from '${element.value}'; */` :
-              `/** @import { ${pathSegments.at(-1)} } from '${element.value}'; */`,
+              `/** @import * as ${element.value} from '${element.value}'; */${
+                commentNodes[0] ? '\n' + indent : ''
+              }` :
+              `/** @import { ${pathSegments.at(-1)} } from '${element.value}'; */${
+                commentNodes[0] ? '\n' + indent : ''
+              }`,
           );
         } : null,
       );

--- a/test/rules/assertions/preferImportTag.js
+++ b/test/rules/assertions/preferImportTag.js
@@ -234,7 +234,6 @@ export default {
          */
       `,
     },
-
     {
       code: `
         /**
@@ -849,6 +848,62 @@ let foo;
       output: `/** @import * as foo from 'foo'; */
 /** @type {foo} */
 let foo;
+      `,
+    },
+    {
+      code: `
+        /** @type {import('foo').bar} */
+        let foo;
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Inline `import()` found; prefer `@import`',
+        },
+      ],
+      output: `
+        /** @import * as foo from 'foo'; */
+        /** @type {foo.bar} */
+        let foo;
+      `,
+    },
+    {
+      code: `
+        /** @type {import('foo').bar} */
+        let foo;
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Inline `import()` found; prefer `@import`',
+        },
+      ],
+      options: [
+        {
+          outputType: 'named-import',
+        },
+      ],
+      output: `
+        /** @import { bar } from 'foo'; */
+        /** @type {bar} */
+        let foo;
+      `,
+    },
+    {
+      code: `
+        /** @type {import('foo').default} */
+        let foo;
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Inline `import()` found; prefer `@import`',
+        },
+      ],
+      output: `
+        /** @import foo from 'foo'; */
+        /** @type {foo} */
+        let foo;
       `,
     },
   ],


### PR DESCRIPTION
fix(`prefer-import-tag`): handle other cases of comments before structures early in the document; fixes #1549