### PR TITLE
feat(`tag-lines`): add `startLinesWithNoTags` option

### DIFF
--- a/.README/rules/tag-lines.md
+++ b/.README/rules/tag-lines.md
@@ -27,7 +27,7 @@ Removes or adds lines between tags or trailing tags.
 |Tags|Any|
 |Recommended|true|
 |Settings|N/A|
-|Options|string ("always", "any", "never") followed by object with `applyToEndTag`, `count`, `endLines`, `maxBlockLines`, `startLines`, `tags`|
+|Options|string ("always", "any", "never") followed by object with `applyToEndTag`, `count`, `endLines`, `maxBlockLines`, `startLines`, `startLinesWithNoTags`, `tags`|
 
 ## Failing examples
 

--- a/docs/rules/tag-lines.md
+++ b/docs/rules/tag-lines.md
@@ -9,6 +9,7 @@
     * [`endLines`](#user-content-tag-lines-options-endlines)
     * [`maxBlockLines`](#user-content-tag-lines-options-maxblocklines)
     * [`startLines`](#user-content-tag-lines-options-startlines)
+    * [`startLinesWithNoTags`](#user-content-tag-lines-options-startlineswithnotags)
     * [`tags`](#user-content-tag-lines-options-tags)
 * [Context and settings](#user-content-tag-lines-context-and-settings)
 * [Failing examples](#user-content-tag-lines-failing-examples)
@@ -36,7 +37,7 @@ Removes or adds lines between tags or trailing tags.
 
 The first option is a string with the following possible values: "always", "any", "never".
 Defaults to "never". "any" is only useful with `tags` (allowing non-enforcement of lines except
-for particular tags) or with `startLines`, `endLines`, or `maxBlockLines`. It is also
+for particular tags) or with `startLines`, `startLinesWithNoTags` `endLines`, or `maxBlockLines`. It is also
 necessary if using the linebreak-setting options of the `sort-tags` rule
 so that the two rules won't conflict in both attempting to set lines
 between tags.
@@ -89,6 +90,12 @@ a line count will not be enforced.
 
 Defaults to `0`.
 
+<a name="user-content-tag-lines-options-startlineswithnotags"></a>
+<a name="tag-lines-options-startlineswithnotags"></a>
+### <code>startLinesWithNoTags</code>
+
+If set to a number, will enforce a starting lines count when there are no tags. Defaults to `undefined`.
+
 <a name="user-content-tag-lines-options-tags"></a>
 <a name="tag-lines-options-tags"></a>
 ### <code>tags</code>
@@ -114,7 +121,7 @@ Defaults to empty object.
 |Tags|Any|
 |Recommended|true|
 |Settings|N/A|
-|Options|string ("always", "any", "never") followed by object with `applyToEndTag`, `count`, `endLines`, `maxBlockLines`, `startLines`, `tags`|
+|Options|string ("always", "any", "never") followed by object with `applyToEndTag`, `count`, `endLines`, `maxBlockLines`, `startLines`, `startLinesWithNoTags`, `tags`|
 
 <a name="user-content-tag-lines-failing-examples"></a>
 <a name="tag-lines-failing-examples"></a>
@@ -422,6 +429,24 @@ function myTestFunction(bar) {
  */
 // "jsdoc/tag-lines": ["error"|"warn", "any",{"startLines":1}]
 // Message: Expected 1 lines after block description
+
+/**
+ * Some text
+ */
+function quux () {
+}
+// "jsdoc/tag-lines": ["error"|"warn", "any",{"startLinesWithNoTags":1}]
+// Message: Expected 1 lines after block description
+
+export interface SubOptionTypeMap {
+  /**
+   * Checkboxes have two states - true (checked) and false (unchecked)
+   *
+   */
+  checkbox: boolean
+}
+// "jsdoc/tag-lines": ["error"|"warn", "any",{"startLinesWithNoTags":0}]
+// Message: Expected only 0 lines after block description
 ````
 
 
@@ -668,5 +693,14 @@ class _Foo {
  * @param {string} a
  */
 // "jsdoc/tag-lines": ["error"|"warn", "any",{"maxBlockLines":2}]
+
+export interface SubOptionTypeMap {
+  /**
+   * Checkboxes have two states - true (checked) and false (unchecked)
+   *
+   */
+  checkbox: boolean
+}
+// "jsdoc/tag-lines": ["error"|"warn", "any",{"endLines":0,"startLines":0}]
 ````
 

--- a/src/rules.d.ts
+++ b/src/rules.d.ts
@@ -2949,6 +2949,10 @@ export interface Rules {
            */
           startLines?: number | null;
           /**
+           * If set to a number, will enforce a starting lines count when there are no tags. Defaults to `undefined`.
+           */
+          startLinesWithNoTags?: number;
+          /**
            * Overrides the default behavior depending on specific tags.
            *
            * An object whose keys are tag names and whose values are objects with the

--- a/src/rules/tagLines.js
+++ b/src/rules/tagLines.js
@@ -78,6 +78,7 @@ export default iterateJsdoc(({
       endLines = 0,
       maxBlockLines = null,
       startLines = 0,
+      startLinesWithNoTags = null,
       tags = {},
     } = {},
   ] = context.options;
@@ -292,8 +293,10 @@ export default iterateJsdoc(({
     return;
   }
 
-  if (typeof startLines === 'number') {
-    if (!jsdoc.tags.length) {
+  if (typeof startLines === 'number' || typeof startLinesWithNoTags === 'number') {
+    const noTags = !jsdoc.tags.length;
+
+    if (noTags && startLinesWithNoTags === null) {
       return;
     }
 
@@ -305,11 +308,13 @@ export default iterateJsdoc(({
       return;
     }
 
+    const startingLines = noTags ? startLinesWithNoTags : startLines;
+
     const trailingLines = description.match(/\n+$/v)?.[0]?.length;
-    const trailingDiff = (trailingLines ?? 0) - startLines;
+    const trailingDiff = (trailingLines ?? 0) - startingLines;
     if (trailingDiff > 0) {
       utils.reportJSDoc(
-        `Expected only ${startLines} line${startLines === 1 ? '' : 's'} after block description`,
+        `Expected only ${startingLines} line${startingLines === 1 ? '' : 's'} after block description`,
         {
           line: lastDescriptionLine - trailingDiff,
         },
@@ -331,7 +336,7 @@ export default iterateJsdoc(({
       );
     } else if (trailingDiff < 0) {
       utils.reportJSDoc(
-        `Expected ${startLines} lines after block description`,
+        `Expected ${startingLines} lines after block description`,
         {
           line: lastDescriptionLine,
         },
@@ -371,7 +376,7 @@ export default iterateJsdoc(({
     schema: [
       {
         description: `Defaults to "never". "any" is only useful with \`tags\` (allowing non-enforcement of lines except
-for particular tags) or with \`startLines\`, \`endLines\`, or \`maxBlockLines\`. It is also
+for particular tags) or with \`startLines\`, \`startLinesWithNoTags\` \`endLines\`, or \`maxBlockLines\`. It is also
 necessary if using the linebreak-setting options of the \`sort-tags\` rule
 so that the two rules won't conflict in both attempting to set lines
 between tags.`,
@@ -439,6 +444,10 @@ first tag only, unless there is only whitespace content, in which case,
 a line count will not be enforced.
 
 Defaults to \`0\`.`,
+          },
+          startLinesWithNoTags: {
+            description: 'If set to a number, will enforce a starting lines count when there are no tags. Defaults to `undefined`.',
+            type: 'number',
           },
           tags: {
             description: `Overrides the default behavior depending on specific tags.

--- a/test/rules/assertions/tagLines.js
+++ b/test/rules/assertions/tagLines.js
@@ -930,6 +930,72 @@ export default /** @type {import('../index.js').TestCases} */ ({
          */
       `,
     },
+    {
+      code: `
+        /**
+         * Some text
+         */
+        function quux () {
+        }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected 1 lines after block description',
+        },
+      ],
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      options: [
+        'any',
+        {
+          startLinesWithNoTags: 1,
+        },
+      ],
+      output: `
+        /**
+         * Some text
+         *
+         */
+        function quux () {
+        }
+      `,
+    },
+    {
+      code: `
+        export interface SubOptionTypeMap {
+          /**
+           * Checkboxes have two states - true (checked) and false (unchecked)
+           *
+           */
+          checkbox: boolean
+        }
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Expected only 0 lines after block description',
+        },
+      ],
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      options: [
+        'any',
+        {
+          startLinesWithNoTags: 0,
+        },
+      ],
+      output: `
+        export interface SubOptionTypeMap {
+          /**
+           * Checkboxes have two states - true (checked) and false (unchecked)
+           */
+          checkbox: boolean
+        }
+      `,
+    },
   ],
   valid: [
     {
@@ -1409,6 +1475,27 @@ export default /** @type {import('../index.js').TestCases} */ ({
         'any',
         {
           maxBlockLines: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        export interface SubOptionTypeMap {
+          /**
+           * Checkboxes have two states - true (checked) and false (unchecked)
+           *
+           */
+          checkbox: boolean
+        }
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      options: [
+        'any',
+        {
+          endLines: 0,
+          startLines: 0,
         },
       ],
     },


### PR DESCRIPTION
feat(`tag-lines`): add `startLinesWithNoTags` option; fixes #1661