### PR TITLE
Allow scoped package names in declaration-reference inline tags

### DIFF
--- a/docs/rules/escape-inline-tags.md
+++ b/docs/rules/escape-inline-tags.md
@@ -224,6 +224,11 @@ The following patterns are not considered problems:
  */
 
 /**
+ * A description with a multi-line inline tag {@link
+ * @scope/pkg#Member} reference.
+ */
+
+/**
  * @example
  * Here are some unescaped tags: @yearly, @monthly
  */

--- a/docs/rules/escape-inline-tags.md
+++ b/docs/rules/escape-inline-tags.md
@@ -112,6 +112,30 @@ The following patterns are considered problems:
 // Message: Unexpected inline JSDoc tag. Did you mean to use {@yearly}, \@yearly, or `@yearly`?
 
 /**
+ * Some description @scope and {@link @scope/pkg#Member}
+ */
+// "jsdoc/escape-inline-tags": ["error"|"warn", {"enableFixer":true}]
+// Message: Unexpected inline JSDoc tag. Did you mean to use {@scope}, \@scope, or `@scope`?
+
+/**
+ * Some description {@example @scope/pkg}
+ */
+// "jsdoc/escape-inline-tags": ["error"|"warn", {"enableFixer":true}]
+// Message: Unexpected inline JSDoc tag. Did you mean to use {@scope}, \@scope, or `@scope`?
+
+/**
+ * Some description {@link @scope/pkg#Member
+ */
+// "jsdoc/escape-inline-tags": ["error"|"warn", {"enableFixer":true}]
+// Message: Unexpected inline JSDoc tag. Did you mean to use {@scope}, \@scope, or `@scope`?
+
+/**
+ * Some description {@ @scope/pkg}
+ */
+// "jsdoc/escape-inline-tags": ["error"|"warn", {"enableFixer":true}]
+// Message: Unexpected inline JSDoc tag. Did you mean to use {@scope}, \@scope, or `@scope`?
+
+/**
  * @param includeNonStandard Whether to include a @yearly, @monthly etc text labels in the generated expression.
  */
 // "jsdoc/escape-inline-tags": ["error"|"warn", {"allowedInlineTags":["monthly"],"enableFixer":true,"fixType":"backticks"}]
