### PR TITLE
Fix typo in error message: change '@reject' to '@rejects'

### DIFF
--- a/src/rules/requireRejects.js
+++ b/src/rules/requireRejects.js
@@ -183,7 +183,7 @@ export default iterateJsdoc(({
   };
 
   if (shouldReport()) {
-    report('Promise-rejecting function requires `@reject` tag');
+    report('Promise-rejecting function requires `@@rejects` tag');
   }
 }, {
   contextDefaults: true,


### PR DESCRIPTION
Fixes #1605

Corrected typo in require-rejects rule error message:
- Changed '@reject' to '@rejects'

This fixes the grammatical error in the Promise-rejecting function error message.