### PR TITLE
fix(`check-param-names`): only fire on `TSPropertySignature` if with `TSFunctionNode`

### DIFF
--- a/docs/rules/check-param-names.md
+++ b/docs/rules/check-param-names.md
@@ -1180,5 +1180,13 @@ const inner = (c: number, d: string): void => {
   console.log(d);
 };
 // Settings: {"jsdoc":{"contexts":["VariableDeclaration"]}}
+
+const emit = defineEmits<{
+  /**
+   * Fired when an editable field is submitted.
+   * @param index the index of the editable field
+   */
+  submitField: [index: number];
+}>();
 ````
 

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -386,12 +386,18 @@ export default iterateJsdoc(({
     useDefaultObjectProperties = false,
   } = context.options[0] || {};
 
+  const nde = /** @type {import('@typescript-eslint/types').TSESTree.Node} */ (node);
+
   // Although we might just remove global settings contexts from applying to
   //   this rule (as they can cause problems with `getFunctionParameterNames`
   //   checks if they are not functions but say variables), the user may
   //   instead wish to narrow contexts in those settings, so this check
   //   is still useful
-  if (!allowedNodes.includes(/** @type {import('estree').Node} */ (node).type)) {
+  if (!allowedNodes.includes(nde.type) ||
+    nde.type === 'TSPropertySignature' &&
+      (/** @type {import('@typescript-eslint/types').TSESTree.TSPropertySignature} */ (
+        nde
+      )?.typeAnnotation?.typeAnnotation?.type !== 'TSFunctionType')) {
     return;
   }
 

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -2064,5 +2064,19 @@ export default /** @type {import('../index.js').TestCases} */ ({
         },
       },
     },
+    {
+      code: `
+        const emit = defineEmits<{
+          /**
+           * Fired when an editable field is submitted.
+           * @param index the index of the editable field
+           */
+          submitField: [index: number];
+        }>();
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+    },
   ],
 });


### PR DESCRIPTION
fix(`check-param-names`): only fire on `TSPropertySignature` if with `TSFunctionNode`; fixes #1663