### PR TITLE
feat(normalize-see-links): add wrapBareUrls option

### DIFF
--- a/.README/rules/normalize-see-links.md
+++ b/.README/rules/normalize-see-links.md
@@ -2,6 +2,11 @@
 
 Normalizes labeled links in `@see` tags to a canonical `{@link}` form.
 
+Set `wrapBareUrls` to `true` to also wrap an `@see` description that contains
+only a lowercase `http:` or `https:` URL in a plain, no-label `{@link}` tag.
+This option defaults to `false`, and its output is independent of
+`canonicalForm` because there is no label to position.
+
 ## Options
 
 {"gitdown": "options"}
@@ -12,7 +17,7 @@ Normalizes labeled links in `@see` tags to a canonical `{@link}` form.
 |Tags|`see`|
 |Recommended|false|
 |Settings||
-|Options|`canonicalForm`, `enableFixer`|
+|Options|`canonicalForm`, `enableFixer`, `wrapBareUrls`|
 
 ## Failing examples
 

--- a/docs/rules/normalize-see-links.md
+++ b/docs/rules/normalize-see-links.md
@@ -4,6 +4,11 @@
 
 Normalizes labeled links in `@see` tags to a canonical `{@link}` form.
 
+Set `wrapBareUrls` to `true` to also wrap an `@see` description that contains
+only a lowercase `http:` or `https:` URL in a plain, no-label `{@link}` tag.
+This option defaults to `false`, and its output is independent of
+`canonicalForm` because there is no label to position.
+
 <a name="user-content-normalize-see-links-options"></a>
 <a name="normalize-see-links-options"></a>
 ## Options
@@ -22,6 +27,12 @@ The canonical `{<code>@link</code>}` form: `"pipe"` produces `{<code>@link</code
 
 Whether to enable the fixer. Defaults to `true`.
 
+<a name="user-content-normalize-see-links-options-wrapbareurls"></a>
+<a name="normalize-see-links-options-wrapbareurls"></a>
+### <code>wrapBareUrls</code>
+
+Whether to wrap an `@see` description containing only a lowercase `http:` or `https:` URL (for example, `@see https://example.com`) in a plain `{<code>@link</code> https://example.com}`. Defaults to `false`.
+
 
 |||
 |---|---|
@@ -29,7 +40,7 @@ Whether to enable the fixer. Defaults to `true`.
 |Tags|`see`|
 |Recommended|false|
 |Settings||
-|Options|`canonicalForm`, `enableFixer`|
+|Options|`canonicalForm`, `enableFixer`, `wrapBareUrls`|
 
 <a name="user-content-normalize-see-links-failing-examples"></a>
 <a name="normalize-see-links-failing-examples"></a>
