### PR TITLE
feat: add normalize-see-links rule

### DIFF
--- a/.README/rules/normalize-see-links.md
+++ b/.README/rules/normalize-see-links.md
@@ -1,0 +1,23 @@
+# `normalize-see-links`
+
+Normalizes labeled links in `@see` tags to a canonical `{@link}` form.
+
+## Options
+
+{"gitdown": "options"}
+
+|||
+|---|---|
+|Context|everywhere|
+|Tags|`see`|
+|Recommended|false|
+|Settings||
+|Options|`canonicalForm`, `enableFixer`|
+
+## Failing examples
+
+<!-- assertions-failing normalizeSeeLinks -->
+
+## Passing examples
+
+<!-- assertions-passing normalizeSeeLinks -->

--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ non-default-recommended fixer).
 ||| [no-restricted-syntax](./docs/rules/no-restricted-syntax.md#readme) | Reports when certain comment structures are present. |
 |On in TS; Off in TS flavor|:wrench:| [no-types](./docs/rules/no-types.md#readme) | This rule reports types being used on `@param` or `@returns` (redundant with TypeScript). |
 |:heavy_check_mark: (Off in TS; Off in TS flavor)|| [no-undefined-types](./docs/rules/no-undefined-types.md#readme) | Besides some expected built-in types, prohibits any types not specified as globals or within `@typedef`. |
+||:wrench:| [normalize-see-links](./docs/rules/normalize-see-links.md#readme) | Normalizes labeled links in `@see` tags to a canonical `{@link}` form. |
 ||:wrench:| [prefer-import-tag](./docs/rules/prefer-import-tag.md#readme) | Prefer `@import` tags to inline `import()` statements. |
 |:heavy_check_mark:|| [reject-any-type](./docs/rules/reject-any-type.md#readme) | Reports use of `any` or `*` type |
 |:heavy_check_mark:|| [reject-function-type](./docs/rules/reject-function-type.md#readme) | Reports use of `Function` type |

--- a/docs/rules/normalize-see-links.md
+++ b/docs/rules/normalize-see-links.md
@@ -14,7 +14,7 @@ A single options object has the following properties.
 <a name="normalize-see-links-options-canonicalform"></a>
 ### <code>canonicalForm</code>
 
-The canonical `{<code>@link</code>}` form. Defaults to `"pipe"`.
+The canonical `{<code>@link</code>}` form: `"pipe"` produces `{<code>@link</code> url|label}`, while `"prefix"` produces `[label]{<code>@link</code> url}`. Defaults to `"pipe"`.
 
 <a name="user-content-normalize-see-links-options-enablefixer"></a>
 <a name="normalize-see-links-options-enablefixer"></a>
@@ -41,7 +41,7 @@ The following patterns are considered problems:
 /**
  * @see [Docs](https://api.example.com/v1?ids=1|2|3)
  */
-// Message: @see link cannot be safely normalized.
+// Message: Expected @see link to use the pipe form.
 
 /**
  * @see [See {options}](https://example.com/api)
@@ -57,15 +57,10 @@ The following patterns are considered problems:
  * @see [Foo](https://example.com/a|b)
  */
 // "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
-// Message: @see link cannot be safely normalized.
+// Message: Expected @see link to use the prefix form.
 
 /**
  * @see [ ](https://example.com)
- */
-// Message: @see link cannot be safely normalized.
-
-/**
- * @see {@link https://example.com|A|B}
  */
 // Message: @see link cannot be safely normalized.
 
@@ -84,6 +79,65 @@ The following patterns are considered problems:
  * @see [Foo](https://example.com/a}b)
  */
 // "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+// Message: Expected @see link to use the prefix form.
+
+/**
+ * @see [Foo](https://example.com/a{b)
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+// Message: Expected @see link to use the prefix form.
+
+/**
+ * @see [Braces](https://example.com/a{b}c)
+ */
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [Existing](https://example.com/%7C?x=1&y=2#frag)
+ */
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [Percent](https://example.com/100%)
+ */
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [A{B](https://example.com)
+ */
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [a}b](https://example.com)
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+// Message: Expected @see link to use the prefix form.
+
+/**
+ * @see {@link https://example.com|A|B}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+// Message: Expected @see link to use the prefix form.
+
+/**
+ * @see {@link https://example.com|A`B}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+// Message: Expected @see link to use the prefix form.
+
+/**
+ * @see [a\}b](https://example.com)
+ */
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see [See {{one} and {two}}](https://example.com)
+ */
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see [A}B|C](https://example.com)
+ */
 // Message: @see link cannot be safely normalized.
 
 /**
@@ -108,12 +162,12 @@ The following patterns are considered problems:
 // Message: Expected @see link to use the pipe form.
 
 /**
- * @see [Unsafe](https://example.com/a|b) and [Safe](https://example.com/safe)
+ * @see [Unsafe](https://example.com/a|b?x=1&y=2#frag) and [Safe](https://example.com/safe)
  */
-// Message: @see link cannot be safely normalized.
+// Message: Expected @see link to use the pipe form.
 
 /**
- * @see [JSDoc Markdown](https://example.com/jsdoc-markdown)
+ * @see [JSDoc Markdown](https://example.com/jsdoc|markdown)
  */
 // Settings: {"jsdoc":{"mode":"jsdoc"}}
 // Message: Expected @see link to use the pipe form.
@@ -194,7 +248,7 @@ The following patterns are considered problems:
 // Message: Expected @see link to use the pipe form.
 
 /**
- * @see [TypeScript](https://example.com/typescript)
+ * @see [TypeScript](https://example.com/type{script})
  */
 const value: string = 'value';
 // Message: Expected @see link to use the pipe form.
@@ -215,6 +269,64 @@ The following patterns are not considered problems:
 
 ````ts
 /**
+ * @see {@link https://api.example.com/v1?ids=1%7C2%7C3|Docs}
+ */
+
+/**
+ * @see [Foo]{@link https://example.com/a%7Cb}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+
+/**
+ * @see [Foo]{@link https://example.com/a%7Db}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+
+/**
+ * @see [Foo]{@link https://example.com/a%7Bb}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+
+/**
+ * @see {@link https://example.com/a%7Bb%7Dc|Braces}
+ */
+
+/**
+ * @see {@link https://example.com/%7C?x=1&y=2#frag|Existing}
+ */
+
+/**
+ * @see {@link https://example.com/100%25|Percent}
+ */
+
+/**
+ * @see {@link https://example.com|A{B}
+ */
+
+/**
+ * @see [a}b]{@link https://example.com}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+
+/**
+ * @see {@link https://example.com|A|B}
+ */
+
+/**
+ * @see [A|B]{@link https://example.com}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+
+/**
+ * @see [A`B]{@link https://example.com}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+
+/**
+ * @see {@link https://example.com/a%7Cb?x=1&y=2#frag|Unsafe} and {@link https://example.com/safe|Safe}
+ */
+
+/**
  * @see {@link https://example.com/read|Read the guide}
  */
 
@@ -232,7 +344,7 @@ The following patterns are not considered problems:
  */
 
 /**
- * @see {@link https://example.com/jsdoc-markdown|JSDoc Markdown}
+ * @see {@link https://example.com/jsdoc%7Cmarkdown|JSDoc Markdown}
  */
 // Settings: {"jsdoc":{"mode":"jsdoc"}}
 
@@ -265,7 +377,7 @@ The following patterns are not considered problems:
 // Settings: {"jsdoc":{"mode":"jsdoc"}}
 
 /**
- * @see {@link https://example.com/typescript|TypeScript}
+ * @see {@link https://example.com/type%7Bscript%7D|TypeScript}
  */
 const value: string = 'value';
 

--- a/docs/rules/normalize-see-links.md
+++ b/docs/rules/normalize-see-links.md
@@ -1,0 +1,308 @@
+<a name="user-content-normalize-see-links"></a>
+<a name="normalize-see-links"></a>
+# <code>normalize-see-links</code>
+
+Normalizes labeled links in `@see` tags to a canonical `{@link}` form.
+
+<a name="user-content-normalize-see-links-options"></a>
+<a name="normalize-see-links-options"></a>
+## Options
+
+A single options object has the following properties.
+
+<a name="user-content-normalize-see-links-options-canonicalform"></a>
+<a name="normalize-see-links-options-canonicalform"></a>
+### <code>canonicalForm</code>
+
+The canonical `{<code>@link</code>}` form. Defaults to `"pipe"`.
+
+<a name="user-content-normalize-see-links-options-enablefixer"></a>
+<a name="normalize-see-links-options-enablefixer"></a>
+### <code>enableFixer</code>
+
+Whether to enable the fixer. Defaults to `true`.
+
+
+|||
+|---|---|
+|Context|everywhere|
+|Tags|`see`|
+|Recommended|false|
+|Settings||
+|Options|`canonicalForm`, `enableFixer`|
+
+<a name="user-content-normalize-see-links-failing-examples"></a>
+<a name="normalize-see-links-failing-examples"></a>
+## Failing examples
+
+The following patterns are considered problems:
+
+````ts
+/**
+ * @see [Docs](https://api.example.com/v1?ids=1|2|3)
+ */
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see [See {options}](https://example.com/api)
+ */
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see [a}b](https://example.com)
+ */
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see [Foo](https://example.com/a|b)
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see [ ](https://example.com)
+ */
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see {@link https://example.com|A|B}
+ */
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see {@link https://example.com|A]B}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see [ ]{@link https://example.com}
+ */
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see [Foo](https://example.com/a}b)
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see [Read the guide](https://example.com/read)
+ */
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [Browse the API]{@link https://example.com/api}
+ */
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [A](https://a.com) and [B](https://b.com)
+ */
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [A](https://a.com)
+ * @see [B](https://b.com)
+ */
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [Unsafe](https://example.com/a|b) and [Safe](https://example.com/safe)
+ */
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see [JSDoc Markdown](https://example.com/jsdoc-markdown)
+ */
+// Settings: {"jsdoc":{"mode":"jsdoc"}}
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [Package](@scope/pkg)
+ */
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see [First](https://example.com/first)
+ *   and [Second](https://example.com/second)
+ */
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [Example](https://example.com)
+ */
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [Guide]{@link https://example.com/guide}
+ */
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [API](https://example.com/api)
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+// Message: Expected @see link to use the prefix form.
+
+/**
+ * @see {@link https://example.com/reference|Reference}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+// Message: Expected @see link to use the prefix form.
+
+/**
+ * @see [No fix](https://example.com/no-fix)
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"enableFixer":false}]
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [Incomplete](https://example.com/incomplete
+ */
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see [Incomplete]{@link}
+ */
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see {@link https://example.com|}
+ */
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see `[Code](https://example.com/code)`
+ */
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see [Package]{@link @scope/pkg}
+ */
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see {@link https://example.com Space label}
+ */
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see [JSDoc]{@link https://example.com/jsdoc}
+ */
+// Settings: {"jsdoc":{"mode":"jsdoc"}}
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [TypeScript](https://example.com/typescript)
+ */
+const value: string = 'value';
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [Complex](https://example.com/a_(b))
+ */
+// Message: @see link cannot be safely normalized.
+````
+
+
+
+<a name="user-content-normalize-see-links-passing-examples"></a>
+<a name="normalize-see-links-passing-examples"></a>
+## Passing examples
+
+The following patterns are not considered problems:
+
+````ts
+/**
+ * @see {@link https://example.com/read|Read the guide}
+ */
+
+/**
+ * @see {@link https://example.com/api|Browse the API}
+ */
+
+/**
+ * @see {@link https://a.com|A} and {@link https://b.com|B}
+ */
+
+/**
+ * @see {@link https://a.com|A}
+ * @see {@link https://b.com|B}
+ */
+
+/**
+ * @see {@link https://example.com/jsdoc-markdown|JSDoc Markdown}
+ */
+// Settings: {"jsdoc":{"mode":"jsdoc"}}
+
+/**
+ * @see {@link https://example.com/first|First}
+ *   and {@link https://example.com/second|Second}
+ */
+
+/**
+ * @see {@link https://example.com|Example}
+ */
+
+/**
+ * @see {@link https://example.com/guide|Guide}
+ */
+
+/**
+ * @see [API]{@link https://example.com/api}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+
+/**
+ * @see [Reference]{@link https://example.com/reference}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+
+/**
+ * @see {@link https://example.com/jsdoc|JSDoc}
+ */
+// Settings: {"jsdoc":{"mode":"jsdoc"}}
+
+/**
+ * @see {@link https://example.com/typescript|TypeScript}
+ */
+const value: string = 'value';
+
+/**
+ * @see https://example.com
+ */
+
+/**
+ * @see MyClass#method
+ */
+
+/**
+ * @see some text
+ */
+
+/**
+ * @see {@link https://example.com}
+ */
+
+/**
+ * @see {@link @scope/pkg|Package}
+ */
+
+/**
+ * @see @scope/pkg
+ */
+
+/**
+ * @returns [Example](https://example.com)
+ */
+
+/**
+ * @see {@code foo|bar}
+ */
+
+/**
+ * @see \[Escaped](https://example.com)
+ */
+````
+

--- a/src/index-cjs.js
+++ b/src/index-cjs.js
@@ -36,6 +36,7 @@ import noDefaults from './rules/noDefaults.js';
 import noMissingSyntax from './rules/noMissingSyntax.js';
 import noMultiAsterisks from './rules/noMultiAsterisks.js';
 import noRestrictedSyntax from './rules/noRestrictedSyntax.js';
+import normalizeSeeLinks from './rules/normalizeSeeLinks.js';
 import noTypes from './rules/noTypes.js';
 import noUndefinedTypes from './rules/noUndefinedTypes.js';
 import preferImportTag from './rules/preferImportTag.js';
@@ -128,6 +129,7 @@ index.rules = {
   'no-restricted-syntax': noRestrictedSyntax,
   'no-types': noTypes,
   'no-undefined-types': noUndefinedTypes,
+  'normalize-see-links': normalizeSeeLinks,
   'prefer-import-tag': preferImportTag,
   'reject-any-type': buildRejectOrPreferRuleDefinition({
     description: 'Reports use of `any` or `*` type',
@@ -318,6 +320,7 @@ const createRecommendedRuleset = (warnOrError, flatName) => {
       'jsdoc/no-restricted-syntax': 'off',
       'jsdoc/no-types': 'off',
       'jsdoc/no-undefined-types': warnOrError,
+      'jsdoc/normalize-see-links': 'off',
       'jsdoc/prefer-import-tag': 'off',
       'jsdoc/reject-any-type': warnOrError,
       'jsdoc/reject-function-type': warnOrError,

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ import noDefaults from './rules/noDefaults.js';
 import noMissingSyntax from './rules/noMissingSyntax.js';
 import noMultiAsterisks from './rules/noMultiAsterisks.js';
 import noRestrictedSyntax from './rules/noRestrictedSyntax.js';
+import normalizeSeeLinks from './rules/normalizeSeeLinks.js';
 import noTypes from './rules/noTypes.js';
 import noUndefinedTypes from './rules/noUndefinedTypes.js';
 import preferImportTag from './rules/preferImportTag.js';
@@ -134,6 +135,7 @@ index.rules = {
   'no-restricted-syntax': noRestrictedSyntax,
   'no-types': noTypes,
   'no-undefined-types': noUndefinedTypes,
+  'normalize-see-links': normalizeSeeLinks,
   'prefer-import-tag': preferImportTag,
   'reject-any-type': buildRejectOrPreferRuleDefinition({
     description: 'Reports use of `any` or `*` type',
@@ -324,6 +326,7 @@ const createRecommendedRuleset = (warnOrError, flatName) => {
       'jsdoc/no-restricted-syntax': 'off',
       'jsdoc/no-types': 'off',
       'jsdoc/no-undefined-types': warnOrError,
+      'jsdoc/normalize-see-links': 'off',
       'jsdoc/prefer-import-tag': 'off',
       'jsdoc/reject-any-type': warnOrError,
       'jsdoc/reject-function-type': warnOrError,

--- a/src/rules.d.ts
+++ b/src/rules.d.ts
@@ -1292,6 +1292,22 @@ export interface Rules {
         }
       ];
 
+  /** Normalizes labeled links in `@see` tags to a canonical `{@link}` form. */
+  "jsdoc/normalize-see-links": 
+    | []
+    | [
+        {
+          /**
+           * The canonical `{@link}` form. Defaults to `"pipe"`.
+           */
+          canonicalForm?: "pipe" | "prefix";
+          /**
+           * Whether to enable the fixer. Defaults to `true`.
+           */
+          enableFixer?: boolean;
+        }
+      ];
+
   /** Prefer `@import` tags to inline `import()` statements. */
   "jsdoc/prefer-import-tag": 
     | []

--- a/src/rules.d.ts
+++ b/src/rules.d.ts
@@ -1298,7 +1298,7 @@ export interface Rules {
     | [
         {
           /**
-           * The canonical `{@link}` form. Defaults to `"pipe"`.
+           * The canonical `{@link}` form: `"pipe"` produces `{@link url|label}`, while `"prefix"` produces `[label]{@link url}`. Defaults to `"pipe"`.
            */
           canonicalForm?: "pipe" | "prefix";
           /**

--- a/src/rules/normalizeSeeLinks.js
+++ b/src/rules/normalizeSeeLinks.js
@@ -1,0 +1,275 @@
+import iterateJsdoc from '../iterateJsdoc.js';
+
+const markdownLinkRegex = /(?<!\\)\[([^`\]\r\n]+)\]\(([^`\(\)\s]+)\)/gv;
+const prefixLinkRegex = /(?<!\\)\[([^`\]\r\n]+)\]\{@link\s+([^\}\s\|]+)\}/gv;
+const pipeLinkRegex = /\{@link\s+([^\}\s\|]+)\s*\|\s*([^\}\r\n]+)\}/gv;
+
+const markdownLinkAttemptRegex = /(?<!\\)\[[^\]\r\n]*\]\([^\r\n]*(?:\)|$)/v;
+const prefixLinkAttemptRegex = /(?<!\\)\[[^\]\r\n]*\]\{@link[^\}\r\n]*(?:\}|$)/v;
+const pipeLinkAttemptRegex = /\{@link[^\}\r\n]*\|[^\}\r\n]*(?:\}|$)/v;
+
+const scopedPackageNameRegex = /^@[\w.\-]+\/[\w.\-]+/v;
+const markdownCodeSpanRegex = /(?<!\\)(`+)(?!`)[\s\S]*?(?<!`)\1(?!`)/gv;
+
+/**
+ * @param {'pipe'|'prefix'} canonicalForm
+ * @param {string} label
+ * @param {string} target
+ * @returns {boolean}
+ */
+const cannotSafelyFormatLink = (canonicalForm, label, target) => {
+  if (!label.trim()) {
+    return true;
+  }
+
+  if (canonicalForm === 'pipe') {
+    return target.includes('|') || /[\}\|]/v.test(label);
+  }
+
+  return label.includes(']') || /[\}\|]/v.test(target);
+};
+
+/**
+ * @param {string} description
+ * @param {number} index
+ * @returns {boolean}
+ */
+const isInsideMarkdownCodeSpan = (description, index) => {
+  for (const match of description.matchAll(markdownCodeSpanRegex)) {
+    const delimiterLength = match[1].length;
+    const contentStart = match.index + delimiterLength;
+    const contentEnd = match.index + match[0].length - delimiterLength;
+
+    if (index >= contentStart && index < contentEnd) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+/**
+ * @param {'pipe'|'prefix'} canonicalForm
+ * @param {string} label
+ * @param {string} target
+ * @returns {string}
+ */
+const formatLink = (canonicalForm, label, target) => {
+  return canonicalForm === 'pipe' ?
+    `{@link ${target}|${label.trim()}}` :
+    `[${label.trim()}]{@link ${target}}`;
+};
+
+/**
+ * @param {string} description
+ * @param {'pipe'|'prefix'} canonicalForm
+ * @returns {string}
+ */
+const normalizeDescription = (description, canonicalForm) => {
+  const markdownNormalized = description.replaceAll(
+    new RegExp(markdownLinkRegex, 'gv'),
+    (_match, label, target) => {
+      return formatLink(canonicalForm, label, target);
+    },
+  );
+
+  if (canonicalForm === 'pipe') {
+    return markdownNormalized.replaceAll(
+      new RegExp(prefixLinkRegex, 'gv'),
+      (_match, label, target) => {
+        return formatLink(canonicalForm, label, target);
+      },
+    );
+  }
+
+  return markdownNormalized.replaceAll(
+    new RegExp(pipeLinkRegex, 'gv'),
+    (_match, target, label) => {
+      return formatLink(canonicalForm, label, target);
+    },
+  );
+};
+
+export default iterateJsdoc(({
+  context,
+  jsdoc,
+  utils,
+}) => {
+  const {
+    canonicalForm = 'pipe',
+    enableFixer = true,
+  } = context.options[0] || {};
+
+  const descriptionMatcher = canonicalForm === 'pipe' ?
+    new RegExp(`${markdownLinkRegex.source}|${prefixLinkRegex.source}`, 'v') :
+    new RegExp(`${markdownLinkRegex.source}|${pipeLinkRegex.source}`, 'v');
+
+  /** @type {import('comment-parser').Spec[]} */
+  const fixableTags = [];
+
+  for (const tag of jsdoc.tags) {
+    if (tag.tag !== 'see') {
+      continue;
+    }
+
+    const firstTokens = tag.source[0].tokens;
+    const tagDescription = String(utils.getTagDescription(tag));
+    const rawDescription = firstTokens.name ?
+      firstTokens.name + firstTokens.postName + tagDescription :
+      tagDescription;
+
+    let hasAmbiguousLink = false;
+    let hasNoncanonicalLink = false;
+
+    for (const match of rawDescription.matchAll(markdownLinkRegex)) {
+      const label = match[1];
+      const target = match[2];
+
+      if (
+        isInsideMarkdownCodeSpan(rawDescription, match.index) ||
+        scopedPackageNameRegex.test(target) ||
+        cannotSafelyFormatLink(canonicalForm, label, target)
+      ) {
+        hasAmbiguousLink = true;
+      } else {
+        hasNoncanonicalLink = true;
+      }
+    }
+
+    for (const inlineTag of tag.inlineTags) {
+      if (inlineTag.tag !== 'link' || !inlineTag.text) {
+        continue;
+      }
+
+      if (inlineTag.format === 'space') {
+        hasAmbiguousLink = true;
+        continue;
+      }
+
+      if (cannotSafelyFormatLink(
+        canonicalForm,
+        inlineTag.text,
+        inlineTag.namepathOrURL,
+      )) {
+        hasAmbiguousLink = true;
+        continue;
+      }
+
+      if (inlineTag.format === canonicalForm) {
+        continue;
+      }
+
+      const {
+        start,
+      } = /** @type {typeof inlineTag & {start: number}} */ (inlineTag);
+
+      if (
+        isInsideMarkdownCodeSpan(rawDescription, start) ||
+        scopedPackageNameRegex.test(inlineTag.namepathOrURL)
+      ) {
+        hasAmbiguousLink = true;
+      } else {
+        hasNoncanonicalLink = true;
+      }
+    }
+
+    const unrecognizedLinkText = rawDescription
+      .replaceAll(new RegExp(markdownLinkRegex, 'gv'), '')
+      .replaceAll(new RegExp(prefixLinkRegex, 'gv'), '')
+      .replaceAll(new RegExp(pipeLinkRegex, 'gv'), '');
+
+    hasAmbiguousLink ||= markdownLinkAttemptRegex.test(unrecognizedLinkText) ||
+      prefixLinkAttemptRegex.test(unrecognizedLinkText) ||
+      pipeLinkAttemptRegex.test(unrecognizedLinkText);
+
+    if (hasAmbiguousLink) {
+      utils.reportJSDoc('@see link cannot be safely normalized.', {
+        line: tag.source[0].number,
+      }, null);
+      continue;
+    }
+
+    if (!hasNoncanonicalLink) {
+      continue;
+    }
+
+    fixableTags.push(tag);
+  }
+
+  for (const [
+    reportIdx,
+    tag,
+  ] of fixableTags.entries()) {
+    utils.reportJSDoc(
+      `Expected @see link to use the ${canonicalForm} form.`,
+      {
+        line: tag.source[0].number,
+      },
+      enableFixer && reportIdx === 0 ?
+        () => {
+          for (const fixableTag of fixableTags) {
+            const firstTokens = fixableTag.source[0].tokens;
+
+            if (firstTokens.name) {
+              firstTokens.description = firstTokens.name +
+                firstTokens.postName + firstTokens.description;
+              firstTokens.name = '';
+              firstTokens.postName = '';
+            }
+
+            for (
+              let sourceIdx = 0;
+              sourceIdx < fixableTag.source.length;
+              sourceIdx++
+            ) {
+              if (!descriptionMatcher.test(
+                fixableTag.source[sourceIdx].tokens.description,
+              )) {
+                continue;
+              }
+
+              utils.setTagDescription(
+                fixableTag,
+                descriptionMatcher,
+                (description) => {
+                  return normalizeDescription(description, canonicalForm);
+                },
+              );
+            }
+          }
+        } :
+        null,
+      true,
+    );
+  }
+}, {
+  iterateAllJsdocs: true,
+  meta: {
+    docs: {
+      description: 'Normalizes labeled links in `@see` tags to a canonical `{@link}` form.',
+      url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/normalize-see-links.md#repos-sticky-header',
+    },
+    fixable: 'code',
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          canonicalForm: {
+            description: 'The canonical `{@link}` form. Defaults to `"pipe"`.',
+            enum: [
+              'pipe',
+              'prefix',
+            ],
+            type: 'string',
+          },
+          enableFixer: {
+            description: 'Whether to enable the fixer. Defaults to `true`.',
+            type: 'boolean',
+          },
+        },
+        type: 'object',
+      },
+    ],
+    type: 'suggestion',
+  },
+});

--- a/src/rules/normalizeSeeLinks.js
+++ b/src/rules/normalizeSeeLinks.js
@@ -1,7 +1,7 @@
 import iterateJsdoc from '../iterateJsdoc.js';
 
 const markdownLinkRegex = /(?<!\\)\[([^`\]\r\n]+)\]\(([^`\(\)\s]+)\)/gv;
-const prefixLinkRegex = /(?<!\\)\[([^`\]\r\n]+)\]\{@link\s+([^\}\s\|]+)\}/gv;
+const prefixLinkRegex = /(?<!\\)\[([^\]\r\n]+)\]\{@link\s+([^\}\s\|]+)\}/gv;
 const pipeLinkRegex = /\{@link\s+([^\}\s\|]+)\s*\|\s*([^\}\r\n]+)\}/gv;
 
 const markdownLinkAttemptRegex = /(?<!\\)\[[^\]\r\n]*\]\([^\r\n]*(?:\)|$)/v;
@@ -14,19 +14,26 @@ const markdownCodeSpanRegex = /(?<!\\)(`+)(?!`)[\s\S]*?(?<!`)\1(?!`)/gv;
 /**
  * @param {'pipe'|'prefix'} canonicalForm
  * @param {string} label
- * @param {string} target
  * @returns {boolean}
  */
-const cannotSafelyFormatLink = (canonicalForm, label, target) => {
+const cannotSafelyFormatLink = (canonicalForm, label) => {
   if (!label.trim()) {
     return true;
   }
 
   if (canonicalForm === 'pipe') {
-    return target.includes('|') || /[\}\|]/v.test(label);
+    return label.includes('}');
   }
 
-  return label.includes(']') || /[\}\|]/v.test(target);
+  return label.includes(']');
+};
+
+/**
+ * @param {string} target
+ * @returns {string}
+ */
+const encodeLinkTarget = (target) => {
+  return encodeURI(target).replaceAll(/%25(?=[\dA-F]{2})/giv, '%');
 };
 
 /**
@@ -55,9 +62,11 @@ const isInsideMarkdownCodeSpan = (description, index) => {
  * @returns {string}
  */
 const formatLink = (canonicalForm, label, target) => {
+  const encodedTarget = encodeLinkTarget(target);
+
   return canonicalForm === 'pipe' ?
-    `{@link ${target}|${label.trim()}}` :
-    `[${label.trim()}]{@link ${target}}`;
+    `{@link ${encodedTarget}|${label.trim()}}` :
+    `[${label.trim()}]{@link ${encodedTarget}}`;
 };
 
 /**
@@ -128,7 +137,7 @@ export default iterateJsdoc(({
       if (
         isInsideMarkdownCodeSpan(rawDescription, match.index) ||
         scopedPackageNameRegex.test(target) ||
-        cannotSafelyFormatLink(canonicalForm, label, target)
+        cannotSafelyFormatLink(canonicalForm, label)
       ) {
         hasAmbiguousLink = true;
       } else {
@@ -149,7 +158,6 @@ export default iterateJsdoc(({
       if (cannotSafelyFormatLink(
         canonicalForm,
         inlineTag.text,
-        inlineTag.namepathOrURL,
       )) {
         hasAmbiguousLink = true;
         continue;
@@ -255,7 +263,7 @@ export default iterateJsdoc(({
         additionalProperties: false,
         properties: {
           canonicalForm: {
-            description: 'The canonical `{@link}` form. Defaults to `"pipe"`.',
+            description: 'The canonical `{@link}` form: `"pipe"` produces `{@link url|label}`, while `"prefix"` produces `[label]{@link url}`. Defaults to `"pipe"`.',
             enum: [
               'pipe',
               'prefix',

--- a/test/rules/assertions/normalizeSeeLinks.js
+++ b/test/rules/assertions/normalizeSeeLinks.js
@@ -13,11 +13,16 @@ export default {
       errors: [
         {
           line: 3,
-          message: '@see link cannot be safely normalized.',
+          message: 'Expected @see link to use the pipe form.',
         },
       ],
-      output: null,
+      output: `
+        /**
+         * @see {@link https://api.example.com/v1?ids=1%7C2%7C3|Docs}
+         */
+      `,
     },
+    // `\}` truncates pipe-label text in @es-joy/jsdoccomment.
     {
       code: `
         /**
@@ -32,6 +37,7 @@ export default {
       ],
       output: null,
     },
+    // `\}` truncates pipe-label text in @es-joy/jsdoccomment.
     {
       code: `
         /**
@@ -55,7 +61,7 @@ export default {
       errors: [
         {
           line: 3,
-          message: '@see link cannot be safely normalized.',
+          message: 'Expected @see link to use the prefix form.',
         },
       ],
       options: [
@@ -63,8 +69,13 @@ export default {
           canonicalForm: 'prefix',
         },
       ],
-      output: null,
+      output: `
+        /**
+         * @see [Foo]{@link https://example.com/a%7Cb}
+         */
+      `,
     },
+    // A blank label has no intended text the fixer can preserve.
     {
       code: `
         /**
@@ -79,20 +90,7 @@ export default {
       ],
       output: null,
     },
-    {
-      code: `
-        /**
-         * @see {@link https://example.com|A|B}
-         */
-      `,
-      errors: [
-        {
-          line: 3,
-          message: '@see link cannot be safely normalized.',
-        },
-      ],
-      output: null,
-    },
+    // `\]` prevents prefix-form parsing in @es-joy/jsdoccomment.
     {
       code: `
         /**
@@ -112,6 +110,7 @@ export default {
       ],
       output: null,
     },
+    // A blank label has no intended text the fixer can preserve.
     {
       code: `
         /**
@@ -135,12 +134,225 @@ export default {
       errors: [
         {
           line: 3,
-          message: '@see link cannot be safely normalized.',
+          message: 'Expected @see link to use the prefix form.',
         },
       ],
       options: [
         {
           canonicalForm: 'prefix',
+        },
+      ],
+      output: `
+        /**
+         * @see [Foo]{@link https://example.com/a%7Db}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [Foo](https://example.com/a{b)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the prefix form.',
+        },
+      ],
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+      output: `
+        /**
+         * @see [Foo]{@link https://example.com/a%7Bb}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [Braces](https://example.com/a{b}c)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://example.com/a%7Bb%7Dc|Braces}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [Existing](https://example.com/%7C?x=1&y=2#frag)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://example.com/%7C?x=1&y=2#frag|Existing}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [Percent](https://example.com/100%)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://example.com/100%25|Percent}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [A{B](https://example.com)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://example.com|A{B}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [a}b](https://example.com)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the prefix form.',
+        },
+      ],
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+      output: `
+        /**
+         * @see [a}b]{@link https://example.com}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com|A|B}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the prefix form.',
+        },
+      ],
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+      output: `
+        /**
+         * @see [A|B]{@link https://example.com}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com|A\`B}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the prefix form.',
+        },
+      ],
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+      output: `
+        /**
+         * @see [A\`B]{@link https://example.com}
+         */
+      `,
+    },
+    // An existing `\}` still truncates pipe-label text in the parser.
+    {
+      code: `
+        /**
+         * @see [a\\}b](https://example.com)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      output: null,
+    },
+    // Nested and repeated braces still contain an unparseable pipe-label `}`.
+    {
+      code: `
+        /**
+         * @see [See {{one} and {two}}](https://example.com)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      output: null,
+    },
+    // The extra pipe is safe, but the closing brace still truncates the label.
+    {
+      code: `
+        /**
+         * @see [A}B|C](https://example.com)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
         },
       ],
       output: null,
@@ -226,21 +438,7 @@ export default {
     {
       code: `
         /**
-         * @see [Unsafe](https://example.com/a|b) and [Safe](https://example.com/safe)
-         */
-      `,
-      errors: [
-        {
-          line: 3,
-          message: '@see link cannot be safely normalized.',
-        },
-      ],
-      output: null,
-    },
-    {
-      code: `
-        /**
-         * @see [JSDoc Markdown](https://example.com/jsdoc-markdown)
+         * @see [Unsafe](https://example.com/a|b?x=1&y=2#frag) and [Safe](https://example.com/safe)
          */
       `,
       errors: [
@@ -251,7 +449,25 @@ export default {
       ],
       output: `
         /**
-         * @see {@link https://example.com/jsdoc-markdown|JSDoc Markdown}
+         * @see {@link https://example.com/a%7Cb?x=1&y=2#frag|Unsafe} and {@link https://example.com/safe|Safe}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [JSDoc Markdown](https://example.com/jsdoc|markdown)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://example.com/jsdoc%7Cmarkdown|JSDoc Markdown}
          */
       `,
       settings: {
@@ -505,7 +721,7 @@ export default {
     {
       code: `
         /**
-         * @see [TypeScript](https://example.com/typescript)
+         * @see [TypeScript](https://example.com/type{script})
          */
         const value: string = 'value';
       `,
@@ -520,7 +736,7 @@ export default {
       },
       output: `
         /**
-         * @see {@link https://example.com/typescript|TypeScript}
+         * @see {@link https://example.com/type%7Bscript%7D|TypeScript}
          */
         const value: string = 'value';
       `,
@@ -541,6 +757,127 @@ export default {
     },
   ],
   valid: [
+    {
+      code: `
+        /**
+         * @see {@link https://api.example.com/v1?ids=1%7C2%7C3|Docs}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [Foo]{@link https://example.com/a%7Cb}
+         */
+      `,
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+    },
+    {
+      code: `
+        /**
+         * @see [Foo]{@link https://example.com/a%7Db}
+         */
+      `,
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+    },
+    {
+      code: `
+        /**
+         * @see [Foo]{@link https://example.com/a%7Bb}
+         */
+      `,
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com/a%7Bb%7Dc|Braces}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com/%7C?x=1&y=2#frag|Existing}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com/100%25|Percent}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com|A{B}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [a}b]{@link https://example.com}
+         */
+      `,
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com|A|B}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [A|B]{@link https://example.com}
+         */
+      `,
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+    },
+    {
+      code: `
+        /**
+         * @see [A\`B]{@link https://example.com}
+         */
+      `,
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com/a%7Cb?x=1&y=2#frag|Unsafe} and {@link https://example.com/safe|Safe}
+         */
+      `,
+    },
     {
       code: `
         /**
@@ -573,7 +910,7 @@ export default {
     {
       code: `
         /**
-         * @see {@link https://example.com/jsdoc-markdown|JSDoc Markdown}
+         * @see {@link https://example.com/jsdoc%7Cmarkdown|JSDoc Markdown}
          */
       `,
       settings: {
@@ -643,7 +980,7 @@ export default {
     {
       code: `
         /**
-         * @see {@link https://example.com/typescript|TypeScript}
+         * @see {@link https://example.com/type%7Bscript%7D|TypeScript}
          */
         const value: string = 'value';
       `,

--- a/test/rules/assertions/normalizeSeeLinks.js
+++ b/test/rules/assertions/normalizeSeeLinks.js
@@ -1,0 +1,718 @@
+import {
+  parser as typescriptEslintParser,
+} from 'typescript-eslint';
+
+export default {
+  invalid: [
+    {
+      code: `
+        /**
+         * @see [Docs](https://api.example.com/v1?ids=1|2|3)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+        /**
+         * @see [See {options}](https://example.com/api)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+        /**
+         * @see [a}b](https://example.com)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+        /**
+         * @see [Foo](https://example.com/a|b)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+        /**
+         * @see [ ](https://example.com)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com|A|B}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com|A]B}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+        /**
+         * @see [ ]{@link https://example.com}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+        /**
+         * @see [Foo](https://example.com/a}b)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+        /**
+         * @see [Read the guide](https://example.com/read)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://example.com/read|Read the guide}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [Browse the API]{@link https://example.com/api}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://example.com/api|Browse the API}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [A](https://a.com) and [B](https://b.com)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://a.com|A} and {@link https://b.com|B}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [A](https://a.com)
+         * @see [B](https://b.com)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+        {
+          line: 4,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://a.com|A}
+         * @see {@link https://b.com|B}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [Unsafe](https://example.com/a|b) and [Safe](https://example.com/safe)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+        /**
+         * @see [JSDoc Markdown](https://example.com/jsdoc-markdown)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://example.com/jsdoc-markdown|JSDoc Markdown}
+         */
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'jsdoc',
+        },
+      },
+    },
+    {
+      code: `
+        /**
+         * @see [Package](@scope/pkg)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+        /**
+         * @see [First](https://example.com/first)
+         *   and [Second](https://example.com/second)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://example.com/first|First}
+         *   and {@link https://example.com/second|Second}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [Example](https://example.com)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://example.com|Example}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [Guide]{@link https://example.com/guide}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://example.com/guide|Guide}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [API](https://example.com/api)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the prefix form.',
+        },
+      ],
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+      output: `
+        /**
+         * @see [API]{@link https://example.com/api}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com/reference|Reference}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the prefix form.',
+        },
+      ],
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+      output: `
+        /**
+         * @see [Reference]{@link https://example.com/reference}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [No fix](https://example.com/no-fix)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      options: [
+        {
+          enableFixer: false,
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+        /**
+         * @see [Incomplete](https://example.com/incomplete
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+        /**
+         * @see [Incomplete]{@link}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com|}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+        /**
+         * @see \`[Code](https://example.com/code)\`
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+        /**
+         * @see [Package]{@link @scope/pkg}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com Space label}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+        /**
+         * @see [JSDoc]{@link https://example.com/jsdoc}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://example.com/jsdoc|JSDoc}
+         */
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'jsdoc',
+        },
+      },
+    },
+    {
+      code: `
+        /**
+         * @see [TypeScript](https://example.com/typescript)
+         */
+        const value: string = 'value';
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      output: `
+        /**
+         * @see {@link https://example.com/typescript|TypeScript}
+         */
+        const value: string = 'value';
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [Complex](https://example.com/a_(b))
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      output: null,
+    },
+  ],
+  valid: [
+    {
+      code: `
+        /**
+         * @see {@link https://example.com/read|Read the guide}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com/api|Browse the API}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://a.com|A} and {@link https://b.com|B}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://a.com|A}
+         * @see {@link https://b.com|B}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com/jsdoc-markdown|JSDoc Markdown}
+         */
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'jsdoc',
+        },
+      },
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com/first|First}
+         *   and {@link https://example.com/second|Second}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com|Example}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com/guide|Guide}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [API]{@link https://example.com/api}
+         */
+      `,
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+    },
+    {
+      code: `
+        /**
+         * @see [Reference]{@link https://example.com/reference}
+         */
+      `,
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com/jsdoc|JSDoc}
+         */
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'jsdoc',
+        },
+      },
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com/typescript|TypeScript}
+         */
+        const value: string = 'value';
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+    },
+    {
+      code: `
+        /**
+         * @see https://example.com
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see MyClass#method
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see some text
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see {@link @scope/pkg|Package}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see @scope/pkg
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @returns [Example](https://example.com)
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see {@code foo|bar}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see \\[Escaped](https://example.com)
+         */
+      `,
+    },
+  ],
+};

--- a/test/rules/ruleNames.json
+++ b/test/rules/ruleNames.json
@@ -30,6 +30,7 @@
   "no-restricted-syntax",
   "no-types",
   "no-undefined-types",
+  "normalize-see-links",
   "prefer-import-tag",
   "reject-any-type",
   "reject-function-type",


### PR DESCRIPTION
Closes #1631 by adding a fixable `normalize-see-links` rule for labeled links in `@see` tags. It converts Markdown `[label](url)` and prefix `[label]{@link url}` links to `{@link url|label}` and leaves that pipe form unchanged. Malformed or delimiter-colliding links, empty labels, code-span content, and scoped-package targets report without a fix. Bare URLs, namepaths, prose, and non-`@see` tags remain no-ops, with bare-URL wrapping deferred as an opt-in because it is "fine as an option if people want it." The default canonical form is pipe, while the `canonicalForm` option also allows prefix if that form is preferred.
