### PR TITLE
feat(normalize-see-links): autofix delimiter-colliding labels via escape round-trip

### DIFF
--- a/.README/rules/normalize-see-links.md
+++ b/.README/rules/normalize-see-links.md
@@ -22,9 +22,6 @@ For prefix form, the fixer escapes `]` in the label:
 /** @see [A\]B]{@link https://example.com} */
 ```
 
-This behavior relies on `@es-joy/jsdoccomment` 0.89.0 or later, which
-round-trips context-specific escaped label delimiters.
-
 ## Options
 
 {"gitdown": "options"}

--- a/.README/rules/normalize-see-links.md
+++ b/.README/rules/normalize-see-links.md
@@ -7,6 +7,24 @@ only a lowercase `http:` or `https:` URL in a plain, no-label `{@link}` tag.
 This option defaults to `false`, and its output is independent of
 `canonicalForm` because there is no label to position.
 
+Labels that contain the destination form's closing delimiter are fixable. For
+pipe form, the fixer escapes `}` in the label:
+
+```js
+/** @see [See {options}](https://example.com/api) */
+/** @see {@link https://example.com/api|See {options\}} */
+```
+
+For prefix form, the fixer escapes `]` in the label:
+
+```js
+/** @see {@link https://example.com|A]B} */
+/** @see [A\]B]{@link https://example.com} */
+```
+
+This behavior relies on `@es-joy/jsdoccomment` 0.89.0 or later, which
+round-trips context-specific escaped label delimiters.
+
 ## Options
 
 {"gitdown": "options"}

--- a/docs/rules/normalize-see-links.md
+++ b/docs/rules/normalize-see-links.md
@@ -9,6 +9,24 @@ only a lowercase `http:` or `https:` URL in a plain, no-label `{@link}` tag.
 This option defaults to `false`, and its output is independent of
 `canonicalForm` because there is no label to position.
 
+Labels that contain the destination form's closing delimiter are fixable. For
+pipe form, the fixer escapes `}` in the label:
+
+```js
+/** @see [See {options}](https://example.com/api) */
+/** @see {@link https://example.com/api|See {options\}} */
+```
+
+For prefix form, the fixer escapes `]` in the label:
+
+```js
+/** @see {@link https://example.com|A]B} */
+/** @see [A\]B]{@link https://example.com} */
+```
+
+This behavior relies on `@es-joy/jsdoccomment` 0.89.0 or later, which
+round-trips context-specific escaped label delimiters.
+
 <a name="user-content-normalize-see-links-options"></a>
 <a name="normalize-see-links-options"></a>
 ## Options
@@ -57,12 +75,23 @@ The following patterns are considered problems:
 /**
  * @see [See {options}](https://example.com/api)
  */
-// Message: @see link cannot be safely normalized.
+// Message: Expected @see link to use the pipe form.
 
 /**
  * @see [a}b](https://example.com)
  */
-// Message: @see link cannot be safely normalized.
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [a\}b](https://example.com)
+ */
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [A\]B](https://example.com)
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+// Message: Expected @see link to use the prefix form.
 
 /**
  * @see [Foo](https://example.com/a|b)
@@ -79,7 +108,7 @@ The following patterns are considered problems:
  * @see {@link https://example.com|A]B}
  */
 // "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
-// Message: @see link cannot be safely normalized.
+// Message: Expected @see link to use the prefix form.
 
 /**
  * @see [ ]{@link https://example.com}
@@ -137,19 +166,41 @@ The following patterns are considered problems:
 // Message: Expected @see link to use the prefix form.
 
 /**
- * @see [a\}b](https://example.com)
+ * @see {@link https://example.com|a\}b}
  */
-// Message: @see link cannot be safely normalized.
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+// Message: Expected @see link to use the prefix form.
+
+/**
+ * @see [A\]B]{@link https://example.com}
+ */
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see {@link https://example.com|A]B\}C}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+// Message: Expected @see link to use the prefix form.
+
+/**
+ * @see [A}B\]C]{@link https://example.com}
+ */
+// Message: Expected @see link to use the pipe form.
+
+/**
+ * @see [Trailing\\](https://example.com)
+ */
+// Message: Expected @see link to use the pipe form.
 
 /**
  * @see [See {{one} and {two}}](https://example.com)
  */
-// Message: @see link cannot be safely normalized.
+// Message: Expected @see link to use the pipe form.
 
 /**
  * @see [A}B|C](https://example.com)
  */
-// Message: @see link cannot be safely normalized.
+// Message: Expected @see link to use the pipe form.
 
 /**
  * @see [Read the guide](https://example.com/read)
@@ -321,7 +372,7 @@ const value: string = 'value';
  * @see [See {options}](https://example.com/labeled)
  */
 // "jsdoc/normalize-see-links": ["error"|"warn", {"wrapBareUrls":true}]
-// Message: @see link cannot be safely normalized.
+// Message: Expected @see link to use the pipe form.
 
 /**
  * @see [No fix](https://example.com/labeled)
@@ -360,6 +411,32 @@ const value: string = 'value';
 The following patterns are not considered problems:
 
 ````ts
+/**
+ * @see {@link https://example.com/api|See {options\}}
+ */
+
+/**
+ * @see [A\]B]{@link https://example.com}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+
+/**
+ * @see [A\]B}C]{@link https://example.com}
+ */
+// "jsdoc/normalize-see-links": ["error"|"warn", {"canonicalForm":"prefix"}]
+
+/**
+ * @see {@link https://example.com|A\}B]C}
+ */
+
+/**
+ * @see {@link https://example.com|Trailing\\}
+ */
+
+/**
+ * @see {@link https://example.com|See {{one\} and {two\}\}}
+ */
+
 /**
  * @see {@link https://api.example.com/v1?ids=1%7C2%7C3|Docs}
  */

--- a/docs/rules/normalize-see-links.md
+++ b/docs/rules/normalize-see-links.md
@@ -24,9 +24,6 @@ For prefix form, the fixer escapes `]` in the label:
 /** @see [A\]B]{@link https://example.com} */
 ```
 