@@ -257,6 +268,87 @@ const value: string = 'value';
  * @see [Complex](https://example.com/a_(b))
  */
 // Message: @see link cannot be safely normalized.
+
+/**
+ * @see https://example.com/docs
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+// Message: Expected bare @see URL to use a {@link} tag.
+
+/**
+ * @see http://example.com/docs
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+// Message: Expected bare @see URL to use a {@link} tag.
+
+/**
+ * @see https://example.com/%7C?ids=1|2&brace={ok}#part}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+// Message: Expected bare @see URL to use a {@link} tag.
+
+/**
+ * @see https://example.com/prefix
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix","wrapBareUrls":true}]
+// Message: Expected bare @see URL to use a {@link} tag.
+
+/**
+ * @see https://example.com/report-only
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"enableFixer":false,"wrapBareUrls":true}]
+// Message: Expected bare @see URL to use a {@link} tag.
+
+/**
+ * @see [Docs](https://example.com/labeled)
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [Docs]{@link https://example.com/labeled}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see {@link https://example.com/labeled|Docs}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix","wrapBareUrls":true}]
+// Message: Expected @see link to use the prefix form.
+
+/**
+ * @see [See {options}](https://example.com/labeled)
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+// Message: @see link cannot be safely normalized.
+
+/**
+ * @see [No fix](https://example.com/labeled)
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"enableFixer":false,"wrapBareUrls":true}]
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see https://example.com/period.
+ * @see https://example.com/comma,
+ * @see https://example.com/paren)
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+// Message: Expected bare @see URL to use a {@link} tag.
+
+/**
+ * @see
+ *   https://example.com/continued
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+// Message: Expected bare @see URL to use a {@link} tag.
+
+/**
+ * @see http:MyClass#method
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+// Message: Expected bare @see URL to use a {@link} tag.
 ````
 
 
@@ -416,5 +508,108 @@ const value: string = 'value';
 /**
  * @see \[Escaped](https://example.com)
  */
+
+/**
+ * @see {@link https://example.com/idempotent}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+
+/**
+ * @see Read https://example.com/docs
+ */
+
+/**
+ * @see Read https://example.com/docs
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+
+/**
+ * @see MyClass#method
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+
+/**
+ * @see ftp://example.com/file
+ */
+
+/**
+ * @see ftp://example.com/file
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+
+/**
+ * @see mailto:docs@example.com
+ */
+
+/**
+ * @see mailto:docs@example.com
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+
+/**
+ * @see file:///tmp/docs
+ */
+
+/**
+ * @see file:///tmp/docs
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+
+/**
+ * @see //example.com/docs
+ */
+
+/**
+ * @see //example.com/docs
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+
+/**
+ * @see `https://example.com/docs`
+ */
+
+/**
+ * @see `https://example.com/docs`
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+
+/**
+ * @see {@link https://example.com/docs}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+
+/**
+ * @see
+ */
+
+/**
+ * @see
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+
+/**
+ * @see https://example.com/one two
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+
+/**
+ * @see HTTP://example.com/docs
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+
+/**
+ * @see https://example.com/one https://example.com/two
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+
+/**
+ * @see <https://example.com/docs>
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
+
+/**
+ * @see {@link https://example.com/%7C}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
 ````
 

--- a/src/rules.d.ts
+++ b/src/rules.d.ts
@@ -1305,6 +1305,10 @@ export interface Rules {
            * Whether to enable the fixer. Defaults to `true`.
            */
           enableFixer?: boolean;
+          /**
+           * Whether to wrap an `@see` description containing only a lowercase `http:` or `https:` URL (for example, `@see https://example.com`) in a plain `{@link https://example.com}`. Defaults to `false`.
+           */
+          wrapBareUrls?: boolean;
         }
       ];
 

--- a/src/rules/normalizeSeeLinks.js
+++ b/src/rules/normalizeSeeLinks.js
@@ -10,6 +10,7 @@ const pipeLinkAttemptRegex = /\{@link[^\}\r\n]*\|[^\}\r\n]*(?:\}|$)/v;
 
 const scopedPackageNameRegex = /^@[\w.\-]+\/[\w.\-]+/v;
 const markdownCodeSpanRegex = /(?<!\\)(`+)(?!`)[\s\S]*?(?<!`)\1(?!`)/gv;
+const bareHttpUrlRegex = /^https?:\S+$/v;
 
 /**
  * @param {'pipe'|'prefix'} canonicalForm
@@ -34,6 +35,42 @@ const cannotSafelyFormatLink = (canonicalForm, label) => {
  */
 const encodeLinkTarget = (target) => {
   return encodeURI(target).replaceAll(/%25(?=[\dA-F]{2})/giv, '%');
+};
+
+/**
+ * @param {string} description
+ * @param {boolean} enabled
+ * @returns {string|null}
+ */
+const getBareHttpUrl = (description, enabled) => {
+  if (!enabled) {
+    return null;
+  }
+
+  const trimmedDescription = description.trim();
+
+  return bareHttpUrlRegex.test(trimmedDescription) &&
+    URL.canParse(trimmedDescription) ?
+    trimmedDescription : null;
+};
+
+/**
+ * @param {string} target
+ * @returns {string}
+ */
+const formatBareUrl = (target) => {
+  return `{@link ${encodeLinkTarget(target)}}`;
+};
+
+/**
+ * @param {string|undefined} bareUrl
+ * @param {'pipe'|'prefix'} canonicalForm
+ * @returns {string}
+ */
+const getExpectedMessage = (bareUrl, canonicalForm) => {
+  return bareUrl ?
+    'Expected bare @see URL to use a {@link} tag.' :
+    `Expected @see link to use the ${canonicalForm} form.`;
 };
 
 /**
@@ -107,6 +144,7 @@ export default iterateJsdoc(({
   const {
     canonicalForm = 'pipe',
     enableFixer = true,
+    wrapBareUrls = false,
   } = context.options[0] || {};
 
   const descriptionMatcher = canonicalForm === 'pipe' ?
@@ -115,6 +153,8 @@ export default iterateJsdoc(({
 
   /** @type {import('comment-parser').Spec[]} */
   const fixableTags = [];
