### PR TITLE
fix(`no-undefined-types`): do not treat type parameters or their references as undefined; #1215

### DIFF
--- a/docs/rules/no-undefined-types.md
+++ b/docs/rules/no-undefined-types.md
@@ -384,6 +384,29 @@ class Filler {
 /** @type {AnotherType} */
 // "jsdoc/no-undefined-types": ["error"|"warn", {"checkUsedTypedefs":true}]
 // Message: This typedef was not used within the file
+
+/** @typedef {'cwd'} */
+let MyOwnType1
+
+/**
+ * @param {`${MyOwnType1}-${string}`} tagName
+ * @param {CustomElementConstructor} component
+ */
+let defineCustomElement = (tagName, component) => {
+  customElements.define(tagName, component)
+}
+
+/** @typedef {string} */
+let MyOwnType2
+
+/**
+ * @param {<T extends unknown>(element: MyOwnType2) => T} callback
+ * @returns {void}
+ */
+let getValue = (callback) => {
+  callback(`hello`)
+}
+// Message: The type 'CustomElementConstructor' is undefined.
 ````
 
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "http://gajus.com"
   },
   "dependencies": {
-    "@es-joy/jsdoccomment": "~0.68.1",
+    "@es-joy/jsdoccomment": "~0.69.0",
     "are-docs-informative": "^0.0.2",
     "comment-parser": "1.4.1",
     "debug": "^4.4.3",
@@ -58,7 +58,7 @@
     "glob": "^11.0.3",
     "globals": "^16.4.0",
     "husky": "^9.1.7",
-    "jsdoc-type-pratt-parser": "^6.3.3",
+    "jsdoc-type-pratt-parser": "^6.4.0",
     "json-schema": "^0.4.0",
     "json-schema-to-typescript": "^15.0.4",
     "lint-staged": "^16.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@es-joy/jsdoccomment':
-        specifier: ~0.68.1
-        version: 0.68.1
+        specifier: ~0.69.0
+        version: 0.69.0
       are-docs-informative:
         specifier: ^0.0.2
         version: 0.0.2
@@ -163,8 +163,8 @@ importers:
         specifier: ^9.1.7
         version: 9.1.7
       jsdoc-type-pratt-parser:
-        specifier: ^6.3.3
-        version: 6.3.3
+        specifier: ^6.4.0
+        version: 6.4.0
       json-schema:
         specifier: ^0.4.0
         version: 0.4.0
@@ -796,8 +796,8 @@ packages:
     resolution: {integrity: sha512-yWi6sm7INEwnfS7IJvE0dU+RTrwzLPFcY7e7eGpu/l5Q9lWfQ2ROwZ0qVnc242jw2TUPsfHX3XMIISkGBv57RQ==}
     engines: {node: '>=20.11.0'}
 
-  '@es-joy/jsdoccomment@0.68.1':
-    resolution: {integrity: sha512-wJJXnfG2Pq7ZC8IeOupkkAVtEH6OYy1uVxRTeshXDQfSNsZneS7FUQlNf710osZ5Yz/b5ev9xChvybTT7CM63g==}
+  '@es-joy/jsdoccomment@0.69.0':
+    resolution: {integrity: sha512-7UgbKSStPxf2RF2fqKqJq3u1QN4kFzhE/lofHtEuptRjQPdYZOLGsqGcKzQGYWoPG5p8PyxUOoc3/Ca+UcFkdA==}
     engines: {node: '>=20.11.0'}
 
   '@eslint-community/eslint-utils@4.9.0':
@@ -3367,8 +3367,8 @@ packages:
     resolution: {integrity: sha512-TYzkACp/wPvDJLRY7qpHXtrhgwoAaojIOnLaaVNi+AbPU2u1kkjfKd9hXXTq0qSAGsyYXvwUXt99h9I5iCmjjw==}
     engines: {node: '>=12.0.0'}
 
-  jsdoc-type-pratt-parser@6.3.3:
-    resolution: {integrity: sha512-N1HQK15ZXdwgmXsALjUWW9Cwyg1BQS5hfP8KzDkbR4mjb+Ep8Uxcfwz+OU1tsNCRg99rk62d8GMNdG8Qz4k+Gg==}
+  jsdoc-type-pratt-parser@6.4.0:
+    resolution: {integrity: sha512-tVwTg612vD9h2w5hoRFRNOni7xITDYZigHwBDieLUf4IYPQtk6IFXe/NqJc/hGYteFAeIM+Ld6ZvmLuizKAZ7A==}
     engines: {node: '>=20.0.0'}
 
   jsdom@6.5.1:
@@ -5917,13 +5917,13 @@ snapshots:
       esquery: 1.6.0
       jsdoc-type-pratt-parser: 5.9.2
 
-  '@es-joy/jsdoccomment@0.68.1':
+  '@es-joy/jsdoccomment@0.69.0':
     dependencies:
       '@types/estree': 1.0.8
       '@typescript-eslint/types': 8.45.0
       comment-parser: 1.4.1
       esquery: 1.6.0
-      jsdoc-type-pratt-parser: 6.3.3
+      jsdoc-type-pratt-parser: 6.4.0
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.37.0(jiti@2.6.1))':
     dependencies:
@@ -8940,7 +8940,7 @@ snapshots:
 
   jsdoc-type-pratt-parser@5.9.2: {}
 
-  jsdoc-type-pratt-parser@6.3.3: {}
+  jsdoc-type-pratt-parser@6.4.0: {}
 
   jsdom@6.5.1:
     dependencies:

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -512,6 +512,25 @@ export default iterateJsdoc(({
         if (!allDefinedTypes.has(val) &&
           (!Array.isArray(structuredTypes) || !structuredTypes.includes(val))
         ) {
+          const parent =
+            /**
+             * @type {import('jsdoc-type-pratt-parser').RootResult & {
+             *   _parent?: import('jsdoc-type-pratt-parser').NonRootResult
+             * }}
+             */ (nde)._parent;
+          if (parent?.type === 'JsdocTypeTypeParameter') {
+            return;
+          }
+
+          if (parent?.type === 'JsdocTypeFunction' &&
+            /** @type {import('jsdoc-type-pratt-parser').FunctionResult} */
+            (parent)?.typeParameters?.some((typeParam) => {
+              return value === typeParam.name.value;
+            })
+          ) {
+            return;
+          }
+
           if (!disableReporting) {
             report(`The type '${val}' is undefined.`, null, tag);
           }

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -670,6 +670,37 @@ export default /** @type {import('../index.js').TestCases} */ ({
         },
       ],
     },
+    {
+      code: `
+        /** @typedef {'cwd'} */
+        let MyOwnType1
+
+        /**
+         * @param {\`\${MyOwnType1}-\${string}\`} tagName
+         * @param {CustomElementConstructor} component
+         */
+        let defineCustomElement = (tagName, component) => {
+          customElements.define(tagName, component)
+        }
+
+        /** @typedef {string} */
+        let MyOwnType2
+
+        /**
+         * @param {<T extends unknown>(element: MyOwnType2) => T} callback
+         * @returns {void}
+         */
+        let getValue = (callback) => {
+          callback(\`hello\`)
+        }
+      `,
+      errors: [
+        {
+          line: 7,
+          message: 'The type \'CustomElementConstructor\' is undefined.',
+        },
+      ],
+    },
   ],
   valid: [
     {


### PR DESCRIPTION
fix(`no-undefined-types`): do not treat type parameters or their references as undefined; #1215