-This behavior relies on `@es-joy/jsdoccomment` 0.89.0 or later, which
-round-trips context-specific escaped label delimiters.
-
 <a name="user-content-normalize-see-links-options"></a>
 <a name="normalize-see-links-options"></a>
 ## Options

--- a/src/rules/normalizeSeeLinks.js
+++ b/src/rules/normalizeSeeLinks.js
@@ -1,8 +1,8 @@
 import iterateJsdoc from '../iterateJsdoc.js';
 
-const markdownLinkRegex = /(?<!\\)\[([^`\]\r\n]+)\]\(([^`\(\)\s]+)\)/gv;
-const prefixLinkRegex = /(?<!\\)\[([^\]\r\n]+)\]\{@link\s+([^\}\s\|]+)\}/gv;
-const pipeLinkRegex = /\{@link\s+([^\}\s\|]+)\s*\|\s*([^\}\r\n]+)\}/gv;
+const markdownLinkRegex = /(?<!\\)\[((?:[^\\`\]\r\n]|\\[^\r\n])+)\]\(([^`\(\)\s]+)\)/gv;
+const prefixLinkRegex = /(?<!\\)\[((?:[^\\\]\r\n]|\\[^\r\n])+)\]\{@link\s+([^\}\s\|]+)\}/gv;
+const pipeLinkRegex = /\{@link\s+([^\}\s\|]+)\s*\|\s*((?:[^\\\}\r\n]|\\[^\r\n])+)\}/gv;
 
 const markdownLinkAttemptRegex = /(?<!\\)\[[^\]\r\n]*\]\([^\r\n]*(?:\)|$)/v;
 const prefixLinkAttemptRegex = /(?<!\\)\[[^\]\r\n]*\]\{@link[^\}\r\n]*(?:\}|$)/v;
@@ -13,20 +13,33 @@ const markdownCodeSpanRegex = /(?<!\\)(`+)(?!`)[\s\S]*?(?<!`)\1(?!`)/gv;
 const bareHttpUrlRegex = /^https?:\S+$/v;
 
 /**
- * @param {'pipe'|'prefix'} canonicalForm
  * @param {string} label
  * @returns {boolean}
  */
