### PR TITLE
fix(`imports-as-dependencies`): check for object-based `types` (or `typings`)

### DIFF
--- a/docs/rules/imports-as-dependencies.md
+++ b/docs/rules/imports-as-dependencies.md
@@ -104,5 +104,9 @@ The following patterns are not considered problems:
 /**
  * @type {null|import('playwright').SomeApi}
  */
+
+/**
+ * @type {null|import('ts-api-utils').SomeApi}
+ */
 ````
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@es-joy/jsdoccomment": "~0.76.0",
-    "@es-joy/resolve.exports": "1.0.0",
+    "@es-joy/resolve.exports": "1.2.0",
     "are-docs-informative": "^0.0.2",
     "comment-parser": "1.4.1",
     "debug": "^4.4.3",
@@ -73,6 +73,7 @@
     "rollup": "^4.52.5",
     "semantic-release": "^25.0.1",
     "sinon": "^21.0.0",
+    "ts-api-utils": "^2.1.0",
     "typescript": "5.9.3",
     "typescript-eslint": "^8.46.2"
   },
@@ -162,7 +163,13 @@
   "pnpm": {
     "overrides": {
       "@types/eslint": "0.0.0-interferes-with-eslint-now"
-    }
+    },
+    "ignoredBuiltDependencies": [
+      "core-js",
+      "core-js-pure",
+      "re2",
+      "unrs-resolver"
+    ]
   },
   "scripts": {
     "ruleTypes": "node ./src/bin/generateRuleTypes.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ~0.76.0
         version: 0.76.0
       '@es-joy/resolve.exports':
-        specifier: 1.0.0
-        version: 1.0.0
+        specifier: 1.2.0
+        version: 1.2.0
       are-docs-informative:
         specifier: ^0.0.2
         version: 0.0.2
@@ -207,6 +207,9 @@ importers:
       sinon:
         specifier: ^21.0.0
         version: 21.0.0
+      ts-api-utils:
+        specifier: ^2.1.0
+        version: 2.1.0(typescript@5.9.3)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -855,8 +858,8 @@ packages:
     resolution: {integrity: sha512-g+RihtzFgGTx2WYCuTHbdOXJeAlGnROws0TeALx9ow/ZmOROOZkVg5wp/B44n0WJgI4SQFP1eWM2iRPlU2Y14w==}
     engines: {node: '>=20.11.0'}
 
-  '@es-joy/resolve.exports@1.0.0':
-    resolution: {integrity: sha512-bbrmzsAZ9GA/3oBS6r8PWMtZarEhKHr413hak8ArwMEZ5DtaLErnkcyEWUsXy7urBcmVu/TpDzHPDVM5uIbx9A==}
+  '@es-joy/resolve.exports@1.2.0':
+    resolution: {integrity: sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==}
     engines: {node: '>=10'}
 
   '@eslint-community/eslint-utils@4.9.0':
@@ -6316,7 +6319,7 @@ snapshots:
       esquery: 1.6.0
       jsdoc-type-pratt-parser: 6.10.0
 
-  '@es-joy/resolve.exports@1.0.0': {}
+  '@es-joy/resolve.exports@1.2.0': {}
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.38.0(jiti@2.6.1))':
     dependencies:

--- a/src/rules/importsAsDependencies.js
+++ b/src/rules/importsAsDependencies.js
@@ -104,15 +104,7 @@ export default iterateJsdoc(({
             // Ignore
           }
 
-          try {
-            if (!pkg || (!pkg.types && !pkg.typings && !resolve.exports(pkg, '.', {
-              conditions: [
-                '!default', '!import', '!node', 'types',
-              ],
-            }))) {
-              mod = `@types/${mod}`;
-            }
-          } catch {
+          if (!pkg || (!pkg.types && !pkg.typings && !resolve.types(pkg))) {
             mod = `@types/${mod}`;
           }
 

--- a/test/rules/assertions/importsAsDependencies.js
+++ b/test/rules/assertions/importsAsDependencies.js
@@ -157,5 +157,12 @@ export default /** @type {import('../index.js').TestCases} */ ({
          */
       `,
     },
+    {
+      code: `
+        /**
+         * @type {null|import('ts-api-utils').SomeApi}
+         */
+      `,
+    },
   ],
 });


### PR DESCRIPTION
fix(`imports-as-dependencies`): check for object-based `types` (or `typings`)