### PR TITLE
fix(escape-inline-tags): ignore Markdown code spans

### DIFF
--- a/docs/rules/escape-inline-tags.md
+++ b/docs/rules/escape-inline-tags.md
@@ -61,6 +61,26 @@ The following patterns are considered problems:
 
 ````ts
 /**
+ * @file Use @outside before `npm init @eslint/config`.
+ */
+// Message: Unexpected inline JSDoc tag. Did you mean to use {@outside}, \@outside, or `@outside`?
+
+/**
+ * @file Run `npm init @eslint/config` with @outside.
+ */
+// Message: Unexpected inline JSDoc tag. Did you mean to use {@outside}, \@outside, or `@outside`?
+
+/**
+ * @file Run `npm init @eslint/config without a closing backtick.
+ */
+// Message: Unexpected inline JSDoc tag. Did you mean to use {@eslint}, \@eslint, or `@eslint`?
+
+/**
+ * @file Literal \`npm init @eslint/config` text.
+ */
+// Message: Unexpected inline JSDoc tag. Did you mean to use {@eslint}, \@eslint, or `@eslint`?
+
+/**
  *
  * Whether to include a @yearly, @monthly etc text labels in the generated expression.
  */
@@ -171,6 +191,14 @@ The following patterns are considered problems:
 The following patterns are not considered problems:
 
 ````ts
+/**
+ * @file Main CLI that is run via the `npm init @eslint/config` command.
+ */
+
+/**
+ * @param value Run ``npm `init` @eslint/config``.
+ */
+
 /**
  * A description with an escaped \@tag.
  */

--- a/src/rules/escapeInlineTags.js
+++ b/src/rules/escapeInlineTags.js
@@ -41,6 +41,34 @@ export default iterateJsdoc(({
     'linkplain',
   ]);
 
+  const markdownCodeSpanRegex = /(?<!\\)(`+)(?!`)[\s\S]*?(?<!`)\1(?!`)/gv;
+
+  /**
+   * @param {string} desc
+   * @param {number} index
+   * @returns {boolean}
+   */
+  const isInsideMarkdownCodeSpan = (desc, index) => {
+    markdownCodeSpanRegex.lastIndex = 0;
+
+    let match;
+    while ((match = markdownCodeSpanRegex.exec(desc)) !== null) {
+      const delimiterLength = match[1].length;
+      const contentStart = match.index + delimiterLength;
+      const contentEnd = match.index + match[0].length - delimiterLength;
+
+      if (index < contentStart) {
+        return false;
+      }
+
+      if (index < contentEnd) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+
   /**
    * @param {string} desc
    * @param {number} atSignIndex
@@ -72,8 +100,9 @@ export default iterateJsdoc(({
     const atSignIndex = offset + match.lastIndexOf('@');
     const inlineTagName = getInlineTagName(desc, atSignIndex);
 
-    return declarationReferenceInlineTags.has(inlineTagName) &&
-      scopedPackageNameRegex.test(desc.slice(atSignIndex));
+    return isInsideMarkdownCodeSpan(desc, atSignIndex) ||
+      declarationReferenceInlineTags.has(inlineTagName) &&
+        scopedPackageNameRegex.test(desc.slice(atSignIndex));
   };
 
   /**

--- a/test/rules/assertions/escapeInlineTags.js
+++ b/test/rules/assertions/escapeInlineTags.js
@@ -3,6 +3,58 @@ export default {
     {
       code: `
         /**
+         * @file Use @outside before \`npm init @eslint/config\`.
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Unexpected inline JSDoc tag. Did you mean to use {@outside}, \\@outside, or `@outside`?',
+        },
+      ],
+    },
+    {
+      code: `
+        /**
+         * @file Run \`npm init @eslint/config\` with @outside.
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Unexpected inline JSDoc tag. Did you mean to use {@outside}, \\@outside, or `@outside`?',
+        },
+      ],
+    },
+    {
+      code: `
+        /**
+         * @file Run \`npm init @eslint/config without a closing backtick.
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Unexpected inline JSDoc tag. Did you mean to use {@eslint}, \\@eslint, or `@eslint`?',
+        },
+      ],
+    },
+    {
+      code: `
+        /**
+         * @file Literal \\\`npm init @eslint/config\` text.
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Unexpected inline JSDoc tag. Did you mean to use {@eslint}, \\@eslint, or `@eslint`?',
+        },
+      ],
+    },
+    {
+      code: `
+        /**
          *
          * Whether to include a @yearly, @monthly etc text labels in the generated expression.
          */
@@ -406,6 +458,20 @@ export default {
     },
   ],
   valid: [
+    {
+      code: `
+        /**
+         * @file Main CLI that is run via the \`npm init @eslint/config\` command.
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @param value Run \`\`npm \`init\` @eslint/config\`\`.
+         */
+      `,
+    },
     {
       code: `
         /**


### PR DESCRIPTION
Fixes #1723.

## Summary

- ignore apparent inline tags when the at-sign is inside a paired Markdown code span
- preserve reports for tags before or after a code span and for escaped or unclosed backticks
- add focused regression cases and regenerate the rule documentation

## Testing

- `pnpm run test-index --rule=escape-inline-tags` (38 passing)
- `pnpm test` (3,156 passing; 100% statements, branches, functions, and lines)
- `pnpm lint` (0 errors; 11 existing warnings in unchanged files)
- `pnpm build`
- `pnpm check-docs`
- full test suite also passed under Node.js 22.22.1