-const cannotSafelyFormatLink = (canonicalForm, label) => {
-  if (!label.trim()) {
-    return true;
-  }
+const cannotSafelyFormatLink = (label) => {
+  return !label.trim();
+};
 
-  if (canonicalForm === 'pipe') {
-    return label.includes('}');
-  }
+/**
+ * @param {'pipe'|'prefix'} canonicalForm
+ * @param {string} label
+ * @param {'markdown'|'pipe'|'prefix'} sourceForm
+ * @returns {string}
+ */
+const escapeLinkLabel = (canonicalForm, label, sourceForm) => {
+  const sourceEscapePattern = sourceForm === 'pipe' ?
+    /\\([\\\}])/gv :
+    (sourceForm === 'prefix' ?
+      /\\([\\\]])/gv :
+      /\\([\\\}\]])/gv);
+  const targetEscapePattern = canonicalForm === 'pipe' ?
+    /\\(?=$|[\\\}])|\}/gv :
+    /\\(?=$|[\\\]])|\]/gv;
+  const decodedLabel = label.trim().replaceAll(sourceEscapePattern, '$1');
 
-  return label.includes(']');
+  return decodedLabel.replaceAll(targetEscapePattern, (character) => {
+    return `\\${character}`;
+  });
 };
 
 /**
@@ -95,15 +108,17 @@ const isInsideMarkdownCodeSpan = (description, index) => {
 /**
  * @param {'pipe'|'prefix'} canonicalForm
  * @param {string} label
+ * @param {'markdown'|'pipe'|'prefix'} sourceForm
  * @param {string} target
  * @returns {string}
  */
-const formatLink = (canonicalForm, label, target) => {
+const formatLink = (canonicalForm, label, sourceForm, target) => {
   const encodedTarget = encodeLinkTarget(target);
+  const escapedLabel = escapeLinkLabel(canonicalForm, label, sourceForm);
 
   return canonicalForm === 'pipe' ?
-    `{@link ${encodedTarget}|${label.trim()}}` :
-    `[${label.trim()}]{@link ${encodedTarget}}`;
+    `{@link ${encodedTarget}|${escapedLabel}}` :
+    `[${escapedLabel}]{@link ${encodedTarget}}`;
 };
 
 /**
@@ -115,7 +130,7 @@ const normalizeDescription = (description, canonicalForm) => {
   const markdownNormalized = description.replaceAll(
     new RegExp(markdownLinkRegex, 'gv'),
     (_match, label, target) => {
-      return formatLink(canonicalForm, label, target);
+      return formatLink(canonicalForm, label, 'markdown', target);
     },
   );
 
@@ -123,7 +138,7 @@ const normalizeDescription = (description, canonicalForm) => {
     return markdownNormalized.replaceAll(
       new RegExp(prefixLinkRegex, 'gv'),
       (_match, label, target) => {
-        return formatLink(canonicalForm, label, target);
+        return formatLink(canonicalForm, label, 'prefix', target);
       },
     );
   }
@@ -131,7 +146,7 @@ const normalizeDescription = (description, canonicalForm) => {
   return markdownNormalized.replaceAll(
     new RegExp(pipeLinkRegex, 'gv'),
     (_match, target, label) => {
-      return formatLink(canonicalForm, label, target);
+      return formatLink(canonicalForm, label, 'pipe', target);
     },
   );
 };
@@ -183,7 +198,7 @@ export default iterateJsdoc(({
       if (
         isInsideMarkdownCodeSpan(rawDescription, match.index) ||
         scopedPackageNameRegex.test(target) ||
-        cannotSafelyFormatLink(canonicalForm, label)
+        cannotSafelyFormatLink(label)
       ) {
         hasAmbiguousLink = true;
       } else {
@@ -201,10 +216,7 @@ export default iterateJsdoc(({
         continue;
       }
 
-      if (cannotSafelyFormatLink(
-        canonicalForm,
-        inlineTag.text,
-      )) {
+      if (cannotSafelyFormatLink(inlineTag.text)) {
         hasAmbiguousLink = true;
         continue;
       }

--- a/test/rules/assertions/normalizeSeeLinks.js
+++ b/test/rules/assertions/normalizeSeeLinks.js
@@ -22,7 +22,7 @@ export default {
          */
       `,
     },
-    // `\}` truncates pipe-label text in @es-joy/jsdoccomment.
+    // jsdoccomment 0.89 and later round-trip an escaped pipe-label delimiter.
     {
       code: `
         /**
@@ -32,12 +32,16 @@ export default {
       errors: [
         {
           line: 3,
-          message: '@see link cannot be safely normalized.',
+          message: 'Expected @see link to use the pipe form.',
         },
       ],
-      output: null,
+      name: 'escapes a closing brace when emitting a pipe label',
+      output: `
+        /**
+         * @see {@link https://example.com/api|See {options\\}}
+         */
+      `,
     },
-    // `\}` truncates pipe-label text in @es-joy/jsdoccomment.
     {
       code: `
         /**
@@ -47,10 +51,58 @@ export default {
       errors: [
         {
           line: 3,
-          message: '@see link cannot be safely normalized.',
+          message: 'Expected @see link to use the pipe form.',
         },
       ],
-      output: null,
+      name: 'escapes a closing brace in the middle of a pipe label',
+      output: `
+        /**
+         * @see {@link https://example.com|a\\}b}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [a\\}b](https://example.com)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      name: 'normalizes a pre-escaped markdown label without double escaping',
+      output: `
+        /**
+         * @see {@link https://example.com|a\\}b}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [A\\]B](https://example.com)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the prefix form.',
+        },
+      ],
+      name: 'normalizes a pre-escaped markdown prefix label without double escaping',
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+      output: `
+        /**
+         * @see [A\\]B]{@link https://example.com}
+         */
+      `,
     },
     {
       code: `
