### PR TITLE
fix(normalize-see-links): minimally escape link targets instead of encodeURI

### DIFF
--- a/src/rules/normalizeSeeLinks.js
+++ b/src/rules/normalizeSeeLinks.js
@@ -47,7 +47,11 @@ const escapeLinkLabel = (canonicalForm, label, sourceForm) => {
  * @returns {string}
  */
 const encodeLinkTarget = (target) => {
-  return encodeURI(target).replaceAll(/%25(?=[\dA-F]{2})/giv, '%');
+  return target
+    .replaceAll(/%(?![\dA-F]{2})/giv, '%25')
+    .replaceAll('|', '%7C')
+    .replaceAll('{', '%7B')
+    .replaceAll('}', '%7D');
 };
 
 /**

--- a/test/rules/assertions/normalizeSeeLinks.js
+++ b/test/rules/assertions/normalizeSeeLinks.js
@@ -22,6 +22,46 @@ export default {
          */
       `,
     },
+    {
+      code: `
+        /**
+         * @see [Unicode](https://example.com/päth)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      ignoreReadme: true,
+      name: 'preserves non-ASCII characters in link targets',
+      output: `
+        /**
+         * @see {@link https://example.com/päth|Unicode}
+         */
+      `,
+    },
+    {
+      code: `
+        /**
+         * @see [Caret](https://example.com/a^b)
+         */
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Expected @see link to use the pipe form.',
+        },
+      ],
+      ignoreReadme: true,
+      name: 'preserves encodeURI-only ASCII characters in link targets',
+      output: `
+        /**
+         * @see {@link https://example.com/a^b|Caret}
+         */
+      `,
+    },
     // jsdoccomment 0.89 and later round-trip an escaped pipe-label delimiter.
     {
       code: `


### PR DESCRIPTION
Implements your suggestion in [#1734 (comment)](https://github.com/gajus/eslint-plugin-jsdoc/pull/1734#issuecomment-5082670960): `encodeLinkTarget` now applies only the four fixed mappings — unescaped `%` → `%25` (existing `%XX` escapes preserved as-is, case-insensitive), `|` → `%7C`, `{` → `%7B`, `}` → `%7D` — instead of `encodeURI`, so characters that never collide with `{@link}` parsing (non-ASCII, `^`, `"`, …) stay readable in autofixed targets.

The unescaped-`%` pass runs before the delimiter mappings, so the `%` introduced by `%7C`/`%7B`/`%7D` is never re-escaped.

All existing delimiter and percent-preservation assertions pass unchanged; two new cases pin the delta (literal `ä` and `^` preserved through the autofix). Full suite 3282 passing at 100% coverage; `check-docs` clean — no generated-doc changes.