### PR TITLE
fix: allow typedef returns that may be void

### DIFF
--- a/.README/rules/require-returns-check.md
+++ b/.README/rules/require-returns-check.md
@@ -15,6 +15,11 @@ Will report if native types are specified for `@returns` on an async function.
 
 Will also report if multiple `@returns` tags are present.
 
+If a `@returns` type references a typedef in the same source document and that
+typedef may be `void` or `undefined`, the rule treats the return type as
+allowing an absent return value unless `reportMissingReturnForUndefinedTypes`
+is set to `true`.
+
 ## Options
 
 {"gitdown": "options"}

--- a/docs/rules/require-returns-check.md
+++ b/docs/rules/require-returns-check.md
@@ -449,7 +449,21 @@ const maybeResult = () => {
  */
 const maybeResult = () => {
   if (Math.random() > 0.5) {
-    return 'ok';
+    return;
+  }
+};
+// Message: JSDoc @returns declaration present but return expression not available in function.
+
+/**
+ * @typedef {{ ok: boolean }} MaybeResult
+ */
+
+/**
+ * @returns {Array<MaybeResult|void>} Result.
+ */
+const maybeResult = () => {
+  if (Math.random() > 0.5) {
+    return;
   }
 };
 // Message: JSDoc @returns declaration present but return expression not available in function.
@@ -1034,17 +1048,83 @@ const maybeResult = () => {
 };
 
 /**
- * @returns {MaybeResult|string} Result.
+ * @typedef {{ ok: boolean } | void} MaybeResult
+ */
+
+/**
+ * @returns {MaybeResult} Result.
  */
 const maybeResult = () => {
   if (Math.random() > 0.5) {
-    return 'ok';
+    return { ok: true };
+  }
+};
+// Settings: {"jsdoc":{"mode":"permissive"}}
+
+/**
+ * @returns {MaybeResult} Result.
+ */
+const maybeResult = () => {
+  if (Math.random() > 0.5) {
+    return { ok: true };
   }
 };
 
 /**
  * @typedef {{ ok: boolean } | void} MaybeResult
  */
+
+/**
+ * @typedef {{ ok: boolean } | undefined} MaybeResult
+ */
+
+/**
+ * @returns {MaybeResult|string} Result.
+ */
+const maybeResult = () => {
+  if (Math.random() > 0.5) {
+    return { ok: true };
+  }
+};
+
+/**
+ * @typedef {{ ok: boolean }} MaybeResult
+ */
+
+/**
+ * @returns {MaybeResult|void} Result.
+ */
+const maybeResult = () => {
+  if (Math.random() > 0.5) {
+    return { ok: true };
+  }
+};
+
+/**
+ * @typedef {{ ok: boolean }} MaybeResult
+ */
+
+/**
+ * @returns {(MaybeResult|void)} Result.
+ */
+const maybeResult = () => {
+  if (Math.random() > 0.5) {
+    return { ok: true };
+  }
+};
+
+/**
+ * @typedef {{ ok: boolean }} MaybeResult
+ */
+
+/**
+ * @returns {(MaybeResult|undefined)} Result.
+ */
+const maybeResult = () => {
+  if (Math.random() > 0.5) {
+    return { ok: true };
+  }
+};
 
 /**
  * @param {AST} astNode

--- a/docs/rules/require-returns-check.md
+++ b/docs/rules/require-returns-check.md
@@ -25,6 +25,11 @@ Will report if native types are specified for `@returns` on an async function.
 
 Will also report if multiple `@returns` tags are present.
 
+If a `@returns` type references a typedef in the same source document and that
+typedef may be `void` or `undefined`, the rule treats the return type as
+allowing an absent return value unless `reportMissingReturnForUndefinedTypes`
+is set to `true`.
+
 <a name="user-content-require-returns-check-options"></a>
 <a name="require-returns-check-options"></a>
 ## Options
@@ -420,6 +425,20 @@ async function quux (foo) {
 }
 // "jsdoc/require-returns-check": ["error"|"warn", {"exemptAsync":false}]
 // Message: Function is async or otherwise returns a Promise but the return type is a native type.
+
+/**
+ * @typedef {{ ok: boolean }} MaybeResult
+ */
+
+/**
+ * @returns {MaybeResult} Result.
+ */
+const maybeResult = () => {
+  if (Math.random() > 0.5) {
+    return;
+  }
+};
+// Message: JSDoc @returns declaration present but return expression not available in function.
 ````
 
 
@@ -952,6 +971,71 @@ function maybeTrue() {
 }
 
 /**
+ * @param {string} name
+ *
+ * @typedef {{ loadTime: number; runTime: number; totalTime: number } | void} PerfResult
+ * @returns {PerfResult} Perf result
+ */
+const perfCase = name => {
+  const loadStartTime = performance.now();
+
+  let syncFn;
+
+  try {
+    syncFn = require(`./${name}.cjs`);
+  } catch {
+    return;
+  }
+
+  const loadTime = performance.now() - loadStartTime;
+
+  let i = RUN_TIMES;
+
+  const runStartTime = performance.now();
+
+  while (i-- > 0) {
+    syncFn(__filename);
+  }
+
+  const runTime = performance.now() - runStartTime;
+
+  return {
+    loadTime,
+    runTime,
+    totalTime: runTime + loadTime,
+  };
+};
+// Settings: {"jsdoc":{"mode":"typescript"}}
+
+/**
+ * @typedef {{ ok: boolean } | void} MaybeResult
+ */
+
+/**
+ * @returns {MaybeResult} Result.
+ */
+const maybeResult = () => {
+  if (Math.random() > 0.5) {
+    return { ok: true };
+  }
+};
+// Settings: {"jsdoc":{"mode":"typescript"}}
+
+/**
+ * @returns {MaybeResult} Result.
+ */
+const maybeResult = () => {
+  if (Math.random() > 0.5) {
+    return { ok: true };
+  }
+};
+
+/**
+ * @typedef {{ ok: boolean } | void} MaybeResult
+ */
+// Settings: {"jsdoc":{"mode":"typescript"}}
+
+/**
  * @param {AST} astNode
  * @returns {AST}
  */
@@ -1044,4 +1128,3 @@ function foo() {
   }
 }
 ````
