### PR TITLE
fix(`require-template`): treat infer statement types as defined

### DIFF
--- a/docs/rules/require-template.md
+++ b/docs/rules/require-template.md
@@ -418,5 +418,10 @@ export interface Test<Foo extends string> {
   bar: Foo;
 }
 // Settings: {"jsdoc":{"tagNamePreference":{"template":"typeParam"}}}
+
+/**
+ * @template T
+ * @typedef {T extends Record<string, Record<string, infer F>> ? F : never} ExtractFunction
+ */
 ````
 

--- a/src/rules/requireTemplate.js
+++ b/src/rules/requireTemplate.js
@@ -135,10 +135,16 @@ export default iterateJsdoc(({
     }
 
     traverse(parsedType, (nde) => {
+      if (nde.type === 'JsdocTypeInfer') {
+        templateNames.push(nde.element.value);
+        return;
+      }
+
       const {
         type,
         value,
       } = /** @type {import('jsdoc-type-pratt-parser').NameResult} */ (nde);
+
       if (type === 'JsdocTypeName' && (/^[A-Z]$/v).test(value)) {
         usedNames.add(value);
         if (!usedNameToTag.has(value)) {

--- a/test/rules/assertions/requireTemplate.js
+++ b/test/rules/assertions/requireTemplate.js
@@ -746,5 +746,13 @@ export default /** @type {import('../index.js').TestCases} */ ({
         },
       },
     },
+    {
+      code: `
+        /**
+         * @template T
+         * @typedef {T extends Record<string, Record<string, infer F>> ? F : never} ExtractFunction
+         */
+      `,
+    },
   ],
 });


### PR DESCRIPTION
fix(`require-template`): treat infer statement types as defined; fixes #1628