### PR TITLE
fix(check-template-names): detect template usage in @augments/@extends/@implements types

### DIFF
--- a/docs/rules/check-template-names.md
+++ b/docs/rules/check-template-names.md
@@ -417,5 +417,23 @@ export function createMessageChannel(messageType) {
 
   return messageChannel;
 }
+
+/**
+ * @template T
+ * @augments {Set<T>}
+ */
+export class MySet extends Set {}
+
+/**
+ * @template U
+ * @extends {Set<U>}
+ */
+export class MySet extends Set {}
+
+/**
+ * @template T
+ * @implements {Iterable<T>}
+ */
+export class MyIterable {}
 ````
 

--- a/src/rules/checkTemplateNames.js
+++ b/src/rules/checkTemplateNames.js
@@ -132,6 +132,16 @@ export default iterateJsdoc(({
       }
     }
 
+    // Template names may be used only within the heritage clause types of a
+    // class/interface, e.g. `@template T` used in `@augments {Base<T>}`.
+    for (const heritageTagName of [
+      'augments', 'extends', 'implements',
+    ]) {
+      for (const heritageTag of getTags(jsdoc, heritageTagName)) {
+        checkForUsedTypes(heritageTag.type);
+      }
+    }
+
     checkTemplateTags();
   };
 

--- a/test/rules/assertions/checkTemplateNames.js
+++ b/test/rules/assertions/checkTemplateNames.js
@@ -787,5 +787,32 @@ export default /** @type {import('../index.js').TestCases} */ ({
         }
       `,
     },
+    {
+      code: `
+        /**
+         * @template T
+         * @augments {Set<T>}
+         */
+        export class MySet extends Set {}
+      `,
+    },
+    {
+      code: `
+        /**
+         * @template U
+         * @extends {Set<U>}
+         */
+        export class MySet extends Set {}
+      `,
+    },
+    {
+      code: `
+        /**
+         * @template T
+         * @implements {Iterable<T>}
+         */
+        export class MyIterable {}
+      `,
+    },
   ],
 });


### PR DESCRIPTION
## Expected behavior

No error: a `@template` parameter used inside a class/interface heritage clause type (`@augments` / `@extends` / `@implements`) should count as "in use".

## Actual behavior

`@template T not in use` is reported when the template is referenced only in the heritage clause type, e.g. `@template T` used in `@augments {Base<T>}`.

## ESLint sample (eslint-plugin-jsdoc 63.0.7, eslint 9.39.x)

```js
/** @template T @augments {Set<T>} */
export class A extends Set {}        // ❌ "@template T not in use"

/** @template U @extends {Set<U>} */
export class B extends Set {}        // ❌ "@template U not in use"

/** @template V @param {V} value */
export function f(value) {}          // ✅ no error (param usage already detected)
```

Config: `{ rules: { 'jsdoc/check-template-names': 'error' } }`

## Cause

`checkParameters` collects used template names from `@param`/`@returns`, class-body members and typedef/property types (added in #1287, #1407, #1271), but never scans the `@augments`/`@extends`/`@implements` tag types of the documented class/interface itself. A template used only as a type argument to a base class (`@augments {Base<T>}`) therefore looks unused.

## Fix

Scan the `@augments`/`@extends`/`@implements` heritage clause types via the existing `checkForUsedTypes` helper, so type names referenced there (e.g. `T` in `Base<T>`) are registered as used. The change is purely additive: it can only add names to the used set, never produce a new "not in use" report.

Added three valid test cases (`@augments`, `@extends`, `@implements`); docs regenerated via `generateDocs`.

This pattern is common with generic base classes. Verified against a production codebase: 54 of 55 false positives resolved (the 1 remaining is an unrelated template-name parsing issue with bracketed defaults like `[T=Record<string, unknown>]`).