@@ -180,11 +204,19 @@ The following patterns are not considered problems:
  */
 
 /**
+ * Use this CodeMirror {@link @codemirror/state#StateField} reference.
+ */
+
+/**
  * @someTag {@link https://example.com}
  */
 
 /**
  * @param {SomeType} aName {@link https://example.com}
+ */
+
+/**
+ * @param {SomeType} aName {@inheritDoc @scope-name/pkg-name#Member}
  */
 
 /**

--- a/src/rules/escapeInlineTags.js
+++ b/src/rules/escapeInlineTags.js
@@ -138,17 +138,33 @@ export default iterateJsdoc(({
     return '';
   };
 
+  const normalizedDescription = description.startsWith('\n') ?
+    description.slice(1) :
+    description;
+
+  let nextLineStartOffset = 0;
   for (const [
     idx,
     descLine,
-  ] of (
-      description.startsWith('\n') ? description.slice(1) : description
-    ).split('\n').entries()
+  ] of normalizedDescription.split('\n').entries()
   ) {
+    const lineStartOffset = nextLineStartOffset;
+
+    // +1 for the `\n` removed by split.
+    nextLineStartOffset += descLine.length + 1;
+
     descLine.replaceAll(unescapedInlineTagRegex, (match, tagName, offset) => {
       if (
         allowedInlineTags.includes(tagName) ||
-        shouldIgnoreMatch(descLine, match, offset)
+        // Run ignore-detection against the full description text so that
+        // multi-line inline tags (e.g. `{@link` on one line and
+        // `@scope/pkg#Member}` on the next) are recognized as being inside an
+        // inline tag rather than scanned per-line.
+        shouldIgnoreMatch(
+          normalizedDescription,
+          match,
+          lineStartOffset + offset,
+        )
       ) {
         return match;
       }
@@ -171,12 +187,15 @@ export default iterateJsdoc(({
       },
       enableFixer ?
         () => {
+          // `tagName` and `fixType` are constant here, so compute the escaper
+          // once rather than rebuilding the RegExp + closure for every line.
+          const [
+            ,
+            escapeInlineTag,
+          ] = escapeInlineTags(tagName);
+
           utils.setBlockDescription((info, seedTokens, descLines) => {
             return descLines.map((desc) => {
-              const [
-                ,
-                escapeInlineTag,
-              ] = escapeInlineTags(tagName);
               const newDesc = escapeInlineTag(desc);
 
               return {

--- a/src/rules/escapeInlineTags.js
+++ b/src/rules/escapeInlineTags.js
@@ -31,61 +31,50 @@ export default iterateJsdoc(({
   const indexes = [];
 
   const unescapedInlineTagRegex = /(?:^|\s)@(\w+)/gv;
-  for (const [
-    idx,
-    descLine,
-  ] of (
-      description.startsWith('\n') ? description.slice(1) : description
-    ).split('\n').entries()
-  ) {
-    descLine.replaceAll(unescapedInlineTagRegex, (_, tagName) => {
-      if (allowedInlineTags.includes(tagName)) {
-        return _;
-      }
 
-      tagNames.push(tagName);
-      indexes.push(idx);
+  const scopedPackageNameRegex = /^@[\w.\-]+\/[\w.\-]+/v;
 
-      return _;
-    });
-  }
+  const declarationReferenceInlineTags = new Set([
+    'inheritDoc',
+    'link',
+    'linkcode',
+    'linkplain',
+  ]);
 
-  for (const [
-    idx,
-    tagName,
-  ] of tagNames.entries()) {
-    utils.reportJSDoc(
-      `Unexpected inline JSDoc tag. Did you mean to use {@${tagName}}, \\@${tagName}, or \`@${tagName}\`?`,
-      {
-        line: indexes[idx] + 1,
-      },
-      enableFixer ?
-        () => {
-          utils.setBlockDescription((info, seedTokens, descLines) => {
-            return descLines.map((desc) => {
-              const newDesc = desc.replaceAll(
-                new RegExp(`(^|\\s)@${
-                  // No need to escape, as contains only safe characters
-                  tagName
-                }`, 'gv'),
-                fixType === 'backticks' ? '$1`@' + tagName + '`' : '$1\\@' + tagName,
-              );
+  /**
+   * @param {string} desc
+   * @param {number} atSignIndex
+   * @returns {string}
+   */
+  const getInlineTagName = (desc, atSignIndex) => {
+    const inlineTagStart = desc.lastIndexOf('{@', atSignIndex);
 
-              return {
-                number: 0,
-                source: '',
-                tokens: seedTokens({
-                  ...info,
-                  description: newDesc,
-                  postDelimiter: newDesc.trim() ? ' ' : '',
-                }),
-              };
-            });
-          });
-        } :
-        null,
-    );
-  }
+    if (inlineTagStart === -1) {
+      return '';
+    }
+
+    const inlineTagEnd = desc.indexOf('}', inlineTagStart);
+
+    if (inlineTagEnd === -1 || inlineTagEnd <= atSignIndex) {
+      return '';
+    }
+
+    return desc.slice(inlineTagStart + 2).match(/^\w+/v)?.[0] || '';
+  };
+
+  /**
+   * @param {string} desc
+   * @param {string} match
+   * @param {number} offset
+   * @returns {boolean}
+   */
+  const shouldIgnoreMatch = (desc, match, offset) => {
+    const atSignIndex = offset + match.lastIndexOf('@');
+    const inlineTagName = getInlineTagName(desc, atSignIndex);
+
+    return declarationReferenceInlineTags.has(inlineTagName) &&
+      scopedPackageNameRegex.test(desc.slice(atSignIndex));
+  };
 
   /**
    * @param {string} tagName
@@ -108,11 +97,103 @@ export default iterateJsdoc(({
       (desc) => {
         return desc.replaceAll(
           regex,
-          fixType === 'backticks' ? '$1`@' + tagName + '`' : '$1\\@' + tagName,
+          (match, prefix, offset) => {
+            if (shouldIgnoreMatch(desc, match, offset)) {
+              return match;
+            }
+
+            return fixType === 'backticks' ?
+              prefix + '`@' + tagName + '`' :
+              prefix + '\\@' + tagName;
+          },
         );
       },
     ];
   };
+
+  /**
+   * @param {string} desc
+   * @returns {string}
+   */
+  const getUnescapedInlineTagName = (desc) => {
+    unescapedInlineTagRegex.lastIndex = 0;
+
+    let match;
+    while ((match = unescapedInlineTagRegex.exec(desc)) !== null) {
+      const [
+        fullMatch,
+        tagName,
+      ] = match;
+
+      if (
+        allowedInlineTags.includes(tagName) ||
+        shouldIgnoreMatch(desc, fullMatch, match.index)
+      ) {
+        continue;
+      }
+
+      return tagName;
+    }
+
+    return '';
+  };
+
+  for (const [
+    idx,
+    descLine,
+  ] of (
+      description.startsWith('\n') ? description.slice(1) : description
+    ).split('\n').entries()
+  ) {
+    descLine.replaceAll(unescapedInlineTagRegex, (match, tagName, offset) => {
+      if (
+        allowedInlineTags.includes(tagName) ||
+        shouldIgnoreMatch(descLine, match, offset)
+      ) {
+        return match;
+      }
+
+      tagNames.push(tagName);
+      indexes.push(idx);
+
+      return match;
+    });
+  }
+
+  for (const [
+    idx,
+    tagName,
+  ] of tagNames.entries()) {
+    utils.reportJSDoc(
+      `Unexpected inline JSDoc tag. Did you mean to use {@${tagName}}, \\@${tagName}, or \`@${tagName}\`?`,
+      {
+        line: indexes[idx] + 1,
+      },
+      enableFixer ?
+        () => {
+          utils.setBlockDescription((info, seedTokens, descLines) => {
+            return descLines.map((desc) => {
+              const [
+                ,
+                escapeInlineTag,
+              ] = escapeInlineTags(tagName);
+              const newDesc = escapeInlineTag(desc);
+
+              return {
+                number: 0,
+                source: '',
+                tokens: seedTokens({
+                  ...info,
+                  description: newDesc,
+                  postDelimiter: newDesc.trim() ? ' ' : '',
+                }),
+              };
+            });
+          });
+        } :
+        null,
+    );
+  }
 
   for (const tag of jsdoc.tags) {
     if (tag.tag === 'example') {
@@ -125,10 +206,7 @@ export default iterateJsdoc(({
       utils.getTagDescription(tag, true)
     // eslint-disable-next-line no-loop-func -- Safe
     ).some((desc) => {
-      tagName = unescapedInlineTagRegex.exec(desc)?.[1] ?? '';
-      if (allowedInlineTags.includes(tagName)) {
-        return false;
-      }
+      tagName = getUnescapedInlineTagName(desc);
 
       return tagName;
     })) {

--- a/test/rules/assertions/escapeInlineTags.js
+++ b/test/rules/assertions/escapeInlineTags.js
@@ -500,6 +500,14 @@ export default {
     {
       code: `
         /**
+         * A description with a multi-line inline tag {@link
+         * @scope/pkg#Member} reference.
+         */
+      `,
+    },
+    {
+      code: `
+        /**
          * @example
          * Here are some unescaped tags: @yearly, @monthly
          */

--- a/test/rules/assertions/escapeInlineTags.js
+++ b/test/rules/assertions/escapeInlineTags.js
@@ -212,6 +212,98 @@ export default {
     {
       code: `
         /**
+         * Some description @scope and {@link @scope/pkg#Member}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Unexpected inline JSDoc tag. Did you mean to use {@scope}, \\@scope, or `@scope`?',
+        },
+      ],
+      options: [
+        {
+          enableFixer: true,
+        },
+      ],
+      output: `
+        /**
+         * Some description \\@scope and {@link @scope/pkg#Member}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * Some description {@example @scope/pkg}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Unexpected inline JSDoc tag. Did you mean to use {@scope}, \\@scope, or `@scope`?',
+        },
+      ],
+      options: [
+        {
+          enableFixer: true,
+        },
+      ],
+      output: `
+        /**
+         * Some description {@example \\@scope/pkg}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * Some description {@link @scope/pkg#Member
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Unexpected inline JSDoc tag. Did you mean to use {@scope}, \\@scope, or `@scope`?',
+        },
+      ],
+      options: [
+        {
+          enableFixer: true,
+        },
+      ],
+      output: `
+        /**
+         * Some description {@link \\@scope/pkg#Member
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * Some description {@ @scope/pkg}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Unexpected inline JSDoc tag. Did you mean to use {@scope}, \\@scope, or `@scope`?',
+        },
+      ],
+      options: [
+        {
+          enableFixer: true,
+        },
+      ],
+      output: `
+        /**
+         * Some description {@ \\@scope/pkg}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
          * @param includeNonStandard Whether to include a @yearly, @monthly etc text labels in the generated expression.
          */
       `,
@@ -373,6 +465,13 @@ export default {
     {
       code: `
         /**
+         * Use this CodeMirror {@link @codemirror/state#StateField} reference.
+         */
+      `,
+    },
+    {
+      code: `
+        /**
          * @someTag {@link https://example.com}
          */
       `,
@@ -381,6 +480,13 @@ export default {
       code: `
         /**
          * @param {SomeType} aName {@link https://example.com}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @param {SomeType} aName {@inheritDoc @scope-name/pkg-name#Member}
          */
       `,
     },


### PR DESCRIPTION
`escape-inline-tags` was reporting scoped npm package names inside declaration-reference inline tags, like `{@link @codemirror/state#StateField}`.
This allows scoped package references inside `link`, `linkcode`, `linkplain`, and `inheritDoc` inline tags while keeping bare `@scope` text and non-reference inline tag bodies reportable. I checked it with the focused rule tests passing 31 tests, generated docs check, changed-file ESLint, TypeScript, full Node 22 coverage at 3,132 passing with 100% coverage, build, and `git diff --check`.
Fixes #1695
