### PR TITLE
fix(`no-undefined-types`): ensure template tags are defined and avoid treating infer type identifier as undefined

### DIFF
--- a/docs/rules/no-undefined-types.md
+++ b/docs/rules/no-undefined-types.md
@@ -1240,5 +1240,16 @@ class Test {}
  * @template {Test} T
  * @typedef {T extends Test<infer I> ? I : never} TestType
  */
+
+/**
+ * @template T
+ */
+class Test {
+  /** @typedef {T} Type */
+  /** @type {Type} */
+  t;
+}
+
+console.log(Test);
 ````
 

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -235,9 +235,15 @@ export default iterateJsdoc(({
     ancestorNodes.flatMap((ancestorNode) => {
       return getTemplateTags(ancestorNode);
     }) :
-    utils.getPresentTags([
-      'template',
-    ]);
+    // We err on the side of being too aggressive; checking only
+    //   present tags is not sufficient
+    comments.flatMap((doc) => {
+      return doc.tags.filter(({
+        tag,
+      }) => {
+        return tag === 'template';
+      });
+    });
 
   const closureGenericTypes = templateTags.flatMap((tag) => {
     return utils.parseClosureTemplateTag(tag);

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -2137,5 +2137,19 @@ export default /** @type {import('../index.js').TestCases} */ ({
          */
       `,
     },
+    {
+      code: `
+        /**
+         * @template T
+         */
+        class Test {
+          /** @typedef {T} Type */
+          /** @type {Type} */
+          t;
+        }
+
+        console.log(Test);
+      `,
+    },
   ],
 });


### PR DESCRIPTION
- fix(`no-undefined-types`): avoid treating infer type identifier as undefined; fixes #1654
- fix(`no-undefined-types`): ensure template tags are defined; fixes #1655