@@ -90,7 +142,7 @@ export default {
       ],
       output: null,
     },
-    // `\]` prevents prefix-form parsing in @es-joy/jsdoccomment.
+    // jsdoccomment 0.89 and later round-trip an escaped prefix-label delimiter.
     {
       code: `
         /**
@@ -100,15 +152,20 @@ export default {
       errors: [
         {
           line: 3,
-          message: '@see link cannot be safely normalized.',
+          message: 'Expected @see link to use the prefix form.',
         },
       ],
+      name: 'escapes a closing bracket when emitting a prefix label',
       options: [
         {
           canonicalForm: 'prefix',
         },
       ],
-      output: null,
+      output: `
+        /**
+         * @see [A\\]B]{@link https://example.com}
+         */
+      `,
     },
     // A blank label has no intended text the fixer can preserve.
     {
@@ -312,22 +369,111 @@ export default {
          */
       `,
     },
-    // An existing `\}` still truncates pipe-label text in the parser.
     {
       code: `
         /**
-         * @see [a\\}b](https://example.com)
+         * @see {@link https://example.com|a\\}b}
          */
       `,
       errors: [
         {
           line: 3,
-          message: '@see link cannot be safely normalized.',
+          message: 'Expected @see link to use the prefix form.',
         },
       ],
-      output: null,
+      name: 're-emits a pre-escaped pipe label without double escaping',
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+      output: `
+        /**
+         * @see [a}b]{@link https://example.com}
+         */
+      `,
     },
