### PR TITLE
fix(`no-undefined-types`): check descendant scopes for variables

### DIFF
--- a/docs/rules/no-undefined-types.md
+++ b/docs/rules/no-undefined-types.md
@@ -1260,5 +1260,14 @@ declare global {
  * {@link foo}
  */
 export const bar = 1;
+
+/** {@link foo} */
+function a(foo: number) {}
+
+/** {@link foo} */
+const b = function (foo: number) {};
+
+/** {@link foo} */
+const b = (foo: number) => {};
 ````
 

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -246,6 +246,31 @@ export default iterateJsdoc(({
     const result = new Set();
 
     let scp = scope;
+
+    /**
+     * @param {import("eslint").Scope.Scope | null} sc
+     */
+    const getChildScopes = (sc) => {
+      if (sc) {
+        // We must check child scopes because when multiple nodes find
+        //   the same comment block, only one node is reported by our code,
+        //   and it can be the children which are not reported.
+        for (const childScope of sc.childScopes) {
+          for (const {
+            name,
+          } of childScope.variables) {
+            result.add(name);
+          }
+
+          for (const grandChildScope of childScope.childScopes) {
+            getChildScopes(grandChildScope);
+          }
+        }
+      }
+    };
+
+    getChildScopes(scp);
+
     while (scp) {
       for (const {
         name,

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -2166,5 +2166,32 @@ export default /** @type {import('../index.js').TestCases} */ ({
         parser: typescriptEslintParser,
       },
     },
+    {
+      code: `
+        /** {@link foo} */
+        function a(foo: number) {}
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+    },
+    {
+      code: `
+        /** {@link foo} */
+        const b = function (foo: number) {};
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+    },
+    {
+      code: `
+        /** {@link foo} */
+        const b = (foo: number) => {};
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+    },
   ],
 });


### PR DESCRIPTION
fix(`no-undefined-types`): check descendant scopes for variables; fixes #1704