### PR TITLE
fix(`no-undefined-types`): support strict validation for TS namespaces

### DIFF
--- a/docs/rules/no-undefined-types.md
+++ b/docs/rules/no-undefined-types.md
@@ -407,6 +407,26 @@ let getValue = (callback) => {
   callback(`hello`)
 }
 // Message: The type 'CustomElementConstructor' is undefined.
+
+class MyClass {
+  static Existent = () =>{}
+}
+/** @type {MyClass.nonExistent} */
+const a = 1;
+// Message: The type 'MyClass.nonExistent' is undefined.
+
+declare namespace MyNamespace {
+  type MyType = string;
+  interface FooBar {
+    foobiz: string;
+  }
+}
+/** @type {MyNamespace.MyType} */
+const a = 's';
+/** @type {MyNamespace.OtherType} */
+const b = 's';
+// "jsdoc/no-undefined-types": ["error"|"warn", {"definedTypes":["MyNamespace"]}]
+// Message: The type 'MyNamespace.OtherType' is undefined.
 ````
 
 
@@ -1125,5 +1145,94 @@ export default Severities;
 const checkIsOnOf = (value, ...validValues) => {
   return validValues.includes(value);
 };
+
+declare namespace MyNamespace {
+  type MyType = string;
+  interface FooBar {
+    foobiz: string;
+  }
+}
+/** @type {MyNamespace.MyType} */
+const a = 's';
+/** @type {MyNamespace.FooBar} */
+const c = { foobiz: 's' };
+/**
+ * Function quux.
+ * @param {MyNamespace.FooBar['foobiz']} biz - Parameter 'foobiz' from FooBar.
+ */
+function quux(biz) {}
+// "jsdoc/no-undefined-types": ["error"|"warn", {"definedTypes":["MyNamespace"]}]
+
+declare namespace MyNamespace {
+  interface I {
+    [key: string]: string;
+    (): void;
+    new (): void;
+  }
+}
+/** @type {MyNamespace.I} */
+const x = null;
+// "jsdoc/no-undefined-types": ["error"|"warn", {"definedTypes":["MyNamespace"]}]
+
+declare namespace Nested {
+  namespace Namespace {
+    export interface C {}
+  }
+}
+/** @type {Nested.Namespace.C} */
+const x = null;
+// "jsdoc/no-undefined-types": ["error"|"warn", {"definedTypes":["Nested"]}]
+
+declare namespace NamespaceWithInterface {
+  export interface HasIndexSig {
+    [key: string]: string;
+    normalProp: number;
+  }
+}
+/** @type {NamespaceWithInterface.HasIndexSig} */
+const x = { normalProp: 1 };
+/** @type {NamespaceWithInterface.HasIndexSig['normalProp']} */
+const y = 1;
+// "jsdoc/no-undefined-types": ["error"|"warn", {"definedTypes":["NamespaceWithInterface"]}]
+
+declare namespace NsWithLiteralKey {
+  export interface HasLiteralKey {
+    "string-key": string;
+    normalProp: number;
+  }
+}
+/** @type {NsWithLiteralKey.HasLiteralKey} */
+const x = { "string-key": "value", normalProp: 1 };
+// "jsdoc/no-undefined-types": ["error"|"warn", {"definedTypes":["NsWithLiteralKey"]}]
+
+class MyClass {
+}
+MyClass.Existent = () => {};
+/** @type {MyClass.Existent} */
+const a = MyClass.Existent;
+
+class MyClass {
+  static Existent = () => {};
+}
+/** @type {MyClass.Existent} */
+const a = MyClass.Existent;
+
+declare namespace NamespaceWithEnum {
+  export enum Color {
+    Red,
+    Green,
+    Blue
+  }
+  export interface I {}
+}
+/** @type {NamespaceWithEnum.I} */
+const x = {};
+// "jsdoc/no-undefined-types": ["error"|"warn", {"definedTypes":["NamespaceWithEnum"]}]
+
+declare module "my-module" {
+  export interface ModuleType {}
+}
+/** @type {import("my-module").ModuleType} */
+const x = {};
 ````
 

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -701,6 +701,51 @@ export default /** @type {import('../index.js').TestCases} */ ({
         },
       ],
     },
