### PR TITLE
feat(check-param-names): add order fixer and suggestions

### DIFF
--- a/.README/rules/check-param-names.md
+++ b/.README/rules/check-param-names.md
@@ -7,11 +7,22 @@ the function declaration.
 
 ## Fixer
 
-Auto-removes `@param` duplicates (based on identical names).
+With `enableFixer`, reorders non-nested `@param` definitions whose names match
+the function signature but appear in a different order. The whole tag block is
+moved, including multiline descriptions and any text after the final tag.
+Destructured and nested parameters are reported without an automatic fix.
 
-Note that this option will remove duplicates of the same name even if
-the definitions do not match in other ways (e.g., the second param will
-be removed even if it has a different type or description).
+The fixer also auto-removes `@param` duplicates (based on identical names).
+This can be disabled with `duplicateParams`. Duplicate removal does not compare
+the rest of the definitions, so the second tag is removed even if it has a
+different type or description.
+
+## Suggestions
+
+Set `extraParams` to `true` to offer a suggestion that removes an `@param`
+without a corresponding function parameter. Set `badParamNames` to `true` to
+offer a suggestion that renames a mismatched `@param` to the corresponding
+function parameter name.
 
 ## Destructuring
 
@@ -47,7 +58,7 @@ may appear that there is an actual property named `extra`.
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
-|Options|`allowExtraTrailingParamDocs`, `checkDestructured`, `checkRestProperty`, `checkTypesPattern`, `disableExtraPropertyReporting`, `disableMissingParamChecks`, `enableFixer`, `useDefaultObjectProperties`|
+|Options|`allowExtraTrailingParamDocs`, `badParamNames`, `badParamOrder`, `checkDestructured`, `checkRestProperty`, `checkTypesPattern`, `disableExtraPropertyReporting`, `disableMissingParamChecks`, `duplicateParams`, `enableFixer`, `extraParams`, `useDefaultObjectProperties`|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
 |Recommended|true|

--- a/.README/rules/check-param-names.md
+++ b/.README/rules/check-param-names.md
@@ -19,10 +19,13 @@ different type or description.
 
 ## Suggestions
 
-Set `extraParams` to `true` to offer a suggestion that removes an `@param`
-without a corresponding function parameter. Set `badParamNames` to `true` to
-offer a suggestion that renames a mismatched `@param` to the corresponding
-function parameter name.
+An `@param` without a corresponding function parameter always offers a
+suggestion to remove it. A mismatched `@param` name always offers a suggestion
+to rename it to the corresponding function parameter name.
+
+Set `extraParams` to `true` to auto-apply the extra-parameter removal under
+`--fix`. Set `badParamNames` to `true` to auto-apply the mismatched-name rename
+under `--fix`. Both options default to `false`.
 
 ## Destructuring
 

