### PR TITLE
fix(`check-param-names`): check arrow function properties in interfaces (TSPropertySignature)

### DIFF
--- a/docs/rules/check-param-names.md
+++ b/docs/rules/check-param-names.md
@@ -724,6 +724,14 @@ export function fn(...[type, arg]: FnArgs): void {
   // ...
 }
 // Message: Expected @param name to be "type". Got "arg".
+
+interface Foo {
+  /** @param wrongNameA ... */
+  method(name1: string): void
+  /** @param wrongNameB ... */
+  arrow: (name2: string) => void
+}
+// Message: Expected @param names to be "name1". Got "wrongNameA".
 ````
 
 

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -476,11 +476,14 @@ const getFunctionParameterNames = (
     return [];
   }
 
-  return (/** @type {import('@typescript-eslint/types').TSESTree.FunctionDeclaration} */ (
-    functionNode
-  ).params || /** @type {import('@typescript-eslint/types').TSESTree.MethodDefinition} */ (
-    functionNode
-  ).value?.params || []).map((param) => {
+  return (
+    /** @type {import('@typescript-eslint/types').TSESTree.TSFunctionType} */
+    (/** @type {import('@typescript-eslint/types').TSESTree.TSPropertySignature} */ (functionNode)?.typeAnnotation?.typeAnnotation)?.params ||
+    /** @type {import('@typescript-eslint/types').TSESTree.FunctionDeclaration} */ (
+      functionNode
+    ).params || /** @type {import('@typescript-eslint/types').TSESTree.MethodDefinition} */ (
+      functionNode
+    ).value?.params || []).map((param) => {
     return getParamName(param);
   });
 };

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -365,7 +365,7 @@ const validateParameterNamesDeep = (
 const allowedNodes = [
   'ArrowFunctionExpression', 'FunctionDeclaration', 'FunctionExpression', 'TSDeclareFunction',
   // Add this to above defaults
-  'TSMethodSignature',
+  'TSMethodSignature', 'TSPropertySignature',
 ];
 
 export default iterateJsdoc(({

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -1318,6 +1318,30 @@ export default /** @type {import('../index.js').TestCases} */ ({
         sourceType: 'module',
       },
     },
+    {
+      code: `
+        interface Foo {
+          /** @param wrongNameA ... */
+          method(name1: string): void
+          /** @param wrongNameB ... */
+          arrow: (name2: string) => void
+        }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @param names to be "name1". Got "wrongNameA".',
+        },
+        {
+          line: 5,
+          message: 'Expected @param names to be "name2". Got "wrongNameB".',
+        },
+      ],
+      languageOptions: {
+        parser: typescriptEslintParser,
+        sourceType: 'module',
+      },
+    },
   ],
   valid: [
     {


### PR DESCRIPTION
fix(`check-param-names`): check arrow function properties in interfaces (TSPropertySignature); fixes #1657