### PR TITLE
fix(`require-yields-*`, `require-throws-*`): ensure alias of throws (exception) and of yields (yield) are checked

### DIFF
--- a/docs/rules/require-yields-type.md
+++ b/docs/rules/require-yields-type.md
@@ -23,6 +23,11 @@ The following patterns are considered problems:
  * @yields
  */
 // Message: @yields should have a type
+
+/**
+ * @yield
+ */
+// Message: @yields should have a type
 ````
 
 

--- a/src/index-cjs.js
+++ b/src/index-cjs.js
@@ -205,7 +205,7 @@ index.rules = {
   'require-throws-description': buildForbidRuleDefinition({
     contexts: [
       {
-        comment: 'JsdocBlock:has(JsdocTag[tag=throws]:not([description!=""]))',
+        comment: 'JsdocBlock:has(JsdocTag[tag=/^(?:throws|exception)$/]:not([description!=""]))',
         context: 'any',
         message: '@throws should have a description',
       },
@@ -216,7 +216,7 @@ index.rules = {
   'require-throws-type': buildForbidRuleDefinition({
     contexts: [
       {
-        comment: 'JsdocBlock:has(JsdocTag[tag=throws]:not([parsedType.type]))',
+        comment: 'JsdocBlock:has(JsdocTag[tag=/^(?:throws|exception)$/]:not([parsedType.type]))',
         context: 'any',
         message: '@throws should have a type',
       },
@@ -229,7 +229,7 @@ index.rules = {
   'require-yields-description': buildForbidRuleDefinition({
     contexts: [
       {
-        comment: 'JsdocBlock:has(JsdocTag[tag=yields]:not([name!=""]):not([description!=""]))',
+        comment: 'JsdocBlock:has(JsdocTag[tag=/^yields?$/]:not([name!=""]):not([description!=""]))',
         context: 'any',
         message: '@yields should have a description',
       },
@@ -240,7 +240,7 @@ index.rules = {
   'require-yields-type': buildForbidRuleDefinition({
     contexts: [
       {
-        comment: 'JsdocBlock:has(JsdocTag[tag=yields]:not([parsedType.type]))',
+        comment: 'JsdocBlock:has(JsdocTag[tag=/^yields?$/]:not([parsedType.type]))',
         context: 'any',
         message: '@yields should have a type',
       },

--- a/src/index.js
+++ b/src/index.js
@@ -211,7 +211,7 @@ index.rules = {
   'require-throws-description': buildForbidRuleDefinition({
     contexts: [
       {
-        comment: 'JsdocBlock:has(JsdocTag[tag=throws]:not([description!=""]))',
+        comment: 'JsdocBlock:has(JsdocTag[tag=/^(?:throws|exception)$/]:not([description!=""]))',
         context: 'any',
         message: '@throws should have a description',
       },
@@ -222,7 +222,7 @@ index.rules = {
   'require-throws-type': buildForbidRuleDefinition({
     contexts: [
       {
-        comment: 'JsdocBlock:has(JsdocTag[tag=throws]:not([parsedType.type]))',
+        comment: 'JsdocBlock:has(JsdocTag[tag=/^(?:throws|exception)$/]:not([parsedType.type]))',
         context: 'any',
         message: '@throws should have a type',
       },
@@ -235,7 +235,7 @@ index.rules = {
   'require-yields-description': buildForbidRuleDefinition({
     contexts: [
       {
-        comment: 'JsdocBlock:has(JsdocTag[tag=yields]:not([name!=""]):not([description!=""]))',
+        comment: 'JsdocBlock:has(JsdocTag[tag=/^yields?$/]:not([name!=""]):not([description!=""]))',
         context: 'any',
         message: '@yields should have a description',
       },
@@ -246,7 +246,7 @@ index.rules = {
   'require-yields-type': buildForbidRuleDefinition({
     contexts: [
       {
-        comment: 'JsdocBlock:has(JsdocTag[tag=yields]:not([parsedType.type]))',
+        comment: 'JsdocBlock:has(JsdocTag[tag=/^yields?$/]:not([parsedType.type]))',
         context: 'any',
         message: '@yields should have a type',
       },

--- a/test/rules/assertions/requireYieldsType.js
+++ b/test/rules/assertions/requireYieldsType.js
@@ -13,6 +13,19 @@ export default {
         },
       ],
     },
+    {
+      code: `
+        /**
+         * @yield
+         */
+      `,
+      errors: [
+        {
+          line: 2,
+          message: '@yields should have a type',
+        },
+      ],
+    },
   ],
   valid: [
     {


### PR DESCRIPTION
fix(`require-yields-*`, `require-throws-*`): ensure alias of throws (exception) and of yields (yield) are checked; fixes #1559