### PR TITLE
fix(check-template-names): keep commas inside @template default type values

### DIFF
--- a/docs/rules/valid-types.md
+++ b/docs/rules/valid-types.md
@@ -409,7 +409,7 @@ parseArray = function(parser) {
     };
 };
 // Settings: {"jsdoc":{"mode":"closure"}}
-// Message: Syntax error in namepath: T<~
+// Message: Syntax error in namepath: T<~, R
 
 /**
  * @template T, R<~
@@ -1009,5 +1009,10 @@ const MY_BITMASK_CONSTANT = {
     BITMASK_VALUE_A: 1 << 4,
     BITMASK_VALUE_B: somePrivateVariableHere
 };
+
+/**
+ * @template [T=Record<string, unknown>]
+ */
+function quux () {}
 ````
 

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -1578,6 +1578,42 @@ const isInlineTag = (tag) => {
 */
 
 /**
+ * Splits a `@template` tag's names on commas that separate template entries,
+ * ignoring commas nested within a type expression so that default values such
+ * as `[T=Record<string, unknown>]` are not split apart.
+ *
+ * Only `<`, `(` and `{` are treated as nesting: a comma within them is part of
+ * a type (generic arguments, function params, object type). Square brackets are
+ * deliberately not counted, since `[...]` is the optional/default wrapper in
+ * which commas do separate entries, e.g. `[T=string, U=number]`.
+ * @param {string} str
+ * @returns {string[]}
+ */
+const splitTopLevelCommas = (str) => {
+  const parts = [];
+  let depth = 0;
+  let current = '';
+  for (const char of str) {
+    if (char === '<' || char === '{' || char === '(') {
+      depth++;
+    } else if (char === '>' || char === '}' || char === ')') {
+      depth = Math.max(0, depth - 1);
+    }
+
+    if (char === ',' && depth === 0) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  parts.push(current);
+
+  return parts;
+};
+
+/**
  * Parses GCC Generic/Template types
  * @see {@link https://github.com/google/closure-compiler/wiki/Generic-Types}
  * @see {@link https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#template}
@@ -1585,8 +1621,7 @@ const isInlineTag = (tag) => {
  * @returns {string[]}
  */
 const parseClosureTemplateTag = (tag) => {
-  return tag.name
-    .split(',')
+  return splitTopLevelCommas(tag.name)
     .map((type) => {
       return type.trim().replace(/^\[?(?<name>.*?)=.*$/v, '$<name>');
     });

--- a/src/rules/validTypes.js
+++ b/src/rules/validTypes.js
@@ -399,13 +399,7 @@ export default iterateJsdoc(({
 
     if (hasNamepathPosition) {
       if (mode !== 'jsdoc' && tag.tag === 'template') {
-        if (!tryParsePathIgnoreError(
-          // May be an issue with the commas of
-          //   `utils.parseClosureTemplateTag`, so first try a raw
-          //   value; we really need a proper parser instead, however.
-          tag.name.trim().replace(/^\[?(?<name>.*?)=.*$/v, '$<name>'),
-          mode,
-        )) {
+        if (!tryParsePathIgnoreError(tag.name.trim(), mode)) {
           for (const namepath of utils.parseClosureTemplateTag(tag)) {
             validNamepathParsing(namepath);
           }

--- a/test/jsdocUtils.js
+++ b/test/jsdocUtils.js
@@ -167,4 +167,55 @@ describe('jsdocUtils', () => {
       });
     });
   });
+  describe('parseClosureTemplateTag()', () => {
+    it('splits multiple template names on top-level commas', () => {
+      expect(jsdocUtils.parseClosureTemplateTag({
+        name: 'S, T',
+      })).to.deep.equal([
+        'S', 'T',
+      ]);
+    });
+    it('returns a single template name', () => {
+      expect(jsdocUtils.parseClosureTemplateTag({
+        name: 'T',
+      })).to.deep.equal([
+        'T',
+      ]);
+    });
+    it('splits multiple defaulted names within the optional wrapper', () => {
+      expect(jsdocUtils.parseClosureTemplateTag({
+        name: '[T=string, U=number]',
+      })).to.deep.equal([
+        'T', 'U',
+      ]);
+    });
+    it('keeps commas inside a generic-type default', () => {
+      expect(jsdocUtils.parseClosureTemplateTag({
+        name: '[T=Record<string, unknown>]',
+      })).to.deep.equal([
+        'T',
+      ]);
+    });
+    it('keeps commas inside an object-type default', () => {
+      expect(jsdocUtils.parseClosureTemplateTag({
+        name: '[T={a: string, b: number}]',
+      })).to.deep.equal([
+        'T',
+      ]);
+    });
+    it('keeps commas inside a function-type default', () => {
+      expect(jsdocUtils.parseClosureTemplateTag({
+        name: '[T=(a: string, b: number) => void]',
+      })).to.deep.equal([
+        'T',
+      ]);
+    });
+    it('does not let an unbalanced closer push depth below zero', () => {
+      expect(jsdocUtils.parseClosureTemplateTag({
+        name: 'A>, B',
+      })).to.deep.equal([
+        'A>', 'B',
+      ]);
+    });
+  });
 });

--- a/test/rules/assertions/validTypes.js
+++ b/test/rules/assertions/validTypes.js
@@ -738,7 +738,7 @@ export default /** @type {import('../index.js').TestCases} */ ({
       errors: [
         {
           line: 3,
-          message: 'Syntax error in namepath: T<~',
+          message: 'Syntax error in namepath: T<~, R',
         },
       ],
       settings: {
@@ -2077,6 +2077,14 @@ export default /** @type {import('../index.js').TestCases} */ ({
             BITMASK_VALUE_A: 1 << 4,
             BITMASK_VALUE_B: somePrivateVariableHere
         };
+      `,
+    },
+    {
+      code: `
+        /**
+         * @template [T=Record<string, unknown>]
+         */
+        function quux () {}
       `,
     },
   ],


### PR DESCRIPTION
## Expected behavior

A `@template` whose default value contains a comma inside a type expression, e.g. `@template [T=Record<string, unknown>]`, declares a single template named `T`.

## Actual behavior

`parseClosureTemplateTag` splits the tag on every comma, so the comma inside `Record<string, unknown>` is treated as a separator. This yields a bogus second "template name" (`unknown>]`), producing spurious reports such as `@template unknown>] not in use` (`check-template-names`) and namepath syntax errors (`valid-types`).

## ESLint sample (eslint-plugin-jsdoc 63.0.7)

```js
/** @template [T=Record<string, unknown>] */
function quux() {}
// check-template-names -> "@template unknown>] not in use"
// valid-types          -> "Syntax error in namepath: unknown>]"
```

## Cause

```js
const parseClosureTemplateTag = (tag) => {
  return tag.name
    .split(',')   // splits commas inside Record<string, unknown> too
    .map((type) => type.trim().replace(/^\[?(?<name>.*?)=.*$/v, '$<name>'));
};
```

The `,` split is meant to separate multiple template names (`@template S, T`), but it is applied to the raw string, breaking type expressions in default values.

## Fix

Split only on commas that are not nested within `<`, `(` or `{` (generic arguments, function params, object types). Square brackets are deliberately not counted, since `[...]` is the optional/default wrapper in which commas legitimately separate entries (`[T=string, U=number]` -> `T`, `U` as before).

Affects the three rules that consume `parseClosureTemplateTag`: `check-template-names`, `require-template`, `valid-types`.

Added a `valid-types` test for the `Record<string, unknown>` default; updated the one existing test on the intentionally-malformed input `@template T<~, R` (the reported namepath now includes the full unparseable segment, still flagged as a syntax error); docs regenerated.
