### PR TITLE
fix: type the tsdoc config names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -89,9 +89,11 @@ import semver from 'semver';
  * @typedef {"recommended" | "stylistic" | "contents" | "logical" | "requirements"} ConfigGroups
  * @typedef {"" | "-typescript" | "-typescript-flavor"} ConfigVariants
  * @typedef {"" | "-error"} ErrorLevelVariants
+ * @typedef {`flat/${ConfigGroups}${ConfigVariants}${ErrorLevelVariants}` |
+ *   "flat/recommended-tsdoc" | "flat/recommended-tsdoc-error"} FlatConfigNames
  * @type {import('eslint').ESLint.Plugin & {
  *   configs: Record<
- *       `flat/${ConfigGroups}${ConfigVariants}${ErrorLevelVariants}`,
+ *       FlatConfigNames,
  *       import('eslint').Linter.Config
  *     > &
  *     Record<
@@ -766,7 +768,7 @@ export default index;
 /**
  * @type {((
  *   cfg?: import('eslint').Linter.Config & {
- *     config?: `flat/${ConfigGroups}${ConfigVariants}${ErrorLevelVariants}`,
+ *     config?: FlatConfigNames,
  *     mergeSettings?: boolean,
  *     settings?: Partial<import('./iterateJsdoc.js').Settings>,
  *     rules?: {[key in keyof import('./rules.d.ts').Rules]?: import('eslint').Linter.RuleEntry<import('./rules.d.ts').Rules[key]>},


### PR DESCRIPTION
## Problem

`flat/recommended-tsdoc` and `flat/recommended-tsdoc-error` are assigned at runtime:

```js
// src/index.js
index.configs['flat/recommended-tsdoc'] = createRecommendedTsDocRuleset('warn', 'flat/recommended-tsdoc');
index.configs['flat/recommended-tsdoc-error'] = createRecommendedTsDocRuleset('error', 'flat/recommended-tsdoc-error');
```

…but no type expresses them. Both the `configs` record and the `jsdoc()` helper's `config` option are typed as `` `flat/${ConfigGroups}${ConfigVariants}${ErrorLevelVariants}` ``, and `ConfigVariants` is `'' | '-typescript' | '-typescript-flavor'` — no `-tsdoc`.

So this fails to typecheck although it works at runtime:

```ts
import { jsdoc } from 'eslint-plugin-jsdoc'

export default [
  jsdoc({ config: 'flat/recommended-tsdoc-error' }),
  //             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  // TS2820: Type '"flat/recommended-tsdoc-error"' is not assignable to type
  // '"flat/contents" | … | undefined'. Did you mean '"flat/recommended-error"'?
]
```

Reading `index.configs['flat/recommended-tsdoc']` in a typed context fails the same way.

Reproduced on 63.2.1 and on current `main`.

## Fix

Adds the two names via a new `FlatConfigNames` typedef, used at both sites.

I chose that over adding `-tsdoc` to `ConfigVariants` for two reasons:

1. **`-tsdoc` only ever combines with `recommended`.** Putting it in `ConfigVariants` would additionally claim eight configs that do not exist — `flat/stylistic-tsdoc`, `flat/contents-tsdoc-error`, `flat/logical-tsdoc`, and so on.
2. **It matches the existing idiom.** `flat/recommended-mixed` is already named explicitly two lines below, for the same reason (it is also outside the group×variant grid, and is a `Config[]`).

The typedef also removes an existing duplication: the template literal was previously spelled out at both use sites.

```diff
+ * @typedef {`flat/${ConfigGroups}${ConfigVariants}${ErrorLevelVariants}` |
+ *   "flat/recommended-tsdoc" | "flat/recommended-tsdoc-error"} FlatConfigNames
```

## Scope

Types only — no runtime change, and no existing config name changes meaning.

The non-`flat/` aliases (`recommended-tsdoc`, `recommended-tsdoc-error`, set at `src/index.js:576-577`) stay untyped, but so does the whole non-`flat/` family today, so widening that is a separate concern and I kept this focused.

## Verification

- `tsc` reports **114** errors on `main` and **114** with this change — identical, all pre-existing and confined to `test/` (missing test-runner globals). `src/` is clean before and after.
- `eslint src/index.js` passes.
- Built the declarations with `tsc -p tsconfig-prod.json`, dropped the resulting `dist/index.d.ts` into a real project that calls `jsdoc({ config: 'flat/recommended-tsdoc-error', … })`: **1 error before, 0 after**.