-    // Nested and repeated braces still contain an unparseable pipe-label `}`.
+    {
+      code: `
+        /**
+         * @see [A\\]B]{@link https://example.com}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      name: 're-emits a pre-escaped prefix label without double escaping',
+      output: `
+        /**
+         * @see {@link https://example.com|A]B}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com|A]B\\}C}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the prefix form.',
+        },
+      ],
+      name: 're-escapes a mixed delimiter label for prefix form',
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+      output: `
+        /**
+         * @see [A\\]B}C]{@link https://example.com}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [A}B\\]C]{@link https://example.com}
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      name: 're-escapes a mixed delimiter label for pipe form',
+      output: `
+        /**
+         * @see {@link https://example.com|A\\}B]C}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [Trailing\\\\](https://example.com)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      name: 'escapes a label ending in a lone backslash',
+      output: `
+        /**
+         * @see {@link https://example.com|Trailing\\\\}
+         */
+      `,
+    },
     {
       code: `
         /**
@@ -337,12 +483,16 @@ export default {
       errors: [
         {
           line: 3,
-          message: '@see link cannot be safely normalized.',
+          message: 'Expected @see link to use the pipe form.',
         },
       ],
-      output: null,
+      name: 'escapes each closing brace in a nested pipe label',
+      output: `
+        /**
+         * @see {@link https://example.com|See {{one\\} and {two\\}\\}}
+         */
+      `,
     },
-    // The extra pipe is safe, but the closing brace still truncates the label.
     {
       code: `
         /**
@@ -352,10 +502,15 @@ export default {
       errors: [
         {
           line: 3,
-          message: '@see link cannot be safely normalized.',
+          message: 'Expected @see link to use the pipe form.',
         },
       ],
-      output: null,
+      name: 'preserves an extra pipe while escaping a closing brace',
+      output: `
+        /**
+         * @see {@link https://example.com|A\\}B|C}
+         */
+      `,
     },
     {
       code: `
@@ -946,7 +1101,7 @@ export default {
          */
       `,
     },
-    // wrapBareUrls: labeled-link collision remains report-only when enabled.
+    // wrapBareUrls does not alter delimiter-collision escaping.
     {
       code: `
         /**
@@ -956,15 +1111,20 @@ export default {
       errors: [
         {
           line: 3,
-          message: '@see link cannot be safely normalized.',
+          message: 'Expected @see link to use the pipe form.',
         },
       ],
+      name: 'escapes a colliding label when bare URL wrapping is enabled',
       options: [
         {
           wrapBareUrls: true,
         },
       ],
-      output: null,
+      output: `
+        /**
+         * @see {@link https://example.com/labeled|See {options\\}}
+         */
+      `,
     },
     // wrapBareUrls: labeled enableFixer behavior is unchanged when enabled.
     {
@@ -1092,6 +1252,64 @@ export default {
     },
   ],
   valid: [
+    {
+      code: `
+        /**
+         * @see {@link https://example.com/api|See {options\\}}
+         */
+      `,
+      name: 'accepts a fixed pipe label with an escaped closing brace',
+    },
+    {
+      code: `
+        /**
+         * @see [A\\]B]{@link https://example.com}
+         */
+      `,
+      name: 'accepts a fixed prefix label with an escaped closing bracket',
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+    },
+    {
+      code: `
+        /**
+         * @see [A\\]B}C]{@link https://example.com}
+         */
+      `,
+      name: 'accepts a mixed delimiter label fixed to prefix form',
+      options: [
+        {
+          canonicalForm: 'prefix',
+        },
+      ],
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com|A\\}B]C}
+         */
+      `,
+      name: 'accepts a mixed delimiter label fixed to pipe form',
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com|Trailing\\\\}
+         */
+      `,
+      name: 'accepts a fixed label ending in a lone backslash',
+    },
+    {
+      code: `
+        /**
+         * @see {@link https://example.com|See {{one\\} and {two\\}\\}}
+         */
+      `,
+      name: 'accepts a fixed pipe label with repeated escaped braces',
+    },
     {
       code: `
         /**


### PR DESCRIPTION
Follow-up to #1725, which kept delimiter-colliding labels report-only because jsdoccomment 0.88.0 could not round-trip `\}` in pipe labels or `\]` in prefix labels. es-joy/jsdoccomment#26 (shipped in 0.89.0; this repo is on 0.90.0) made escaped inline-tag text round-trip, so the fixer now emits those labels with minimal escaping instead of only reporting: source-form escapes are decoded first, then the destination form escapes its own closing delimiter, and a backslash is doubled only where it would otherwise merge with a following backslash, the delimiter, or the end of the label. Pre-escaped labels normalize without double escaping, and the new fixtures assert fixpoint behavior (a second pass fixes and reports nothing) across pipe, prefix, mixed-delimiter, and trailing-backslash cases. Empty labels, space-format tags, code-span content, scoped-package targets, and malformed attempts keep their existing report-only behavior.
