### PR TITLE
fix(`require-rejects`): do not treat synchronous throw as rejection

### DIFF
--- a/docs/rules/require-rejects.md
+++ b/docs/rules/require-rejects.md
@@ -352,5 +352,10 @@ async function quux () {
   throw new Error('abc');
 }
 // Settings: {"jsdoc":{"tagNamePreference":{"rejects":false}}}
+
+/** @param bar Something. */
+export function foo(bar: string): void {
+  throw new Error(`some error: ${bar}`);
+}
 ````
 

--- a/test/rules/assertions/requireRejects.js
+++ b/test/rules/assertions/requireRejects.js
@@ -1,4 +1,8 @@
-export default {
+import {
+  parser as typescriptEslintParser,
+} from 'typescript-eslint';
+
+export default /** @type {import('../index.js').TestCases} */ ({
   invalid: [
     {
       code: `
@@ -485,5 +489,17 @@ export default {
         },
       },
     },
+    {
+      code: `
+        /** @param bar Something. */
+        export function foo(bar: string): void {
+          throw new Error(\`some error: \${bar}\`);
+        }
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+        sourceType: 'module',
+      },
+    },
   ],
-};
+});


### PR DESCRIPTION
fix(`require-rejects`): do not treat synchronous throw as rejection; fixes #1603