### PR TITLE
fix(`no-undefined-types`): treat TS module vars as defined

### DIFF
--- a/docs/rules/no-undefined-types.md
+++ b/docs/rules/no-undefined-types.md
@@ -1251,5 +1251,14 @@ class Test {
 }
 
 console.log(Test);
+
+declare global {
+  const foo: number;
+}
+
+/**
+ * {@link foo}
+ */
+export const bar = 1;
 ````
 

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -340,6 +340,17 @@ export default iterateJsdoc(({
   /** @type {Set<string>} */
   const closedTypes = new Set();
 
+  const tsModuleVariables = scopeManager.scopes.find(({
+    type,
+  }) => {
+    // @ts-expect-error TS
+    return type === 'tsModule';
+  })?.variables.map(({
+    name,
+  }) => {
+    return name;
+  }) ?? [];
+
   const allDefinedTypes = new Set(globalScope.variables.map(({
     name,
   }) => {
@@ -431,6 +442,7 @@ export default iterateJsdoc(({
     .concat(typedefDeclarations)
     .concat(importTags)
     .concat(definedTypes)
+    .concat(tsModuleVariables)
     .concat(/** @type {string[]} */ (definedPreferredTypes))
     .concat((() => {
       // Other methods are not in scope, but we need them, and we grab them here

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -2151,5 +2151,20 @@ export default /** @type {import('../index.js').TestCases} */ ({
         console.log(Test);
       `,
     },
+    {
+      code: `
+        declare global {
+          const foo: number;
+        }
+
+        /**
+         * {@link foo}
+         */
+        export const bar = 1;
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+    },
   ],
 });


### PR DESCRIPTION
fix(`no-undefined-types`): treat TS module vars as defined; fixes #1701