### PR TITLE
fix: `to-valid-identifier` should be a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "object-deep-merge": "^1.0.5",
     "parse-imports-exports": "^0.2.4",
     "semver": "^7.7.3",
-    "spdx-expression-parse": "^4.0.0"
+    "spdx-expression-parse": "^4.0.0",
+    "to-valid-identifier": "^0.1.1"
   },
   "description": "JSDoc linting rules for ESLint.",
   "devDependencies": {
@@ -67,7 +68,6 @@
     "replace": "^1.2.2",
     "rimraf": "^6.0.1",
     "semantic-release": "^24.2.9",
-    "to-valid-identifier": "^0.1.1",
     "typescript": "5.9.3",
     "typescript-eslint": "^8.46.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       spdx-expression-parse:
         specifier: ^4.0.0
         version: 4.0.0
+      to-valid-identifier:
+        specifier: ^0.1.1
+        version: 0.1.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.18.2
@@ -189,9 +192,6 @@ importers:
       semantic-release:
         specifier: ^24.2.9
         version: 24.2.9(typescript@5.9.3)
-      to-valid-identifier:
-        specifier: ^0.1.1
-        version: 0.1.1
       typescript:
         specifier: 5.9.3
         version: 5.9.3


### PR DESCRIPTION
fix: `to-valid-identifier` should be a dependency; fixes #1574