### PR TITLE
fix(`no-undefined-types`): predefine Iterable/Iterator types

### DIFF
--- a/docs/rules/no-undefined-types.md
+++ b/docs/rules/no-undefined-types.md
@@ -1269,5 +1269,14 @@ const b = function (foo: number) {};
 
 /** {@link foo} */
 const b = (foo: number) => {};
+
+/**
+ * @param {...Iterable<any>} its
+ * @returns {IteratorObject<any>}
+ * @see https://developer.mozilla.org/Web/JavaScript/Reference/Global_Objects/Iterator/concat
+ */
+const concatIteratorJSDoc = (...its) => {
+    return Iterator.from(its.flat());
+};
 ````
 

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -28,7 +28,15 @@ const globalTypes = [
   'globalThis', 'global', 'window', 'self',
 ];
 
+const iterableIterator = [
+  'Iterable',
+  'Iterator',
+  'IteratorObject',
+];
+
 const typescriptGlobals = [
+  ...iterableIterator,
+
   // https://www.typescriptlang.org/docs/handbook/utility-types.html
   'Awaited',
   'Partial',

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -2193,5 +2193,17 @@ export default /** @type {import('../index.js').TestCases} */ ({
         parser: typescriptEslintParser,
       },
     },
+    {
+      code: `
+        /**
+         * @param {...Iterable<any>} its
+         * @returns {IteratorObject<any>}
+         * @see https://developer.mozilla.org/Web/JavaScript/Reference/Global_Objects/Iterator/concat
+         */
+        const concatIteratorJSDoc = (...its) => {
+            return Iterator.from(its.flat());
+        };
+      `,
+    },
   ],
 });


### PR DESCRIPTION
fix(`no-undefined-types`): predefine Iterable/Iterator types; fixes #1712