-

--- a/docs/rules/require-returns-check.md
+++ b/docs/rules/require-returns-check.md
@@ -438,6 +438,7 @@ const maybeResult = () => {
     return;
   }
 };
+// Settings: {"jsdoc":{"mode":"typescript"}}
 // Message: JSDoc @returns declaration present but return expression not available in function.
 ````
 
@@ -1128,3 +1129,4 @@ function foo() {
   }
 }
 ````
+

--- a/docs/rules/require-returns-check.md
+++ b/docs/rules/require-returns-check.md
@@ -438,7 +438,20 @@ const maybeResult = () => {
     return;
   }
 };
-// Settings: {"jsdoc":{"mode":"typescript"}}
+// Message: JSDoc @returns declaration present but return expression not available in function.
+
+/**
+ * @typedef {{ ok: boolean }} MaybeResult
+ */
+
+/**
+ * @returns {MaybeResult|string} Result.
+ */
+const maybeResult = () => {
+  if (Math.random() > 0.5) {
+    return 'ok';
+  }
+};
 // Message: JSDoc @returns declaration present but return expression not available in function.
 ````
 
@@ -1000,13 +1013,12 @@ const perfCase = name => {
 
   const runTime = performance.now() - runStartTime;
 
-  return {
+return {
     loadTime,
     runTime,
     totalTime: runTime + loadTime,
   };
 };
-// Settings: {"jsdoc":{"mode":"typescript"}}
 
 /**
  * @typedef {{ ok: boolean } | void} MaybeResult
@@ -1020,21 +1032,19 @@ const maybeResult = () => {
     return { ok: true };
   }
 };
-// Settings: {"jsdoc":{"mode":"typescript"}}
 
 /**
- * @returns {MaybeResult} Result.
+ * @returns {MaybeResult|string} Result.
  */
 const maybeResult = () => {
   if (Math.random() > 0.5) {
-    return { ok: true };
+    return 'ok';
   }
 };
 
 /**
  * @typedef {{ ok: boolean } | void} MaybeResult
  */
-// Settings: {"jsdoc":{"mode":"typescript"}}
 
 /**
  * @param {AST} astNode
@@ -1129,4 +1139,3 @@ function foo() {
   }
 }
 ````
-

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -6,6 +6,7 @@ import {
 } from './tagNames.js';
 import WarnSettings from './WarnSettings.js';
 import {
+  parseComment,
   stringify,
   tryParse,
 } from '@es-joy/jsdoccomment';
@@ -734,6 +735,42 @@ const filterTags = (jsdoc, filter) => {
   return jsdoc.tags.filter((tag) => {
     return filter(tag);
   });
+};
+
+/**
+ * @param {import('eslint').SourceCode} sourceCode
+ * @returns {import('comment-parser').Block[]}
+ */
+const getJSDocComments = (sourceCode) => {
+  return sourceCode.getAllComments()
+    .filter((comment) => {
+      return (/^\*(?!\*)/v).test(comment.value);
+    })
+    .map((commentNode) => {
+      return parseComment(commentNode, '');
+    });
+};
+
+/**
+ * @param {import('./iterateJsdoc.js').Utils} utils
+ * @param {import('eslint').SourceCode} sourceCode
+ * @returns {import('comment-parser').Spec[]}
+ */
+const getDocumentTypedefTags = (utils, sourceCode) => {
+  return getJSDocComments(sourceCode)
+    .flatMap((doc) => {
+      return doc.tags.filter(({
+        tag,
+      }) => {
+        return utils.isNameOrNamepathDefiningTag(tag) && ![
+          'arg',
+          'argument',
+          'param',
+          'prop',
+          'property',
+        ].includes(tag);
+      });
+    });
 };
 
 /**
@@ -2110,9 +2147,11 @@ export {
   forEachPreferredTag,
   getAllTags,
   getContextObject,
+  getDocumentTypedefTags,
   getFunctionParameterNames,
   getIndent,
   getInlineTags,
+  getJSDocComments,
   getJsdocTagsDeep,
   getPreferredTagName,
   getPreferredTagNameSimple,

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -738,42 +738,6 @@ const filterTags = (jsdoc, filter) => {
 };
 
 /**
- * @param {import('eslint').SourceCode} sourceCode
- * @returns {import('comment-parser').Block[]}
- */
-const getJSDocComments = (sourceCode) => {
-  return sourceCode.getAllComments()
-    .filter((comment) => {
-      return (/^\*(?!\*)/v).test(comment.value);
-    })
-    .map((commentNode) => {
-      return parseComment(commentNode, '');
-    });
-};
-
-/**
- * @param {import('./iterateJsdoc.js').Utils} utils
- * @param {import('eslint').SourceCode} sourceCode
- * @returns {import('comment-parser').Spec[]}
- */
-const getDocumentTypedefTags = (utils, sourceCode) => {
-  return getJSDocComments(sourceCode)
-    .flatMap((doc) => {
-      return doc.tags.filter(({
-        tag,
-      }) => {
-        return utils.isNameOrNamepathDefiningTag(tag) && ![
-          'arg',
-          'argument',
-          'param',
-          'prop',
-          'property',
-        ].includes(tag);
-      });
-    });
-};
-
-/**
  * @param {import('./iterateJsdoc.js').JsdocBlockWithInline} jsdoc
  * @param {string} tagName
  * @returns {import('comment-parser').Spec[]}
@@ -1119,6 +1083,41 @@ const isNameOrNamepathDefiningTag = (tag, tagMap = tagStructure) => {
     'namepath-defining',
   ]).includes(/** @type {string|boolean|undefined} */ (
     tagStruct.get('namepathRole')));
