### PR TITLE
fix(`valid-types`): allow numeric properties for jsdoc mode

### DIFF
--- a/docs/rules/valid-types.md
+++ b/docs/rules/valid-types.md
@@ -992,5 +992,12 @@ class Test {
 let SettingName = /** @type {const} */ ({
   THEME: `theme`,
 })
+
+/**
+ * @typedef {Array} AnnotatedCharacter
+ * @property {string} 0 Character data
+ * @property {string[]} 1 Annotation hashses
+ */
+// Settings: {"jsdoc":{"mode":"jsdoc"}}
 ````
 

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -176,6 +176,15 @@ export default iterateJsdoc(({
             break;
           }
 
+          case 'prop':
+          case 'property': {
+            if (mode === 'jsdoc' && (/^\d+$/v).test(namepath)) {
+              handled = true;
+            }
+
+            break;
+          }
+
           case 'borrows': {
             const startChar = namepath.charAt(0);
             if ([

--- a/test/rules/assertions/validTypes.js
+++ b/test/rules/assertions/validTypes.js
@@ -2037,5 +2037,34 @@ export default /** @type {import('../index.js').TestCases} */ ({
         })
       `,
     },
+    {
+      code: `
+        /**
+         * @typedef {Array} AnnotatedCharacter
+         * @property {string} 0 Character data
+         * @property {string[]} 1 Annotation hashses
+         */
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'jsdoc',
+        },
+      },
+    },
+    {
+      code: `
+        /**
+         * @typedef {Array} AnnotatedCharacter
+         * @prop {string} 0 Character data
+         * @prop {string[]} 1 Annotation hashses
+         */
+      `,
+      ignoreReadme: true,
+      settings: {
+        jsdoc: {
+          mode: 'jsdoc',
+        },
+      },
+    },
   ],
 });


### PR DESCRIPTION
fix(`valid-types`): allow numeric properties for jsdoc mode; fixes #1646