### PR TITLE
fix(`no-unnecessary-type-assertion`): avoid multiple warnings when typescript-eslint is not referenced

### DIFF
--- a/.README/rules/no-unnecessary-type-assertion.md
+++ b/.README/rules/no-unnecessary-type-assertion.md
@@ -6,9 +6,9 @@ TypeScript infers for the expression.
 
 Currently only supports `VariableDeclaration`.
 
-**Note that this rule requires that the `typescript` package is installed. You must
-also install and point to the `typescript-eslint` parser, targeting your JavaScript +
-JSDoc files.**
+**Note that this experimental rule requires that the `typescript` package is installed.
+You must also install and point to the `typescript-eslint` parser, targeting your
+JavaScript + JSDoc files. Note also that this rule runs fairly slowly.**
 
 ```js
 // eslint.config.js
@@ -24,7 +24,7 @@ export default [
       parserOptions: {
         projectService: {
           allowDefaultProject: [
-            '**/*.js',
+            '*.js',
           ],
         },
         tsconfigRootDir: import.meta.dirname,

--- a/docs/rules/no-unnecessary-type-assertion.md
+++ b/docs/rules/no-unnecessary-type-assertion.md
@@ -8,9 +8,9 @@ TypeScript infers for the expression.
 
 Currently only supports `VariableDeclaration`.
 
-**Note that this rule requires that the `typescript` package is installed. You must
-also install and point to the `typescript-eslint` parser, targeting your JavaScript +
-JSDoc files.**
+**Note that this experimental rule requires that the `typescript` package is installed.
+You must also install and point to the `typescript-eslint` parser, targeting your
+JavaScript + JSDoc files. Note also that this rule runs fairly slowly.**
 
 ```js
 // eslint.config.js
@@ -26,7 +26,7 @@ export default [
       parserOptions: {
         projectService: {
           allowDefaultProject: [
-            '**/*.js',
+            '*.js',
           ],
         },
         tsconfigRootDir: import.meta.dirname,

--- a/src/rules/noUnnecessaryTypeAssertion.js
+++ b/src/rules/noUnnecessaryTypeAssertion.js
@@ -4,6 +4,8 @@ import {
   createRequire,
 } from 'module';
 
+let warned = false;
+
 /** @type {any} */
 let ts;
 
@@ -94,11 +96,15 @@ export default iterateJsdoc(({
      * @type {import('@typescript-eslint/utils').ParserServices}
      */ (context.sourceCode.parserServices);
 
-  /* c8 ignore next 6 -- Guard */
+  /* c8 ignore next 10 -- Guard */
   if (!services || !services.program) {
-    // Cannot proceed without type-aware linting enabled
-    // eslint-disable-next-line no-console -- Feedback
-    console.warn('⚠️ You must point ESLint to the `typescript-eslint` parser using `languageOptions`. See the documentation for `jsdoc/no-unnecessary-type-assertion`.');
+    if (!warned) {
+      // Cannot proceed without type-aware linting enabled
+      // eslint-disable-next-line no-console -- Feedback
+      console.warn('⚠️ You must point ESLint to the `typescript-eslint` parser using `languageOptions`. See the documentation for `jsdoc/no-unnecessary-type-assertion`.');
+      warned = true;
+    }
+
     return;
   }
 


### PR DESCRIPTION
fix(`no-unnecessary-type-assertion`): avoid multiple warnings when typescript-eslint is not referenced

Also:
- docs: correct `allowDefaultProject` usage and refer to experimental, potentially slow nature of the rule