+    {
+      code: `
+        class MyClass {
+          static Existent = () =>{}
+        }
+        /** @type {MyClass.nonExistent} */
+        const a = 1;
+      `,
+      errors: [
+        {
+          line: 5,
+          message: 'The type \'MyClass.nonExistent\' is undefined.',
+        },
+      ],
+    },
+    {
+      code: `
+        declare namespace MyNamespace {
+          type MyType = string;
+          interface FooBar {
+            foobiz: string;
+          }
+        }
+        /** @type {MyNamespace.MyType} */
+        const a = 's';
+        /** @type {MyNamespace.OtherType} */
+        const b = 's';
+      `,
+      errors: [
+        {
+          line: 10,
+          message: 'The type \'MyNamespace.OtherType\' is undefined.',
+        },
+      ],
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      options: [
+        {
+          definedTypes: [
+            'MyNamespace',
+          ],
+        },
+      ],
+    },
   ],
   valid: [
     {
@@ -1903,6 +1948,185 @@ export default /** @type {import('../index.js').TestCases} */ ({
           return validValues.includes(value);
         };
       `,
+    },
+    {
+      code: `
+        declare namespace MyNamespace {
+          type MyType = string;
+          interface FooBar {
+            foobiz: string;
+          }
+        }
+        /** @type {MyNamespace.MyType} */
+        const a = 's';
+        /** @type {MyNamespace.FooBar} */
+        const c = { foobiz: 's' };
+        /**
+         * Function quux.
+         * @param {MyNamespace.FooBar['foobiz']} biz - Parameter 'foobiz' from FooBar.
+         */
+        function quux(biz) {}
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      options: [
+        {
+          definedTypes: [
+            'MyNamespace',
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        declare namespace MyNamespace {
+          interface I {
+            [key: string]: string;
+            (): void;
+            new (): void;
+          }
+        }
+        /** @type {MyNamespace.I} */
+        const x = null;
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      options: [
+        {
+          definedTypes: [
+            'MyNamespace',
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        declare namespace Nested {
+          namespace Namespace {
+            export interface C {}
+          }
+        }
+        /** @type {Nested.Namespace.C} */
+        const x = null;
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      options: [
+        {
+          definedTypes: [
+            'Nested',
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        declare namespace NamespaceWithInterface {
+          export interface HasIndexSig {
+            [key: string]: string;
+            normalProp: number;
+          }
+        }
+        /** @type {NamespaceWithInterface.HasIndexSig} */
+        const x = { normalProp: 1 };
+        /** @type {NamespaceWithInterface.HasIndexSig['normalProp']} */
+        const y = 1;
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      options: [
+        {
+          definedTypes: [
+            'NamespaceWithInterface',
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        declare namespace NsWithLiteralKey {
+          export interface HasLiteralKey {
+            "string-key": string;
+            normalProp: number;
+          }
+        }
+        /** @type {NsWithLiteralKey.HasLiteralKey} */
+        const x = { "string-key": "value", normalProp: 1 };
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      options: [
+        {
+          definedTypes: [
+            'NsWithLiteralKey',
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        class MyClass {
+        }
+        MyClass.Existent = () => {};
+        /** @type {MyClass.Existent} */
+        const a = MyClass.Existent;
+      `,
+      languageOptions: {
+        ecmaVersion: 2_022,
+      },
+    },
+    {
+      code: `
+        class MyClass {
+          static Existent = () => {};
+        }
+        /** @type {MyClass.Existent} */
+        const a = MyClass.Existent;
+      `,
+      languageOptions: {
+        ecmaVersion: 2_022,
+      },
+    },
+    {
+      code: `
+        declare namespace NamespaceWithEnum {
+          export enum Color {
+            Red,
+            Green,
+            Blue
+          }
+          export interface I {}
+        }
+        /** @type {NamespaceWithEnum.I} */
+        const x = {};
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      options: [
+        {
+          definedTypes: [
+            'NamespaceWithEnum',
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        declare module "my-module" {
+          export interface ModuleType {}
+        }
+        /** @type {import("my-module").ModuleType} */
+        const x = {};
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
     },
   ],
 });


### PR DESCRIPTION
## Description

This PR updates the `no-undefined-types` rule to support strict validation of TypeScript namespaces. Previously, the rule might have been too permissive or failed to recognize types defined within namespaces in the same file.

This became an issue recently with an update that led to `definedTypes` matching a declared namespace on a `.d.ts` file starting to report their inner properties/types/interfaces as `undefined`.

An example would be configuring the `no-undefined-types` with:

```js
'jsdoc/no-undefined-types': ['error', { definedTypes: ['Foobar'] }],
```

while having a `.d.ts` file with something such as the following:

```ts
export type * as Foobiz from './foobiz';
export interface FoobarInterface {
  foo: string;
  bar: number;
}

export as namespace Foobar;
```

And then wanting to use `Foobar.FoobarInterface`, `Foobar.FoobarInterface['foo']`, or `Foobar.Foobiz.biz` as types on JSDoc. The TS LSP would recognize them, but this rule started reporting errors.

```js
/**
 * @param {Foobar.FoobarInterface} foobarInterface - Foobar interface.
 * @returns {{ biz: Foobar.FoobarInterface['bar'], foo: Foobar.FoobarInterface['foo'] }} Biz and Foo.
 */
const functionOverFoobarInterface = foobarInterface => {
  const { bar, foo } = foobarInterface;

  return { biz: bar * 2, foo };
};
```

## Changes

- **Strict Namespace Validation**: Namespaces defined in the current file (`TSModuleDeclaration`) are now added to the `closedTypes` set. This means the rule will strictly validate members accessed on these namespaces (e.g., `MyNamespace.NonExistentType` will now be reported as undefined).
- **Recursive Type Discovery**: The rule now recursively finds exported types within namespaces, including:
    - `TSTypeAliasDeclaration`.
    - `TSInterfaceDeclaration` (including their properties).
- **Test Updates**: 
    - Added test cases to verify valid access to defined namespace types and interfaces.
    - Added test cases to verify invalid access to undefined namespace types (strict validation).
    - Added a coverage test case to ensure `ExportNamedDeclaration` variants (like `export class` and `export {}`) are properly handled (ignored) without reducing code coverage.