+};
+
+/**
+ * @param {import('eslint').SourceCode} sourceCode
+ * @returns {import('@es-joy/jsdoccomment').JsdocBlockWithInline[]}
+ */
+const getJSDocCommentBlocks = (sourceCode) => {
+  return sourceCode.getAllComments()
+    .filter((comment) => {
+      return (/^\*(?!\*)/v).test(comment.value);
+    })
+    .map((commentNode) => {
+      return parseComment(commentNode, '');
+    });
+};
+
+/**
+ * @param {import('eslint').SourceCode} sourceCode
+ * @returns {import('comment-parser').Spec[]}
+ */
+const getDocumentNamepathDefiningTags = (sourceCode) => {
+  return getJSDocCommentBlocks(sourceCode)
+    .flatMap((doc) => {
+      return doc.tags.filter(({
+        tag,
+      }) => {
+        return isNameOrNamepathDefiningTag(tag) && ![
+          'arg',
+          'argument',
+          'param',
+          'prop',
+          'property',
+        ].includes(tag);
+      });
+    });
 };
 
 /**
@@ -2147,11 +2146,11 @@ export {
   forEachPreferredTag,
   getAllTags,
   getContextObject,
-  getDocumentTypedefTags,
+  getDocumentNamepathDefiningTags,
   getFunctionParameterNames,
   getIndent,
   getInlineTags,
-  getJSDocComments,
+  getJSDocCommentBlocks,
   getJsdocTagsDeep,
   getPreferredTagName,
   getPreferredTagNameSimple,

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -2,6 +2,10 @@ import iterateJsdoc, {
   parseComment,
 } from '../iterateJsdoc.js';
 import {
+  getDocumentTypedefTags,
+  getJSDocComments,
+} from '../jsdocUtils.js';
+import {
   getJSDocComment,
   parse as parseType,
   traverse,
@@ -123,13 +127,7 @@ export default iterateJsdoc(({
   }
 
   const allComments = sourceCode.getAllComments();
-  const comments = allComments
-    .filter((comment) => {
-      return (/^\*(?!\*)/v).test(comment.value);
-    })
-    .map((commentNode) => {
-      return parseComment(commentNode, '');
-    });
+  const comments = getJSDocComments(sourceCode);
 
   const globals = allComments
     .filter((comment) => {
@@ -138,20 +136,7 @@ export default iterateJsdoc(({
       return commentNode.value.replace(/^\s*globals/v, '').trim().split(/,\s*/v);
     }).concat(Object.keys(context.languageOptions.globals ?? []));
 