+  /** @type {Map<import('comment-parser').Spec, string>} */
+  const bareUrlTags = new Map();
 
   for (const tag of jsdoc.tags) {
     if (tag.tag !== 'see') {
@@ -129,6 +169,12 @@ export default iterateJsdoc(({
 
     let hasAmbiguousLink = false;
     let hasNoncanonicalLink = false;
+    const bareUrl = getBareHttpUrl(rawDescription, wrapBareUrls);
+
+    if (bareUrl) {
+      bareUrlTags.set(tag, bareUrl);
+      hasNoncanonicalLink = true;
+    }
 
     for (const match of rawDescription.matchAll(markdownLinkRegex)) {
       const label = match[1];
@@ -208,8 +254,10 @@ export default iterateJsdoc(({
     reportIdx,
     tag,
   ] of fixableTags.entries()) {
+    const bareUrl = bareUrlTags.get(tag);
+
     utils.reportJSDoc(
-      `Expected @see link to use the ${canonicalForm} form.`,
+      getExpectedMessage(bareUrl, canonicalForm),
       {
         line: tag.source[0].number,
       },
@@ -223,6 +271,26 @@ export default iterateJsdoc(({
                 firstTokens.postName + firstTokens.description;
               firstTokens.name = '';
               firstTokens.postName = '';
+            }
+
+            const fixableBareUrl = bareUrlTags.get(fixableTag);
+
+            if (fixableBareUrl) {
+              for (const source of fixableTag.source) {
+                if (!source.tokens.description.includes(fixableBareUrl)) {
+                  continue;
+                }
+
+                source.tokens.description = source.tokens.description.replace(
+                  fixableBareUrl,
+                  () => {
+                    return formatBareUrl(fixableBareUrl);
+                  },
+                );
+                break;
+              }
+
+              continue;
             }
 
             for (
@@ -272,6 +340,10 @@ export default iterateJsdoc(({
           },
           enableFixer: {
             description: 'Whether to enable the fixer. Defaults to `true`.',
+            type: 'boolean',
+          },
+          wrapBareUrls: {
+            description: 'Whether to wrap an `@see` description containing only a lowercase `http:` or `https:` URL (for example, `@see https://example.com`) in a plain `{@link https://example.com}`. Defaults to `false`.',
             type: 'boolean',
           },
         },

--- a/test/rules/assertions/normalizeSeeLinks.js
+++ b/test/rules/assertions/normalizeSeeLinks.js
@@ -755,6 +755,341 @@ export default {
       ],
       output: null,
     },
+    // wrapBareUrls: whole-description HTTPS URL.
+    {
+      code: `
+        /**
+         * @see https://example.com/docs
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected bare @see URL to use a {@link} tag.',
+        },
+      ],
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://example.com/docs}
+         */
+      `,
+    },
+    // wrapBareUrls: whole-description HTTP URL.
+    {
+      code: `
+        /**
+         * @see http://example.com/docs
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected bare @see URL to use a {@link} tag.',
+        },
+      ],
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+      output: `
+        /**
+         * @see {@link http://example.com/docs}
+         */
+      `,
+    },
+    // wrapBareUrls: existing escapes stay encoded and link delimiters are encoded.
+    {
+      code: `
+        /**
+         * @see https://example.com/%7C?ids=1|2&brace={ok}#part}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected bare @see URL to use a {@link} tag.',
+        },
+      ],
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://example.com/%7C?ids=1%7C2&brace=%7Bok%7D#part%7D}
+         */
+      `,
+    },
+    // wrapBareUrls: canonicalForm prefix still produces a plain no-label link.
+    {
+      code: `
+        /**
+         * @see https://example.com/prefix
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected bare @see URL to use a {@link} tag.',
+        },
+      ],
+      options: [
+        {
+          canonicalForm: 'prefix',
+          wrapBareUrls: true,
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://example.com/prefix}
+         */
+      `,
+    },
+    // wrapBareUrls: enableFixer false reports without changing the URL.
+    {
+      code: `
+        /**
+         * @see https://example.com/report-only
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected bare @see URL to use a {@link} tag.',
+        },
+      ],
+      options: [
+        {
+          enableFixer: false,
+          wrapBareUrls: true,
+        },
+      ],
+      output: null,
+    },
+    // wrapBareUrls: Markdown labeled-link behavior is unchanged when enabled.
+    {
+      code: `
+        /**
+         * @see [Docs](https://example.com/labeled)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://example.com/labeled|Docs}
+         */
+      `,
+    },
+    // wrapBareUrls: prefix labeled-link behavior is unchanged when enabled.
+    {
+      code: `
+        /**
+         * @see [Docs]{@link https://example.com/labeled}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://example.com/labeled|Docs}
+         */
+      `,
+    },
+    // wrapBareUrls: pipe labeled-link behavior is unchanged when enabled.
+    {
+      code: `
+        /**
+         * @see {@link https://example.com/labeled|Docs}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the prefix form.',
+        },
+      ],
+      options: [
+        {
+          canonicalForm: 'prefix',
+          wrapBareUrls: true,
+        },
+      ],
+      output: `
+        /**
+         * @see [Docs]{@link https://example.com/labeled}
+         */
+      `,
+    },
+    // wrapBareUrls: labeled-link collision remains report-only when enabled.
+    {
+      code: `
+        /**
+         * @see [See {options}](https://example.com/labeled)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: '@see link cannot be safely normalized.',
+        },
+      ],
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+      output: null,
+    },
+    // wrapBareUrls: labeled enableFixer behavior is unchanged when enabled.
+    {
+      code: `
+        /**
+         * @see [No fix](https://example.com/labeled)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      options: [
+        {
+          enableFixer: false,
+          wrapBareUrls: true,
+        },
+      ],
+      output: null,
+    },
+    // wrapBareUrls adversarial: trailing URL punctuation is preserved as target text.
+    {
+      code: `
+        /**
+         * @see https://example.com/period.
+         * @see https://example.com/comma,
+         * @see https://example.com/paren)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected bare @see URL to use a {@link} tag.',
+        },
+        {
+          line: 4,
+          message: 'Expected bare @see URL to use a {@link} tag.',
+        },
+        {
+          line: 5,
+          message: 'Expected bare @see URL to use a {@link} tag.',
+        },
+      ],
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+      output: `
+        /**
+         * @see {@link https://example.com/period.}
+         * @see {@link https://example.com/comma,}
+         * @see {@link https://example.com/paren)}
+         */
+      `,
+    },
+    // wrapBareUrls adversarial: outer whitespace is ignored for recognition and preserved by the fix.
+    {
+      code: '/**\n * @see https://example.com/trailing \n */',
+      errors: [
+        {
+          line: 2,
+          message: 'Expected bare @see URL to use a {@link} tag.',
+        },
+      ],
+      ignoreReadme: true,
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+      output: '/**\n * @see {@link https://example.com/trailing} \n */',
+    },
+    // wrapBareUrls: a URL on a continuation line is still the whole trimmed description.
+    {
+      code: `
+        /**
+         * @see
+         *   https://example.com/continued
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected bare @see URL to use a {@link} tag.',
+        },
+      ],
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+      output: `
+        /**
+         * @see
+         *   {@link https://example.com/continued}
+         */
+      `,
+    },
+    // wrapBareUrls adversarial: an HTTP URL with namepath-looking text is still a URL.
+    {
+      code: `
+        /**
+         * @see http:MyClass#method
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected bare @see URL to use a {@link} tag.',
+        },
+      ],
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+      output: `
+        /**
+         * @see {@link http:MyClass#method}
+         */
+      `,
+    },
   ],
   valid: [
     {
@@ -1050,6 +1385,250 @@ export default {
          * @see \\[Escaped](https://example.com)
          */
       `,
+    },
+    // wrapBareUrls: fixed output is idempotent.
+    {
+      code: `
+        /**
+         * @see {@link https://example.com/idempotent}
+         */
+      `,
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+    },
+    // wrapBareUrls off/on: a URL inside prose remains a no-op.
+    {
+      code: `
+        /**
+         * @see Read https://example.com/docs
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see Read https://example.com/docs
+         */
+      `,
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+    },
+    // wrapBareUrls on: namepaths remain no-ops (the off case above is unchanged).
+    {
+      code: `
+        /**
+         * @see MyClass#method
+         */
+      `,
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+    },
+    // wrapBareUrls off/on: FTP URLs remain no-ops.
+    {
+      code: `
+        /**
+         * @see ftp://example.com/file
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see ftp://example.com/file
+         */
+      `,
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+    },
+    // wrapBareUrls off/on: mailto URLs remain no-ops.
+    {
+      code: `
+        /**
+         * @see mailto:docs@example.com
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see mailto:docs@example.com
+         */
+      `,
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+    },
+    // wrapBareUrls off/on: file URLs remain no-ops.
+    {
+      code: `
+        /**
+         * @see file:///tmp/docs
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see file:///tmp/docs
+         */
+      `,
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+    },
+    // wrapBareUrls off/on: protocol-relative URLs remain no-ops.
+    {
+      code: `
+        /**
+         * @see //example.com/docs
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see //example.com/docs
+         */
+      `,
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+    },
+    // wrapBareUrls off/on: code-spanned URLs remain no-ops.
+    {
+      code: `
+        /**
+         * @see \`https://example.com/docs\`
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see \`https://example.com/docs\`
+         */
+      `,
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+    },
+    // wrapBareUrls on: already-inline links remain no-ops (the off case above is unchanged).
+    {
+      code: `
+        /**
+         * @see {@link https://example.com/docs}
+         */
+      `,
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+    },
+    // wrapBareUrls off/on: empty descriptions remain no-ops.
+    {
+      code: `
+        /**
+         * @see
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see
+         */
+      `,
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+    },
+    // wrapBareUrls adversarial: internal whitespace prevents whole-URL recognition.
+    {
+      code: `
+        /**
+         * @see https://example.com/one two
+         */
+      `,
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+    },
+    // wrapBareUrls adversarial: schemes are intentionally case-sensitive.
+    {
+      code: `
+        /**
+         * @see HTTP://example.com/docs
+         */
+      `,
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+    },
+    // wrapBareUrls adversarial: two URLs are not a whole-description single URL.
+    {
+      code: `
+        /**
+         * @see https://example.com/one https://example.com/two
+         */
+      `,
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+    },
+    // wrapBareUrls adversarial: Markdown autolink syntax remains unchanged.
+    {
+      code: `
+        /**
+         * @see <https://example.com/docs>
+         */
+      `,
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
+    },
+    // wrapBareUrls adversarial: already-encoded delimiters are not double-encoded.
+    {
+      code: `
+        /**
+         * @see {@link https://example.com/%7C}
+         */
+      `,
+      options: [
+        {
+          wrapBareUrls: true,
+        },
+      ],
     },
   ],
 };


### PR DESCRIPTION
`normalize-see-links` leaves an `@see` description unchanged when its trimmed content is only a lowercase `http:` or `https:` URL. This adds a default-off `wrapBareUrls` option that wraps that form in a plain `{@link ...}`, while labeled links, URLs in prose, non-HTTP targets, and existing defaults stay unchanged. It does not invent labels, and `canonicalForm` continues to control only existing labeled inputs. Follow-up to #1631 and #1725.
