### PR TITLE
fix(`no-undefined-types`): consider module scope variables as defined

### DIFF
--- a/docs/rules/no-undefined-types.md
+++ b/docs/rules/no-undefined-types.md
@@ -1097,5 +1097,23 @@ class Storage {
   /** @type {globalThis.localStorage} */
   #storage
 }
+
+/**
+ * La liste des sévérités.
+ *
+ * @type {Object<string, number>}
+ */
+const Severities = {
+    FATAL: 1,
+    ERROR: 2,
+    WARN: 3,
+    INFO: 4,
+};
+
+/**
+ * @typedef {Severities[keyof Severities]} Severity Le type des sévérités.
+ */
+
+export default Severities;
 ````
 

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -342,7 +342,10 @@ export default iterateJsdoc(({
                 break;
               }
 
-              return [];
+              // Module scope names are also defined
+              return [
+                name,
+              ];
           }
 
           return [

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -1870,5 +1870,26 @@ export default /** @type {import('../index.js').TestCases} */ ({
         },
       },
     },
+    {
+      code: `
+        /**
+         * La liste des sévérités.
+         *
+         * @type {Object<string, number>}
+         */
+        const Severities = {
+            FATAL: 1,
+            ERROR: 2,
+            WARN: 3,
+            INFO: 4,
+        };
+
+        /**
+         * @typedef {Severities[keyof Severities]} Severity Le type des sévérités.
+         */
+
+        export default Severities;
+      `,
+    },
   ],
 });


### PR DESCRIPTION
fix(`no-undefined-types`): consider module scope variables as defined; fixes #1581