-  const typedefs = comments
-    .flatMap((doc) => {
-      return doc.tags.filter(({
-        tag,
-      }) => {
-        return utils.isNameOrNamepathDefiningTag(tag) && ![
-          'arg',
-          'argument',
-          'param',
-          'prop',
-          'property',
-        ].includes(tag);
-      });
-    });
+  const typedefs = getDocumentTypedefTags(utils, sourceCode);
 
   const typedefDeclarations = typedefs
     .map((tag) => {

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -2,8 +2,8 @@ import iterateJsdoc, {
   parseComment,
 } from '../iterateJsdoc.js';
 import {
-  getDocumentTypedefTags,
-  getJSDocComments,
+  getDocumentNamepathDefiningTags,
+  getJSDocCommentBlocks,
 } from '../jsdocUtils.js';
 import {
   getJSDocComment,
@@ -127,7 +127,7 @@ export default iterateJsdoc(({
   }
 
   const allComments = sourceCode.getAllComments();
-  const comments = getJSDocComments(sourceCode);
+  const comments = getJSDocCommentBlocks(sourceCode);
 
   const globals = allComments
     .filter((comment) => {
@@ -136,7 +136,7 @@ export default iterateJsdoc(({
       return commentNode.value.replace(/^\s*globals/v, '').trim().split(/,\s*/v);
     }).concat(Object.keys(context.languageOptions.globals ?? []));
 
-  const typedefs = getDocumentTypedefTags(utils, sourceCode);
+  const typedefs = getDocumentNamepathDefiningTags(sourceCode);
 
   const typedefDeclarations = typedefs
     .map((tag) => {

--- a/src/rules/requireReturnsCheck.js
+++ b/src/rules/requireReturnsCheck.js
@@ -1,13 +1,27 @@
 import iterateJsdoc from '../iterateJsdoc.js';
 import {
-  getDocumentTypedefTags,
+  getDocumentNamepathDefiningTags,
   strictNativeTypes,
 } from '../jsdocUtils.js';
 import {
-  parse as parseType,
   traverse,
   tryParse as tryParseType,
 } from '@es-joy/jsdoccomment';
+
+/**
+ * @type {Partial<Record<import('../jsdocUtils.js').ParserMode, import('jsdoc-type-pratt-parser').ParseMode[]>>}
+ */
+const parseTypeModes = {
+  closure: [
+    'closure',
+  ],
+  jsdoc: [
+    'jsdoc',
+  ],
+  typescript: [
+    'typescript',
+  ],
+};
 
 /**
  * @param {import('../iterateJsdoc.js').Utils} utils
@@ -42,6 +56,29 @@ const canSkip = (utils, settings) => {
     settings.mode === 'closure' && utils.classHasTag('record');
 };
 
+/**
+ * @param {import('jsdoc-type-pratt-parser').RootResult} parsedType
+ * @returns {import('jsdoc-type-pratt-parser').RootResult}
+ */
+const getReturnTypeLevelNode = (parsedType) => {
+  return parsedType.type === 'JsdocTypeParenthesis' ?
+    parsedType.element :
+    parsedType;
+};
+
+/**
+ * @param {import('eslint').Rule.RuleContext} context
+ * @param {import('../jsdocUtils.js').ParserMode} mode
+ * @returns {import('../jsdocUtils.js').ParserMode}
+ */
+const getParseMode = (context, mode) => {
+  const {
+    jsdoc,
+  } = /** @type {{jsdoc?: {mode?: import('../jsdocUtils.js').ParserMode}}} */ (context.settings);
+
+  return jsdoc?.mode ?? mode;
+};
+
 export default iterateJsdoc(({
   context,
   node,
@@ -56,6 +93,10 @@ export default iterateJsdoc(({
     noNativeTypes = true,
     reportMissingReturnForUndefinedTypes = false,
   } = context.options[0] || {};
+  const {
+    mode,
+  } = settings;
+  const parseMode = getParseMode(context, mode);
 
   if (canSkip(utils, settings)) {
     return;
@@ -97,7 +138,7 @@ export default iterateJsdoc(({
   }
 
   const returnNever = type === 'never';
-  const typedefs = getDocumentTypedefTags(utils, sourceCode);
+  const typedefs = getDocumentNamepathDefiningTags(sourceCode);
 
   /**
    * @param {import('comment-parser').Spec} returnTag
@@ -108,40 +149,45 @@ export default iterateJsdoc(({
       return true;
     }
 
+    const returnType = returnTag.type.trim();
     let parsedType;
     try {
-      const returnType = returnTag.type.trim();
-      parsedType = settings.mode === 'permissive' ?
-        tryParseType(returnType) :
-        parseType(returnType, settings.mode);
+      parsedType = tryParseType(returnType, parseTypeModes[parseMode]);
     } catch {
       return false;
     }
 
+    const returnTypeLevelNode = getReturnTypeLevelNode(parsedType);
     let returnIsUndefined = false;
-    traverse(parsedType, (nde, parentNode) => {
-      const {
-        type: nodeType,
-      } = /** @type {import('jsdoc-type-pratt-parser').NameResult|import('jsdoc-type-pratt-parser').UndefinedResult} */ (nde);
-      const topLevelReturnType = !parentNode || parentNode.type === 'JsdocTypeUnion';
-
-      if (
-        topLevelReturnType && (
-          nodeType === 'JsdocTypeUndefined' ||
-          nodeType === 'JsdocTypeName' &&
-          /** @type {import('jsdoc-type-pratt-parser').NameResult} */ (nde).value === 'void'
-        )
-      ) {
-        returnIsUndefined = true;
+    traverse(returnTypeLevelNode, (nde, parentNode) => {
+      const isReturnLevelNode = !parentNode ||
+        returnTypeLevelNode.type === 'JsdocTypeUnion' && parentNode === returnTypeLevelNode;
+      if (!isReturnLevelNode) {
+        return;
       }
 
-      if (!topLevelReturnType || nodeType !== 'JsdocTypeName') {
+      const {
+        type: nodeType,
+      } = /** @type {import('jsdoc-type-pratt-parser').RootResult} */ (nde);
+
+      if (nodeType === 'JsdocTypeUndefined') {
+        returnIsUndefined = true;
+        return;
+      }
+
+      if (nodeType !== 'JsdocTypeName') {
         return;
       }
 
       const {
         value,
       } = /** @type {import('jsdoc-type-pratt-parser').NameResult} */ (nde);
+
+      if (value === 'void') {
+        returnIsUndefined = true;
+        return;
+      }
+
       const referencedTypedef = typedefs.find((typedefTag) => {
         return typedefTag.name === value;
       });

--- a/src/rules/requireReturnsCheck.js
+++ b/src/rules/requireReturnsCheck.js
@@ -1,9 +1,13 @@
-import iterateJsdoc, {
-  parseComment,
-} from '../iterateJsdoc.js';
+import iterateJsdoc from '../iterateJsdoc.js';
 import {
+  getDocumentTypedefTags,
   strictNativeTypes,
 } from '../jsdocUtils.js';
+import {
+  parse as parseType,
+  traverse,
+  tryParse as tryParseType,
+} from '@es-joy/jsdoccomment';
 
 /**
  * @param {import('../iterateJsdoc.js').Utils} utils
@@ -36,34 +40,6 @@ const canSkip = (utils, settings) => {
     utils.isConstructor() ||
     utils.classHasTag('interface') ||
     settings.mode === 'closure' && utils.classHasTag('record');
-};
-
-/**
- * @param {import('../iterateJsdoc.js').Utils} utils
- * @param {import('eslint').SourceCode} sourceCode
- * @returns {import('comment-parser').Spec[]}
- */
-const getDocumentTypedefs = (utils, sourceCode) => {
-  return sourceCode.getAllComments()
-    .filter((comment) => {
-      return (/^\*(?!\*)/v).test(comment.value);
-    })
-    .map((commentNode) => {
-      return parseComment(commentNode, '');
-    })
-    .flatMap((doc) => {
-      return doc.tags.filter(({
-        tag,
-      }) => {
-        return utils.isNameOrNamepathDefiningTag(tag) && ![
-          'arg',
-          'argument',
-          'param',
-          'prop',
-          'property',
-        ].includes(tag);
-      });
-    });
 };
 
 export default iterateJsdoc(({
@@ -121,7 +97,7 @@ export default iterateJsdoc(({
   }
 
   const returnNever = type === 'never';
-  const typedefs = getDocumentTypedefs(utils, sourceCode);
+  const typedefs = getDocumentTypedefTags(utils, sourceCode);
 
   /**
    * @param {import('comment-parser').Spec} returnTag
@@ -132,12 +108,50 @@ export default iterateJsdoc(({
       return true;
     }
 
-    const returnType = returnTag.type.trim();
-    const referencedTypedef = typedefs.find((typedefTag) => {
-      return typedefTag.name === returnType;
+    let parsedType;
+    try {
+      const returnType = returnTag.type.trim();
+      parsedType = settings.mode === 'permissive' ?
+        tryParseType(returnType) :
+        parseType(returnType, settings.mode);
+    } catch {
+      return false;
+    }
+
+    let returnIsUndefined = false;
+    traverse(parsedType, (nde, parentNode) => {
+      const {
+        type: nodeType,
+      } = /** @type {import('jsdoc-type-pratt-parser').NameResult|import('jsdoc-type-pratt-parser').UndefinedResult} */ (nde);
+      const topLevelReturnType = !parentNode || parentNode.type === 'JsdocTypeUnion';
+
+      if (
+        topLevelReturnType && (
+          nodeType === 'JsdocTypeUndefined' ||
+          nodeType === 'JsdocTypeName' &&
+          /** @type {import('jsdoc-type-pratt-parser').NameResult} */ (nde).value === 'void'
+        )
+      ) {
+        returnIsUndefined = true;
+      }
+
+      if (!topLevelReturnType || nodeType !== 'JsdocTypeName') {
+        return;
+      }
+
+      const {
+        value,
+      } = /** @type {import('jsdoc-type-pratt-parser').NameResult} */ (nde);
+      const referencedTypedef = typedefs.find((typedefTag) => {
+        return typedefTag.name === value;
+      });
+
+      if (referencedTypedef && utils.mayBeUndefinedTypeTag(referencedTypedef)) {
+        returnIsUndefined = true;
+      }
     });
 
-    return Boolean(referencedTypedef && utils.mayBeUndefinedTypeTag(referencedTypedef));
+    return returnIsUndefined;
   };
 
   if (returnNever && utils.hasValueOrExecutorHasNonEmptyResolveValue(false)) {

--- a/src/rules/requireReturnsCheck.js
+++ b/src/rules/requireReturnsCheck.js
@@ -1,4 +1,6 @@
-import iterateJsdoc from '../iterateJsdoc.js';
+import iterateJsdoc, {
+  parseComment,
+} from '../iterateJsdoc.js';
 import {
   strictNativeTypes,
 } from '../jsdocUtils.js';
@@ -36,11 +38,40 @@ const canSkip = (utils, settings) => {
     settings.mode === 'closure' && utils.classHasTag('record');
 };
 
+/**
+ * @param {import('../iterateJsdoc.js').Utils} utils
+ * @param {import('eslint').SourceCode} sourceCode
+ * @returns {import('comment-parser').Spec[]}
+ */
+const getDocumentTypedefs = (utils, sourceCode) => {
+  return sourceCode.getAllComments()
+    .filter((comment) => {
+      return (/^\*(?!\*)/v).test(comment.value);
+    })
+    .map((commentNode) => {
+      return parseComment(commentNode, '');
+    })
+    .flatMap((doc) => {
+      return doc.tags.filter(({
+        tag,
+      }) => {
+        return utils.isNameOrNamepathDefiningTag(tag) && ![
+          'arg',
+          'argument',
+          'param',
+          'prop',
+          'property',
+        ].includes(tag);
+      });
+    });
+};
+
 export default iterateJsdoc(({
   context,
   node,
   report,
   settings,
+  sourceCode,
   utils,
 }) => {
   const {
@@ -90,6 +121,24 @@ export default iterateJsdoc(({
   }
 
   const returnNever = type === 'never';
+  const typedefs = getDocumentTypedefs(utils, sourceCode);
+
+  /**
+   * @param {import('comment-parser').Spec} returnTag
+   * @returns {boolean}
+   */
+  const mayReturnUndefined = (returnTag) => {
+    if (utils.mayBeUndefinedTypeTag(returnTag)) {
+      return true;
+    }
+
+    const returnType = returnTag.type.trim();
+    const referencedTypedef = typedefs.find((typedefTag) => {
+      return typedefTag.name === returnType;
+    });
+
+    return Boolean(referencedTypedef && utils.mayBeUndefinedTypeTag(referencedTypedef));
+  };
 
   if (returnNever && utils.hasValueOrExecutorHasNonEmptyResolveValue(false)) {
     report(`JSDoc @${tagName} declaration set with "never" but return expression is present in function.`);
@@ -107,7 +156,7 @@ export default iterateJsdoc(({
     !returnNever &&
     (
       reportMissingReturnForUndefinedTypes ||
-      !utils.mayBeUndefinedTypeTag(tag)
+      !mayReturnUndefined(tag)
     ) &&
     (tag.type === '' && !utils.hasValueOrExecutorHasNonEmptyResolveValue(
       exemptAsync,

--- a/test/rules/assertions/requireReturnsCheck.js
+++ b/test/rules/assertions/requireReturnsCheck.js
@@ -706,11 +706,28 @@ export default /** @type {import('../index.js').TestCases} */ ({
           message: 'JSDoc @returns declaration present but return expression not available in function.',
         },
       ],
-      settings: {
-        jsdoc: {
-          mode: 'typescript',
+    },
+    {
+      code: `
+      /**
+       * @typedef {{ ok: boolean }} MaybeResult
+       */
+
+      /**
+       * @returns {MaybeResult|string} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return 'ok';
+        }
+      };
+      `,
+      errors: [
+        {
+          line: 6,
+          message: 'JSDoc @returns declaration present but return expression not available in function.',
         },
-      },
+      ],
     },
   ],
   valid: [
@@ -1521,11 +1538,6 @@ export default /** @type {import('../index.js').TestCases} */ ({
         };
       };
       `,
-      settings: {
-        jsdoc: {
-          mode: 'typescript',
-        },
-      },
     },
     {
       code: `
@@ -1561,20 +1573,15 @@ export default /** @type {import('../index.js').TestCases} */ ({
         }
       };
       `,
-      settings: {
-        jsdoc: {
-          mode: 'typescript',
-        },
-      },
     },
     {
       code: `
       /**
-       * @returns {MaybeResult} Result.
+       * @returns {MaybeResult|string} Result.
        */
       const maybeResult = () => {
         if (Math.random() > 0.5) {
-          return { ok: true };
+          return 'ok';
         }
       };
 
@@ -1582,11 +1589,6 @@ export default /** @type {import('../index.js').TestCases} */ ({
        * @typedef {{ ok: boolean } | void} MaybeResult
        */
       `,
-      settings: {
-        jsdoc: {
-          mode: 'typescript',
-        },
-      },
     },
     {
       code: `

--- a/test/rules/assertions/requireReturnsCheck.js
+++ b/test/rules/assertions/requireReturnsCheck.js
@@ -718,7 +718,29 @@ export default /** @type {import('../index.js').TestCases} */ ({
        */
       const maybeResult = () => {
         if (Math.random() > 0.5) {
-          return 'ok';
+          return;
+        }
+      };
+      `,
+      errors: [
+        {
+          line: 6,
+          message: 'JSDoc @returns declaration present but return expression not available in function.',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @typedef {{ ok: boolean }} MaybeResult
+       */
+
+      /**
+       * @returns {Array<MaybeResult|void>} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return;
         }
       };
       `,
@@ -1577,17 +1599,102 @@ export default /** @type {import('../index.js').TestCases} */ ({
     {
       code: `
       /**
-       * @returns {MaybeResult|string} Result.
+       * @typedef {{ ok: boolean } | void} MaybeResult
+       */
+
+      /**
+       * @returns {MaybeResult} Result.
        */
       const maybeResult = () => {
         if (Math.random() > 0.5) {
-          return 'ok';
+          return { ok: true };
+        }
+      };
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'permissive',
+        },
+      },
+    },
+    {
+      code: `
+      /**
+       * @returns {MaybeResult} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return { ok: true };
         }
       };
 
       /**
        * @typedef {{ ok: boolean } | void} MaybeResult
        */
+      `,
+    },
+    {
+      code: `
+      /**
+       * @typedef {{ ok: boolean } | undefined} MaybeResult
+       */
+
+      /**
+       * @returns {MaybeResult|string} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return { ok: true };
+        }
+      };
+      `,
+    },
+    {
+      code: `
+      /**
+       * @typedef {{ ok: boolean }} MaybeResult
+       */
+
+      /**
+       * @returns {MaybeResult|void} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return { ok: true };
+        }
+      };
+      `,
+    },
+    {
+      code: `
+      /**
+       * @typedef {{ ok: boolean }} MaybeResult
+       */
+
+      /**
+       * @returns {(MaybeResult|void)} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return { ok: true };
+        }
+      };
+      `,
+    },
+    {
+      code: `
+      /**
+       * @typedef {{ ok: boolean }} MaybeResult
+       */
+
+      /**
+       * @returns {(MaybeResult|undefined)} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return { ok: true };
+        }
+      };
       `,
     },
     {

--- a/test/rules/assertions/requireReturnsCheck.js
+++ b/test/rules/assertions/requireReturnsCheck.js
@@ -685,6 +685,33 @@ export default /** @type {import('../index.js').TestCases} */ ({
         },
       ],
     },
+    {
+      code: `
+      /**
+       * @typedef {{ ok: boolean }} MaybeResult
+       */
+
+      /**
+       * @returns {MaybeResult} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return;
+        }
+      };
+      `,
+      errors: [
+        {
+          line: 6,
+          message: 'JSDoc @returns declaration present but return expression not available in function.',
+        },
+      ],
+      settings: {
+        jsdoc: {
+          mode: 'typescript',
+        },
+      },
+    },
   ],
   valid: [
     {
@@ -1459,6 +1486,50 @@ export default /** @type {import('../index.js').TestCases} */ ({
     {
       code: `
       /**
+       * @param {string} name
+       *
+       * @typedef {{ loadTime: number; runTime: number; totalTime: number } | void} PerfResult
+       * @returns {PerfResult} Perf result
+       */
+      const perfCase = name => {
+        const loadStartTime = performance.now();
+
+        let syncFn;
+
+        try {
+          syncFn = require(\`./\${name}.cjs\`);
+        } catch {
+          return;
+        }
+
+        const loadTime = performance.now() - loadStartTime;
+
+        let i = RUN_TIMES;
+
+        const runStartTime = performance.now();
+
+        while (i-- > 0) {
+          syncFn(__filename);
+        }
+
+        const runTime = performance.now() - runStartTime;
+
+        return {
+          loadTime,
+          runTime,
+          totalTime: runTime + loadTime,
+        };
+      };
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'typescript',
+        },
+      },
+    },
+    {
+      code: `
+      /**
        * Maybe return a boolean.
        * @return {boolean|void} true, or undefined.
        */
@@ -1472,6 +1543,48 @@ export default /** @type {import('../index.js').TestCases} */ ({
       settings: {
         jsdoc: {
           mode: 'permissive',
+        },
+      },
+    },
+    {
+      code: `
+      /**
+       * @typedef {{ ok: boolean } | void} MaybeResult
+       */
+
+      /**
+       * @returns {MaybeResult} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return { ok: true };
+        }
+      };
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'typescript',
+        },
+      },
+    },
+    {
+      code: `
+      /**
+       * @returns {MaybeResult} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return { ok: true };
+        }
+      };
+
+      /**
+       * @typedef {{ ok: boolean } | void} MaybeResult
+       */
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'typescript',
         },
       },
     },


### PR DESCRIPTION
Fixes #1390.

This updates `require-returns-check` so a `@returns` tag whose type resolves to a same-file `@typedef` is treated as potentially undefined when that typedef includes `void` or `undefined`. That prevents the rule from reporting a missing return expression for patterns like:

```js
/**
 * @typedef {{ loadTime: number; runTime: number; totalTime: number } | void} PerfResult
 * @returns {PerfResult}
 */
```

I also added generated docs coverage for the new valid case.

Verification:

- `pnpm run test-index --rule require-returns-check`
- `pnpm exec eslint src/rules/requireReturnsCheck.js test/rules/assertions/requireReturnsCheck.js`
- `pnpm run tsc`
- `pnpm run check-docs`
- `pnpm run build`
- `git diff --check`