--- a/docs/rules/check-param-names.md
+++ b/docs/rules/check-param-names.md
@@ -3,15 +3,20 @@
 # <code>check-param-names</code>
 
 * [Fixer](#user-content-check-param-names-fixer)
+* [Suggestions](#user-content-check-param-names-suggestions)
 * [Destructuring](#user-content-check-param-names-destructuring)
 * [Options](#user-content-check-param-names-options)
     * [`allowExtraTrailingParamDocs`](#user-content-check-param-names-options-allowextratrailingparamdocs)
+    * [`badParamNames`](#user-content-check-param-names-options-badparamnames)
+    * [`badParamOrder`](#user-content-check-param-names-options-badparamorder)
     * [`checkDestructured`](#user-content-check-param-names-options-checkdestructured)
     * [`checkRestProperty`](#user-content-check-param-names-options-checkrestproperty)
     * [`checkTypesPattern`](#user-content-check-param-names-options-checktypespattern)
     * [`disableExtraPropertyReporting`](#user-content-check-param-names-options-disableextrapropertyreporting)
     * [`disableMissingParamChecks`](#user-content-check-param-names-options-disablemissingparamchecks)
+    * [`duplicateParams`](#user-content-check-param-names-options-duplicateparams)
     * [`enableFixer`](#user-content-check-param-names-options-enablefixer)
+    * [`extraParams`](#user-content-check-param-names-options-extraparams)
     * [`useDefaultObjectProperties`](#user-content-check-param-names-options-usedefaultobjectproperties)
 * [Context and settings](#user-content-check-param-names-context-and-settings)
 * [Failing examples](#user-content-check-param-names-failing-examples)
@@ -25,11 +30,24 @@ the function declaration.
 <a name="check-param-names-fixer"></a>
 ## Fixer
 
-Auto-removes `@param` duplicates (based on identical names).
+With `enableFixer`, reorders non-nested `@param` definitions whose names match
+the function signature but appear in a different order. The whole tag block is
+moved, including multiline descriptions and any text after the final tag.
+Destructured and nested parameters are reported without an automatic fix.
 
-Note that this option will remove duplicates of the same name even if
-the definitions do not match in other ways (e.g., the second param will
-be removed even if it has a different type or description).
+The fixer also auto-removes `@param` duplicates (based on identical names).
+This can be disabled with `duplicateParams`. Duplicate removal does not compare
+the rest of the definitions, so the second tag is removed even if it has a
+different type or description.
+
+<a name="user-content-check-param-names-suggestions"></a>
+<a name="check-param-names-suggestions"></a>
+## Suggestions
+
+Set `extraParams` to `true` to offer a suggestion that removes an `@param`
+without a corresponding function parameter. Set `badParamNames` to `true` to
+offer a suggestion that renames a mismatched `@param` to the corresponding
+function parameter name.
 
 <a name="user-content-check-param-names-destructuring"></a>
 <a name="check-param-names-destructuring"></a>
@@ -72,6 +90,20 @@ If set to `true`, this option will allow extra `@param` definitions (e.g.,
 representing future expected or virtual params) to be present without needing
 their presence within the function signature. Other inconsistencies between
 `@param`'s and present function parameters will still be reported.
+
+<a name="user-content-check-param-names-options-badparamnames"></a>
+<a name="check-param-names-options-badparamnames"></a>
+### <code>badParamNames</code>
+
+Whether to offer a suggestion to rename a mismatched `@param` to the
+corresponding function parameter name. Defaults to `false`.
+
+<a name="user-content-check-param-names-options-badparamorder"></a>
+<a name="check-param-names-options-badparamorder"></a>
+### <code>badParamOrder</code>
+
+Whether to report `@param` definitions whose names match the function
+parameters but appear in a different order. Defaults to `true`.
 
 <a name="user-content-check-param-names-options-checkdestructured"></a>
 <a name="check-param-names-options-checkdestructured"></a>
@@ -145,16 +177,29 @@ that are available and actually used in the function.
 
 Whether to avoid checks for missing `@param` definitions. Defaults to `false`. Change to `true` if you want to be able to omit properties.
 
+<a name="user-content-check-param-names-options-duplicateparams"></a>
+<a name="check-param-names-options-duplicateparams"></a>
+### <code>duplicateParams</code>
+
+Whether to report duplicate `@param` definitions. Defaults to `true`.
+
 <a name="user-content-check-param-names-options-enablefixer"></a>
 <a name="check-param-names-options-enablefixer"></a>
 ### <code>enableFixer</code>
 
-Set to `true` to auto-remove `@param` duplicates (based on identical
-names).
+Set to `true` to reorder non-nested `@param` definitions to match the
+function signature and to auto-remove duplicates (based on identical names).
 
 Note that this option will remove duplicates of the same name even if
 the definitions do not match in other ways (e.g., the second param will
 be removed even if it has a different type or description).
+
+<a name="user-content-check-param-names-options-extraparams"></a>
+<a name="check-param-names-options-extraparams"></a>
+### <code>extraParams</code>
+
+Whether to offer a suggestion to remove an `@param` that has no
+corresponding function parameter. Defaults to `false`.
 
 <a name="user-content-check-param-names-options-usedefaultobjectproperties"></a>
 <a name="check-param-names-options-usedefaultobjectproperties"></a>
@@ -173,7 +218,7 @@ are present and can therefore be documented. Defaults to `false`.
 |||
 |---|---|
 |Context|`ArrowFunctionExpression`, `FunctionDeclaration`, `FunctionExpression`|
-|Options|`allowExtraTrailingParamDocs`, `checkDestructured`, `checkRestProperty`, `checkTypesPattern`, `disableExtraPropertyReporting`, `disableMissingParamChecks`, `enableFixer`, `useDefaultObjectProperties`|
+|Options|`allowExtraTrailingParamDocs`, `badParamNames`, `badParamOrder`, `checkDestructured`, `checkRestProperty`, `checkTypesPattern`, `disableExtraPropertyReporting`, `disableMissingParamChecks`, `duplicateParams`, `enableFixer`, `extraParams`, `useDefaultObjectProperties`|
 |Tags|`param`|
 |Aliases|`arg`, `argument`|
 |Recommended|true|
@@ -185,6 +230,50 @@ are present and can therefore be documented. Defaults to `false`.
 The following patterns are considered problems:
 
 ````ts
+/**
+ * @param {string} first - First value.
+ * @param {string} third - Third value.
+ *   More details about the third value.
+ * @param {string} second - Second value.
+ *
+ * Trailing text for the second value.
+ */
+function quux (first, second, third) {
+
+}
+// "jsdoc/check-param-names": ["error"|"warn", {"enableFixer":true}]
+// Message: Expected @param names to be "first, second, third". Got "first, third, second".
+
+/**
+ * @param foo
+ * @param extra
+ */
+function quux (foo) {
+
+}
+// "jsdoc/check-param-names": ["error"|"warn", {"extraParams":true}]
+// Message: @param "extra" does not match an existing function parameter.
+
+/**
+ * @param {string} bar - A value.
+ */
+function quux (foo) {
+
+}
+// "jsdoc/check-param-names": ["error"|"warn", {"badParamNames":true}]
+// Message: Expected @param names to be "foo". Got "bar".
+
+/**
+ * @param foo
+ * @param foo.value
+ * @param bar
+ */
+function quux (bar, foo) {
+
+}
+// "jsdoc/check-param-names": ["error"|"warn", {"enableFixer":true}]
+// Message: Expected @param names to be "bar, foo". Got "foo, bar".
+
 /**
  * @param Foo
  */
@@ -743,6 +832,24 @@ interface Foo {
 The following patterns are not considered problems:
 
 ````ts
+/**
+ * @param bar
+ * @param foo
+ */
+function quux (foo, bar) {
+
+}
+// "jsdoc/check-param-names": ["error"|"warn", {"badParamOrder":false,"enableFixer":true}]
+
+/**
+ * @param foo
+ * @param foo
+ */
+function quux (foo) {
+
+}
+// "jsdoc/check-param-names": ["error"|"warn", {"duplicateParams":false,"enableFixer":true}]
+
 /**
  *
  */

--- a/docs/rules/check-param-names.md
+++ b/docs/rules/check-param-names.md
@@ -245,6 +245,18 @@ function quux (first, second, third) {
 // Message: Expected @param names to be "first, second, third". Got "first, third, second".
 
 /**
+ * @param bar number to return
+ * @param this desc
+ * @returns number returned back to caller
+ */
+function foo(this: T, bar: number): number {
+  console.log(this.name);
+  return bar;
+}
+// "jsdoc/check-param-names": ["error"|"warn", {"enableFixer":true}]
+// Message: Expected @param names to be "this, bar". Got "bar, this".
+
+/**
  * @param foo
  * @param extra
  */
@@ -1247,6 +1259,17 @@ function foo(this: T, bar: number): number {
   console.log(this.name);
   return bar;
 }
+
+/**
+ * @param bar number to return
+ * @param this desc
+ * @returns number returned back to caller
+ */
+function foo(this: T, bar: number): number {
+  console.log(this.name);
+  return bar;
+}
+// "jsdoc/check-param-names": ["error"|"warn", {"badParamOrder":false}]
 
 /**
  * Documentation

--- a/docs/rules/check-param-names.md
+++ b/docs/rules/check-param-names.md
@@ -44,10 +44,13 @@ different type or description.
 <a name="check-param-names-suggestions"></a>
 ## Suggestions
 
-Set `extraParams` to `true` to offer a suggestion that removes an `@param`
-without a corresponding function parameter. Set `badParamNames` to `true` to
-offer a suggestion that renames a mismatched `@param` to the corresponding
-function parameter name.
+An `@param` without a corresponding function parameter always offers a
+suggestion to remove it. A mismatched `@param` name always offers a suggestion
+to rename it to the corresponding function parameter name.
+
+Set `extraParams` to `true` to auto-apply the extra-parameter removal under
+`--fix`. Set `badParamNames` to `true` to auto-apply the mismatched-name rename
+under `--fix`. Both options default to `false`.
 
 <a name="user-content-check-param-names-destructuring"></a>
 <a name="check-param-names-destructuring"></a>
@@ -95,8 +98,8 @@ their presence within the function signature. Other inconsistencies between
 <a name="check-param-names-options-badparamnames"></a>
 ### <code>badParamNames</code>
 
-Whether to offer a suggestion to rename a mismatched `@param` to the
-corresponding function parameter name. Defaults to `false`.
+Whether to auto-fix a mismatched `@param` name to the corresponding
+function parameter name. A suggestion is always offered. Defaults to `false`.
 
 <a name="user-content-check-param-names-options-badparamorder"></a>
 <a name="check-param-names-options-badparamorder"></a>
@@ -198,8 +201,8 @@ be removed even if it has a different type or description).
 <a name="check-param-names-options-extraparams"></a>
 ### <code>extraParams</code>
 
-Whether to offer a suggestion to remove an `@param` that has no
-corresponding function parameter. Defaults to `false`.
+Whether to auto-remove an `@param` that has no corresponding function
+parameter. A suggestion is always offered. Defaults to `false`.
 
 <a name="user-content-check-param-names-options-usedefaultobjectproperties"></a>
 <a name="check-param-names-options-usedefaultobjectproperties"></a>
@@ -267,12 +270,29 @@ function quux (foo) {
 // Message: @param "extra" does not match an existing function parameter.
 
 /**
+ * @param foo
+ * @param extra
+ */
+function quux (foo) {
+
+}
+// Message: @param "extra" does not match an existing function parameter.
+
+/**
  * @param {string} bar - A value.
  */
 function quux (foo) {
 
 }
 // "jsdoc/check-param-names": ["error"|"warn", {"badParamNames":true}]
+// Message: Expected @param names to be "foo". Got "bar".
+
+/**
+ * @param {string} bar - A value.
+ */
+function quux (foo) {
+
+}
 // Message: Expected @param names to be "foo". Got "bar".
 
 /**

--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -118,6 +118,13 @@ import esquery from 'esquery';
  */
 
 /**
+ * @typedef {{
+ *   desc: string,
+ *   handler: (fixer: import('eslint').Rule.RuleFixer) => import('eslint').Rule.Fix|void
+ * }[]} JsdocSuggestions
+ */
+
+/**
  * @callback ReportJSDoc
  * @param {string} msg
  * @param {null|import('comment-parser').Spec|{line: Integer, column?: Integer}} [tag]
@@ -126,6 +133,7 @@ import esquery from 'esquery';
  * @param {undefined|{
  *   [key: string]: string
  * }} [data]
+ * @param {JsdocSuggestions} [suggestions]
  */
 
 /**
@@ -698,6 +706,7 @@ const getBasicUtils = (context, {
  * @param {undefined|{
  *   [key: string]: string
  * }} [data]
+ * @param {import('eslint').Rule.SuggestionReportDescriptor[]} [suggest]
  * @returns {void}
  */
 
@@ -808,24 +817,42 @@ const getUtils = (
   };
 
   /** @type {ReportJSDoc} */
-  utils.reportJSDoc = (msg, tag, handler, specRewire, data) => {
-    report(msg, handler ? /** @type {import('eslint').Rule.ReportFixer} */ (
-      fixer,
-    ) => {
-      const extraFix = handler(fixer);
+  utils.reportJSDoc = (msg, tag, handler, specRewire, data, suggestions) => {
+    /**
+     * @param {(fixer: import('eslint').Rule.RuleFixer) => import('eslint').Rule.Fix|void} fixHandler
+     * @returns {import('eslint').Rule.ReportFixer}
+     */
+    const makeFix = (fixHandler) => {
+      return (fixer) => {
+        const extraFix = fixHandler(fixer);
 
-      const replacement = utils.stringify(jsdoc, specRewire);
+        const replacement = utils.stringify(jsdoc, specRewire);
 
-      if (!replacement) {
-        const text = sourceCode.getText();
-        const lastLineBreakPos = text.slice(
-          0, jsdocNode.range[0],
-        ).search(/\n[ \t]*$/v);
-        if (lastLineBreakPos > -1) {
+        if (!replacement) {
+          const text = sourceCode.getText();
+          const lastLineBreakPos = text.slice(
+            0, jsdocNode.range[0],
+          ).search(/\n[ \t]*$/v);
+          if (lastLineBreakPos > -1) {
+            return [
+              fixer.removeRange([
+                lastLineBreakPos, jsdocNode.range[1],
+              ]),
+              /* c8 ignore next 2 -- Guard */
+              ...(extraFix ? [
+                extraFix,
+              ] : []),
+            ];
+          }
+
           return [
-            fixer.removeRange([
-              lastLineBreakPos, jsdocNode.range[1],
-            ]),
+            fixer.removeRange(
+              (/\s/v).test(text.charAt(jsdocNode.range[1])) ?
+                [
+                  jsdocNode.range[0], jsdocNode.range[1] + 1,
+                ] :
+                jsdocNode.range,
+            ),
             /* c8 ignore next 2 -- Guard */
             ...(extraFix ? [
               extraFix,
@@ -834,27 +861,29 @@ const getUtils = (
         }
 
         return [
-          fixer.removeRange(
-            (/\s/v).test(text.charAt(jsdocNode.range[1])) ?
-              [
-                jsdocNode.range[0], jsdocNode.range[1] + 1,
-              ] :
-              jsdocNode.range,
-          ),
-          /* c8 ignore next 2 -- Guard */
+          fixer.replaceText(jsdocNode, replacement),
           ...(extraFix ? [
             extraFix,
           ] : []),
         ];
-      }
+      };
+    };
 
-      return [
-        fixer.replaceText(jsdocNode, replacement),
-        ...(extraFix ? [
-          extraFix,
-        ] : []),
-      ];
-    } : null, tag, data);
+    report(
+      msg,
+      handler ? makeFix(handler) : null,
+      tag,
+      data,
+      suggestions?.map(({
+        desc,
+        handler: suggestionHandler,
+      }) => {
+        return {
+          desc,
+          fix: makeFix(suggestionHandler),
+        };
+      }),
+    );
   };
 
   /** @type {GetRegexFromString} */
@@ -1911,7 +1940,9 @@ const getSettings = (context) => {
 /** @type {MakeReport} */
 const makeReport = (context, commentNode) => {
   /** @type {Report} */
-  const report = (message, fix = null, jsdocLoc = null, data = undefined) => {
+  const report = (
+    message, fix = null, jsdocLoc = null, data = undefined, suggest = undefined,
+  ) => {
     let loc;
 
     if (jsdocLoc) {
@@ -1953,6 +1984,7 @@ const makeReport = (context, commentNode) => {
       loc,
       message,
       node: commentNode,
+      suggest,
     });
   };
 

--- a/src/rules.d.ts
+++ b/src/rules.d.ts
@@ -144,6 +144,16 @@ export interface Rules {
            */
           allowExtraTrailingParamDocs?: boolean;
           /**
+           * Whether to offer a suggestion to rename a mismatched `@param` to the
+           * corresponding function parameter name. Defaults to `false`.
+           */
+          badParamNames?: boolean;
+          /**
+           * Whether to report `@param` definitions whose names match the function
+           * parameters but appear in a different order. Defaults to `true`.
+           */
+          badParamOrder?: boolean;
+          /**
            * Whether to check destructured properties. Defaults to `true`.
            */
           checkDestructured?: boolean;
@@ -206,14 +216,23 @@ export interface Rules {
            */
           disableMissingParamChecks?: boolean;
           /**
-           * Set to `true` to auto-remove `@param` duplicates (based on identical
-           * names).
+           * Whether to report duplicate `@param` definitions. Defaults to `true`.
+           */
+          duplicateParams?: boolean;
+          /**
+           * Set to `true` to reorder non-nested `@param` definitions to match the
+           * function signature and to auto-remove duplicates (based on identical names).
            *
            * Note that this option will remove duplicates of the same name even if
            * the definitions do not match in other ways (e.g., the second param will
            * be removed even if it has a different type or description).
            */
           enableFixer?: boolean;
+          /**
+           * Whether to offer a suggestion to remove an `@param` that has no
+           * corresponding function parameter. Defaults to `false`.
+           */
+          extraParams?: boolean;
           /**
            * Set to `true` if you wish to avoid reporting of child property documentation
            * where instead of destructuring, a whole plain object is supplied as default

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -1,14 +1,107 @@
 import iterateJsdoc from '../iterateJsdoc.js';
 
 /**
+ * @param {import('../jsdocUtils.js').ParamNameInfo} parameter
+ * @returns {string|undefined}
+ */
+const getSimpleParameterName = (parameter) => {
+  if (typeof parameter === 'string') {
+    return parameter;
+  }
+
+  if (
+    !parameter ||
+    Array.isArray(parameter) ||
+    typeof parameter !== 'object' ||
+    !('name' in parameter) ||
+    typeof parameter.name !== 'string'
+  ) {
+    return undefined;
+  }
+
+  return parameter.name;
+};
+
+/**
+ * @param {import('../iterateJsdoc.js').Integer} firstChangedTagIndex
+ * @param {import('comment-parser').Spec[]} orderedTags
+ * @param {import('comment-parser').Block} jsdoc
+ * @param {import('../iterateJsdoc.js').Utils} utils
+ * @returns {() => void}
+ */
+const makeParamOrderFix = (
+  firstChangedTagIndex, orderedTags, jsdoc, utils,
+) => {
+  return () => {
+    const itemsToMoveRange = [
+      ...Array.from({
+        length: jsdoc.tags.length - firstChangedTagIndex,
+      }).keys(),
+    ];
+
+    const unchangedPriorTagDescriptions = jsdoc.tags.slice(
+      0,
+      firstChangedTagIndex,
+    ).reduce((count, {
+      source,
+    }) => {
+      return count + source.length - 1;
+    }, 0);
+
+    const initialOffset =
+      /** @type {import('../iterateJsdoc.js').Integer} */ (utils.getFirstLine()) +
+      firstChangedTagIndex + unchangedPriorTagDescriptions;
+
+    for (const index of itemsToMoveRange) {
+      utils.removeTag(index + firstChangedTagIndex);
+    }
+
+    const changedTags = orderedTags.slice(firstChangedTagIndex);
+    let extraTagCount = 0;
+
+    for (const index of itemsToMoveRange) {
+      const changedTag = changedTags[index];
+
+      utils.addTag(
+        changedTag.tag,
+        extraTagCount + initialOffset + index,
+        {
+          ...changedTag.source[0].tokens,
+          end: '',
+        },
+      );
+
+      for (const {
+        tokens,
+      } of changedTag.source.slice(1)) {
+        if (!tokens.end) {
+          utils.addLine(
+            extraTagCount + initialOffset + index + 1,
+            {
+              ...tokens,
+              end: '',
+            },
+          );
+          extraTagCount++;
+        }
+      }
+    }
+  };
+};
+
+/**
  * @param {string} targetTagName
  * @param {boolean} allowExtraTrailingParamDocs
+ * @param {boolean} badParamNames
+ * @param {boolean} badParamOrder
  * @param {boolean} checkDestructured
  * @param {boolean} checkRestProperty
  * @param {RegExp} checkTypesRegex
  * @param {boolean} disableExtraPropertyReporting
  * @param {boolean} disableMissingParamChecks
+ * @param {boolean} duplicateParams
  * @param {boolean} enableFixer
+ * @param {boolean} extraParams
  * @param {import('../jsdocUtils.js').ParamNameInfo[]} functionParameterNames
  * @param {import('comment-parser').Block} jsdoc
  * @param {import('../iterateJsdoc.js').Utils} utils
@@ -18,12 +111,16 @@ import iterateJsdoc from '../iterateJsdoc.js';
 const validateParameterNames = (
   targetTagName,
   allowExtraTrailingParamDocs,
+  badParamNames,
+  badParamOrder,
   checkDestructured,
   checkRestProperty,
   checkTypesRegex,
   disableExtraPropertyReporting,
   disableMissingParamChecks,
+  duplicateParams,
   enableFixer,
+  extraParams,
   functionParameterNames, jsdoc, utils, report,
 ) => {
   const paramTags = Object.entries(jsdoc.tags).filter(([
@@ -36,12 +133,38 @@ const validateParameterNames = (
   ]) => {
     return !tag.name.includes('.');
   });
+  const actualParamNames = paramTagsNonNested.map(([
+    , tag,
+  ]) => {
+    return tag.name.trim();
+  });
+  const simpleFunctionParameterNames = functionParameterNames.filter((parameter) => {
+    return parameter !== 'this';
+  }).map(getSimpleParameterName);
+  const hasOnlySimpleParameterNames = simpleFunctionParameterNames.every((name) => {
+    return name !== undefined;
+  });
+  const expectedParamNames = /** @type {string[]} */ (simpleFunctionParameterNames);
+  const sortedActualParamNames = actualParamNames.toSorted();
+  const sortedExpectedParamNames = expectedParamNames.toSorted();
+  const sameParamNames = hasOnlySimpleParameterNames &&
+    actualParamNames.length === expectedParamNames.length &&
+    sortedActualParamNames.every((name, index) => {
+      return name === sortedExpectedParamNames[index];
+    });
+  const isBadParamOrder = sameParamNames && actualParamNames.some((name, index) => {
+    return name !== expectedParamNames[index];
+  });
+  const canFixParamOrder =
+    paramTags.length === paramTagsNonNested.length &&
+    new Set(actualParamNames).size === actualParamNames.length;
 
   let dotted = 0;
   let thisOffset = 0;
 
   return paramTags.some(([
-    , tag,
+    paramTagIndex,
+    tag,
   // eslint-disable-next-line complexity
   ], index) => {
     /** @type {import('../iterateJsdoc.js').Integer} */
@@ -54,12 +177,20 @@ const validateParameterNames = (
 
       return tg.name === tag.name && idx !== index;
     });
-    if (dupeTagInfo) {
+    if (dupeTagInfo && duplicateParams) {
       utils.reportJSDoc(`Duplicate @${targetTagName} "${tag.name}"`, dupeTagInfo[1], enableFixer ? () => {
         utils.removeTag(tagsIndex);
       } : null);
 
       return true;
+    }
+
+    if (!duplicateParams && paramTags.some(([
+      , earlierTag,
+    ], earlierIndex) => {
+      return earlierIndex < index && earlierTag.name === tag.name;
+    })) {
+      return false;
     }
 
     if (tag.name.includes('.')) {
@@ -79,10 +210,20 @@ const validateParameterNames = (
         return false;
       }
 
-      report(
+      utils.reportJSDoc(
         `@${targetTagName} "${tag.name}" does not match an existing function parameter.`,
-        null,
         tag,
+        null,
+        false,
+        undefined,
+        extraParams ? [
+          {
+            desc: `Remove the extra @${targetTagName} "${tag.name}".`,
+            handler: () => {
+              utils.removeTag(Number(paramTagIndex));
+            },
+          },
+        ] : undefined,
       );
 
       return true;
@@ -269,6 +410,57 @@ const validateParameterNames = (
       }).filter((item) => {
         return item !== 'this';
       });
+      const message = `Expected @${targetTagName} names to be "${
+        expectedNames.map((expectedName) => {
+          return typeof expectedName === 'object' &&
+            'name' in expectedName &&
+            expectedName.restElement ?
+            '...' + expectedName.name :
+            expectedName;
+        }).join(', ')
+      }". Got "${actualNames.join(', ')}".`;
+
+      if (isBadParamOrder) {
+        if (!badParamOrder) {
+          return false;
+        }
+
+        let orderFix = null;
+        if (enableFixer && canFixParamOrder) {
+          const orderedTags =
+            /** @type {import('comment-parser').Spec[]} */ (
+              JSON.parse(JSON.stringify(jsdoc.tags))
+            );
+          for (const [
+            paramIndex,
+            expectedName,
+          ] of expectedParamNames.entries()) {
+            const matchingTag = /** @type {[string, import('comment-parser').Spec]} */ (
+              paramTagsNonNested.find(([
+                , candidateTag,
+              ]) => {
+                return candidateTag.name.trim() === expectedName;
+              })
+            );
+            orderedTags[Number(paramTagsNonNested[paramIndex][0])] =
+              JSON.parse(JSON.stringify(matchingTag[1]));
+          }
+
+          const firstChangedParamIndex = actualParamNames.findIndex((name, paramIndex) => {
+            return name !== expectedParamNames[paramIndex];
+          });
+          orderFix = makeParamOrderFix(
+            Number(paramTagsNonNested[firstChangedParamIndex][0]),
+            orderedTags,
+            jsdoc,
+            utils,
+          );
+        }
+
+        utils.reportJSDoc(message, tag, orderFix, true);
+
+        return true;
+      }
 
       // When disableMissingParamChecks is true tag names can be omitted.
       // Report when the tag names do not match the expected names or they are used out of order.
@@ -286,18 +478,20 @@ const validateParameterNames = (
         }
       }
 
-      report(
-        `Expected @${targetTagName} names to be "${
-          expectedNames.map((expectedName) => {
-            return typeof expectedName === 'object' &&
-              'name' in expectedName &&
-              expectedName.restElement ?
-              '...' + expectedName.name :
-              expectedName;
-          }).join(', ')
-        }". Got "${actualNames.join(', ')}".`,
-        null,
+      utils.reportJSDoc(
+        message,
         tag,
+        null,
+        true,
+        undefined,
+        badParamNames ? [
+          {
+            desc: `Rename @${targetTagName} "${tag.name.trim()}" to "${funcParamName}".`,
+            handler: () => {
+              tag.source[0].tokens.name = String(funcParamName);
+            },
+          },
+        ] : undefined,
       );
 
       return true;
@@ -377,12 +571,16 @@ export default iterateJsdoc(({
 }) => {
   const {
     allowExtraTrailingParamDocs,
+    badParamNames = false,
+    badParamOrder = true,
     checkDestructured = true,
     checkRestProperty = false,
     checkTypesPattern = '/^(?:[oO]bject|[aA]rray|PlainObject|Generic(?:Object|Array))$/',
     disableExtraPropertyReporting = false,
     disableMissingParamChecks = false,
+    duplicateParams = true,
     enableFixer = false,
+    extraParams = false,
     useDefaultObjectProperties = false,
   } = context.options[0] || {};
 
@@ -416,12 +614,16 @@ export default iterateJsdoc(({
   const isError = validateParameterNames(
     targetTagName,
     allowExtraTrailingParamDocs,
+    badParamNames,
+    badParamOrder,
     checkDestructured,
     checkRestProperty,
     checkTypesRegex,
     disableExtraPropertyReporting,
     disableMissingParamChecks,
+    duplicateParams,
     enableFixer,
+    extraParams,
     functionParameterNames,
     jsdoc,
     utils,
@@ -443,6 +645,7 @@ export default iterateJsdoc(({
       url: 'https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/check-param-names.md#repos-sticky-header',
     },
     fixable: 'code',
+    hasSuggestions: true,
     schema: [
       {
         additionalProperties: false,
@@ -452,6 +655,16 @@ export default iterateJsdoc(({
 representing future expected or virtual params) to be present without needing
 their presence within the function signature. Other inconsistencies between
 \`@param\`'s and present function parameters will still be reported.`,
+            type: 'boolean',
+          },
+          badParamNames: {
+            description: `Whether to offer a suggestion to rename a mismatched \`@param\` to the
+corresponding function parameter name. Defaults to \`false\`.`,
+            type: 'boolean',
+          },
+          badParamOrder: {
+            description: `Whether to report \`@param\` definitions whose names match the function
+parameters but appear in a different order. Defaults to \`true\`.`,
             type: 'boolean',
           },
           checkDestructured: {
@@ -516,13 +729,22 @@ that are available and actually used in the function.`,
             description: 'Whether to avoid checks for missing `@param` definitions. Defaults to `false`. Change to `true` if you want to be able to omit properties.',
             type: 'boolean',
           },
+          duplicateParams: {
+            description: 'Whether to report duplicate `@param` definitions. Defaults to `true`.',
+            type: 'boolean',
+          },
           enableFixer: {
-            description: `Set to \`true\` to auto-remove \`@param\` duplicates (based on identical
-names).
+            description: `Set to \`true\` to reorder non-nested \`@param\` definitions to match the
+function signature and to auto-remove duplicates (based on identical names).
 
 Note that this option will remove duplicates of the same name even if
 the definitions do not match in other ways (e.g., the second param will
 be removed even if it has a different type or description).`,
+            type: 'boolean',
+          },
+          extraParams: {
+            description: `Whether to offer a suggestion to remove an \`@param\` that has no
+corresponding function parameter. Defaults to \`false\`.`,
             type: 'boolean',
           },
           useDefaultObjectProperties: {

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -164,7 +164,7 @@ const validateParameterNames = (
   let thisOffset = 0;
 
   return paramTags.some(([
-    paramTagIndex,
+    ,
     tag,
   // eslint-disable-next-line complexity
   ], index) => {
@@ -211,20 +211,25 @@ const validateParameterNames = (
         return false;
       }
 
+      const removeExtraParam = () => {
+        const currentTagIndex = jsdoc.tags.indexOf(tag);
+        if (currentTagIndex !== -1) {
+          utils.removeTag(currentTagIndex);
+        }
+      };
+
       utils.reportJSDoc(
         `@${targetTagName} "${tag.name}" does not match an existing function parameter.`,
         tag,
-        null,
+        extraParams ? removeExtraParam : null,
         false,
         undefined,
-        extraParams ? [
+        [
           {
             desc: `Remove the extra @${targetTagName} "${tag.name}".`,
-            handler: () => {
-              utils.removeTag(Number(paramTagIndex));
-            },
+            handler: removeExtraParam,
           },
-        ] : undefined,
+        ],
       );
 
       return true;
@@ -479,20 +484,22 @@ const validateParameterNames = (
         }
       }
 
+      const renameBadParam = () => {
+        tag.source[0].tokens.name = String(funcParamName);
+      };
+
       utils.reportJSDoc(
         message,
         tag,
-        null,
+        badParamNames ? renameBadParam : null,
         true,
         undefined,
-        badParamNames ? [
+        [
           {
             desc: `Rename @${targetTagName} "${tag.name.trim()}" to "${funcParamName}".`,
-            handler: () => {
-              tag.source[0].tokens.name = String(funcParamName);
-            },
+            handler: renameBadParam,
           },
-        ] : undefined,
+        ],
       );
 
       return true;
@@ -659,8 +666,8 @@ their presence within the function signature. Other inconsistencies between
             type: 'boolean',
           },
           badParamNames: {
-            description: `Whether to offer a suggestion to rename a mismatched \`@param\` to the
-corresponding function parameter name. Defaults to \`false\`.`,
+            description: `Whether to auto-fix a mismatched \`@param\` name to the corresponding
+function parameter name. A suggestion is always offered. Defaults to \`false\`.`,
             type: 'boolean',
           },
           badParamOrder: {
@@ -744,8 +751,8 @@ be removed even if it has a different type or description).`,
             type: 'boolean',
           },
           extraParams: {
-            description: `Whether to offer a suggestion to remove an \`@param\` that has no
-corresponding function parameter. Defaults to \`false\`.`,
+            description: `Whether to auto-remove an \`@param\` that has no corresponding function
+parameter. A suggestion is always offered. Defaults to \`false\`.`,
             type: 'boolean',
           },
           useDefaultObjectProperties: {

--- a/src/rules/checkParamNames.js
+++ b/src/rules/checkParamNames.js
@@ -138,8 +138,9 @@ const validateParameterNames = (
   ]) => {
     return tag.name.trim();
   });
+  const documentsThis = actualParamNames.includes('this');
   const simpleFunctionParameterNames = functionParameterNames.filter((parameter) => {
-    return parameter !== 'this';
+    return documentsThis || parameter !== 'this';
   }).map(getSimpleParameterName);
   const hasOnlySimpleParameterNames = simpleFunctionParameterNames.every((name) => {
     return name !== undefined;
@@ -200,7 +201,7 @@ const validateParameterNames = (
     }
 
     let functionParameterName = functionParameterNames[index - dotted + thisOffset];
-    if (functionParameterName === 'this' && tag.name.trim() !== 'this') {
+    if (!documentsThis && functionParameterName === 'this' && tag.name.trim() !== 'this') {
       ++thisOffset;
       functionParameterName = functionParameterNames[index - dotted + thisOffset];
     }
@@ -408,7 +409,7 @@ const validateParameterNames = (
 
         return item;
       }).filter((item) => {
-        return item !== 'this';
+        return documentsThis || item !== 'this';
       });
       const message = `Expected @${targetTagName} names to be "${
         expectedNames.map((expectedName) => {

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -8,6 +8,140 @@ export default /** @type {import('../index.js').TestCases} */ ({
     {
       code: `
           /**
+           * @param {string} first - First value.
+           * @param {string} third - Third value.
+           *   More details about the third value.
+           * @param {string} second - Second value.
+           *
+           * Trailing text for the second value.
+           */
+          function quux (first, second, third) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'Expected @param names to be "first, second, third". Got "first, third, second".',
+        },
+      ],
+      options: [
+        {
+          enableFixer: true,
+        },
+      ],
+      output: `
+          /**
+           * @param {string} first - First value.
+           * @param {string} second - Second value.
+           *
+           * Trailing text for the second value.
+           * @param {string} third - Third value.
+           *   More details about the third value.
+           */
+          function quux (first, second, third) {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @param foo
+           * @param extra
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 4,
+          message: '@param "extra" does not match an existing function parameter.',
+          suggestions: [
+            {
+              desc: 'Remove the extra @param "extra".',
+              output: `
+          /**
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          extraParams: true,
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+          /**
+           * @param {string} bar - A value.
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @param names to be "foo". Got "bar".',
+          suggestions: [
+            {
+              desc: 'Rename @param "bar" to "foo".',
+              output: `
+          /**
+           * @param {string} foo - A value.
+           */
+          function quux (foo) {
+
+          }
+      `,
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          badParamNames: true,
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+          /**
+           * @param foo
+           * @param foo.value
+           * @param bar
+           */
+          function quux (bar, foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @param names to be "bar, foo". Got "foo, bar".',
+        },
+      ],
+      options: [
+        {
+          enableFixer: true,
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+          /**
            * @param Foo
            */
           function quux (foo = 'FOO') {
@@ -1344,6 +1478,40 @@ export default /** @type {import('../index.js').TestCases} */ ({
     },
   ],
   valid: [
+    {
+      code: `
+          /**
+           * @param bar
+           * @param foo
+           */
+          function quux (foo, bar) {
+
+          }
+      `,
+      options: [
+        {
+          badParamOrder: false,
+          enableFixer: true,
+        },
+      ],
+    },
+    {
+      code: `
+          /**
+           * @param foo
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+      options: [
+        {
+          duplicateParams: false,
+          enableFixer: true,
+        },
+      ],
+    },
     {
       code: `
           /**

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -47,6 +47,44 @@ export default /** @type {import('../index.js').TestCases} */ ({
     {
       code: `
           /**
+           * @param bar number to return
+           * @param this desc
+           * @returns number returned back to caller
+           */
+          function foo(this: T, bar: number): number {
+            console.log(this.name);
+            return bar;
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @param names to be "this, bar". Got "bar, this".',
+        },
+      ],
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      options: [
+        {
+          enableFixer: true,
+        },
+      ],
+      output: `
+          /**
+           * @param this desc
+           * @param bar number to return
+           * @returns number returned back to caller
+           */
+          function foo(this: T, bar: number): number {
+            console.log(this.name);
+            return bar;
+          }
+      `,
+    },
+    {
+      code: `
+          /**
            * @param foo
            * @param extra
            */
@@ -2150,6 +2188,27 @@ export default /** @type {import('../index.js').TestCases} */ ({
       languageOptions: {
         parser: typescriptEslintParser,
       },
+    },
+    {
+      code: `
+        /**
+         * @param bar number to return
+         * @param this desc
+         * @returns number returned back to caller
+         */
+        function foo(this: T, bar: number): number {
+          console.log(this.name);
+          return bar;
+        }
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      options: [
+        {
+          badParamOrder: false,
+        },
+      ],
     },
     {
       code: `

--- a/test/rules/assertions/checkParamNames.js
+++ b/test/rules/assertions/checkParamNames.js
@@ -116,6 +116,44 @@ export default /** @type {import('../index.js').TestCases} */ ({
           extraParams: true,
         },
       ],
+      output: `
+          /**
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @param foo
+           * @param extra
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 4,
+          message: '@param "extra" does not match an existing function parameter.',
+          suggestions: [
+            {
+              desc: 'Remove the extra @param "extra".',
+              output: `
+          /**
+           * @param foo
+           */
+          function quux (foo) {
+
+          }
+      `,
+            },
+          ],
+        },
+      ],
       output: null,
     },
     {
@@ -149,6 +187,43 @@ export default /** @type {import('../index.js').TestCases} */ ({
       options: [
         {
           badParamNames: true,
+        },
+      ],
+      output: `
+          /**
+           * @param {string} foo - A value.
+           */
+          function quux (foo) {
+
+          }
+      `,
+    },
+    {
+      code: `
+          /**
+           * @param {string} bar - A value.
+           */
+          function quux (foo) {
+
+          }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @param names to be "foo". Got "bar".',
+          suggestions: [
+            {
+              desc: 'Rename @param "bar" to "foo".',
+              output: `
+          /**
+           * @param {string} foo - A value.
+           */
+          function quux (foo) {
+
+          }
+      `,
+            },
+          ],
         },
       ],
       output: null,
@@ -190,6 +265,7 @@ export default /** @type {import('../index.js').TestCases} */ ({
         {
           line: 3,
           message: 'Expected @param names to be "foo". Got "Foo".',
+          suggestions: 1,
         },
       ],
     },
@@ -206,6 +282,7 @@ export default /** @type {import('../index.js').TestCases} */ ({
         {
           line: 3,
           message: 'Expected @arg names to be "foo". Got "Foo".',
+          suggestions: 1,
         },
       ],
       settings: {
@@ -229,6 +306,7 @@ export default /** @type {import('../index.js').TestCases} */ ({
         {
           line: 3,
           message: 'Expected @param names to be "foo". Got "Foo".',
+          suggestions: 1,
         },
       ],
     },
@@ -351,6 +429,7 @@ export default /** @type {import('../index.js').TestCases} */ ({
           line: 4,
           message:
             '@param "bar" does not match an existing function parameter.',
+          suggestions: 1,
         },
       ],
     },
@@ -707,6 +786,7 @@ export default /** @type {import('../index.js').TestCases} */ ({
         {
           line: 4,
           message: 'Expected @param names to be "property". Got "prop".',
+          suggestions: 1,
         },
       ],
       languageOptions: {
@@ -832,6 +912,7 @@ export default /** @type {import('../index.js').TestCases} */ ({
           line: 4,
           message:
             'Expected @param names to be "error, cde". Got "error, code".',
+          suggestions: 1,
         },
       ],
     },
@@ -1073,6 +1154,7 @@ export default /** @type {import('../index.js').TestCases} */ ({
         {
           line: 4,
           message: 'Expected @param names to be "root, baz". Got "root, foo".',
+          suggestions: 1,
         },
       ],
       options: [
@@ -1342,6 +1424,7 @@ export default /** @type {import('../index.js').TestCases} */ ({
         {
           line: 3,
           message: 'Expected @param names to be "bar". Got "barr".',
+          suggestions: 1,
         },
       ],
       languageOptions: {
@@ -1361,6 +1444,7 @@ export default /** @type {import('../index.js').TestCases} */ ({
         {
           line: 3,
           message: 'Expected @param names to be "bar, foo". Got "foo".',
+          suggestions: 1,
         },
       ],
       options: [
@@ -1381,6 +1465,7 @@ export default /** @type {import('../index.js').TestCases} */ ({
         {
           line: 3,
           message: 'Expected @param names to be "bar, baz". Got "foo".',
+          suggestions: 1,
         },
       ],
       options: [
@@ -1423,6 +1508,7 @@ export default /** @type {import('../index.js').TestCases} */ ({
         {
           line: 4,
           message: '@param "bar" does not match an existing function parameter.',
+          suggestions: 1,
         },
       ],
       options: [
@@ -1444,6 +1530,7 @@ export default /** @type {import('../index.js').TestCases} */ ({
         {
           line: 4,
           message: 'Expected @param names to be "paramB". Got "paramA".',
+          suggestions: 1,
         },
       ],
       languageOptions: {
@@ -1464,6 +1551,7 @@ export default /** @type {import('../index.js').TestCases} */ ({
         {
           line: 4,
           message: 'Expected @param names to be "key, ...params". Got "params".',
+          suggestions: 1,
         },
       ],
       languageOptions: {
@@ -1503,10 +1591,12 @@ export default /** @type {import('../index.js').TestCases} */ ({
         {
           line: 3,
           message: 'Expected @param names to be "name1". Got "wrongNameA".',
+          suggestions: 1,
         },
         {
           line: 5,
           message: 'Expected @param names to be "name2". Got "wrongNameB".',
+          suggestions: 1,
         },
       ],
       languageOptions: {


### PR DESCRIPTION
`check-param-names` reports out-of-order flat `@param` names as a general name mismatch and cannot put their whole blocks in signature order. Following [brettz9's confirmed direction](https://github.com/gajus/eslint-plugin-jsdoc/issues/47#issuecomment-5071725925), this distinguishes the order case and, with `enableFixer`, reorders whole non-nested tag blocks while preserving multiline descriptions and trailing text attached to the last tag; destructured and nested parameters remain report-only in this first pass. `badParamOrder` and `duplicateParams` default to `true` and can disable their reports individually, while `extraParams` and `badParamNames` default to `false` and opt into removal and rename suggestions instead of automatic fixes. Suggestion support is new to the shared JSDoc reporter; when the two opt-in options are off, the existing reports stay unchanged. Fixes #47
