### PR TITLE
fix(`convert-to-jsdoc-comments`): handle "any" context and avoid extra line break when there is already multiline text

### DIFF
--- a/docs/rules/convert-to-jsdoc-comments.md
+++ b/docs/rules/convert-to-jsdoc-comments.md
@@ -216,6 +216,15 @@ class TestClass {
 var a = []; // Test comment
 // "jsdoc/convert-to-jsdoc-comments": ["error"|"warn", {"contextsBeforeAndAfter":["VariableDeclarator"]}]
 // Message: Line comments should be JSDoc-style.
+
+/*
+ * Seniority levels that participate in distribution, in display
+ * order. `custom` is never a real distribution key. Every test shown in this
+ * modal can recruit each of these levels, so all three are always editable.
+ */
+const SENIORITY_ORDER = ['senior', 'middle', 'specialist'];
+// "jsdoc/convert-to-jsdoc-comments": ["error"|"warn", {"contexts":["any"],"lineOrBlockStyle":"block"}]
+// Message: Block comments should be JSDoc-style.
 ````
 
 

--- a/docs/rules/no-blank-block-descriptions.md
+++ b/docs/rules/no-blank-block-descriptions.md
@@ -48,6 +48,23 @@ function functionWithClearName(x) {}
  */
 function functionWithClearName() {}
 // Message: There should be no extra blank lines in block descriptions not followed by tags.
+
+/**
+ *
+ * Some text
+ * @param {number} x
+ */
+function functionWithClearName(x) {}
+// Message: There should be no blank lines in block descriptions followed by tags.
+
+/**
+ *
+ * Seniority levels that participate in distribution, in display
+ * order. `custom` is never a real distribution key. Every test shown in this
+ * modal can recruit each of these levels, so all three are always editable.
+ */
+const SENIORITY_ORDER = ['senior', 'middle', 'specialist'];
+// Message: There should be no extra blank lines in block descriptions not followed by tags.
 ````
 
 

--- a/src/jsdocUtils.js
+++ b/src/jsdocUtils.js
@@ -1655,9 +1655,10 @@ const enforcedContexts = (context, defaultContexts, settings) => {
  * @param {import('./iterateJsdoc.js').Context[]} contexts
  * @param {import('./iterateJsdoc.js').CheckJsdoc} checkJsdoc
  * @param {import('@es-joy/jsdoccomment').CommentHandler} [handler]
+ * @param {boolean} [convertAny]
  * @returns {import('eslint').Rule.RuleListener}
  */
-const getContextObject = (contexts, checkJsdoc, handler) => {
+const getContextObject = (contexts, checkJsdoc, handler, convertAny) => {
   /** @type {import('eslint').Rule.RuleListener} */
   const properties = {};
 
@@ -1696,11 +1697,16 @@ const getContextObject = (contexts, checkJsdoc, handler) => {
         value = checkJsdoc.bind(null, selInfo, null);
       }
     } else {
+      property = prop;
+
+      if (convertAny && property === 'any') {
+        property = ':not(Program)';
+      }
+
       const selInfo = {
         lastIndex: idx,
-        selector: prop,
+        selector: property,
       };
-      property = prop;
       value = checkJsdoc.bind(null, selInfo, null);
     }
 

--- a/src/rules/convertToJsdocComments.js
+++ b/src/rules/convertToJsdocComments.js
@@ -186,6 +186,31 @@ export default {
     };
 
     /**
+     * Builds the opening portion of the JSDoc comment, i.e. everything before
+     * the closing delimiter.
+     * @param {string} indent
+     * @param {Token} comment
+     * @param {boolean|undefined} inlineCommentBlock
+     * @returns {string}
+     */
+    const getCommentOpening = (indent, comment, inlineCommentBlock) => {
+      if (inlineCommentBlock || enforceJsdocLineStyle === 'single') {
+        return `/** ${comment.value.trim()} `;
+      }
+
+      const body = comment.value.trimEnd();
+
+      // When the comment's text already begins on its own line (e.g. a
+      // multi-line block comment), there is no need for the fixer to add a
+      // leading blank `*` line.
+      if ((/^[ \t]*\n/v).test(body)) {
+        return `/**${body.replace(/^[ \t]+/v, '')}\n${indent}`;
+      }
+
+      return `/**\n${indent}*${body}\n${indent}`;
+    };
+
+    /**
      * @type {import('../iterateJsdoc.js').CheckJsdoc}
      */
     const checkNonJsdoc = (_info, _handler, node) => {
@@ -205,11 +230,7 @@ export default {
 
       /** @type {AddComment} */
       const addComment = (inlineCommentBlock, commentToAdd, indent, lines, fixer) => {
-        const insertion = (
-          inlineCommentBlock || enforceJsdocLineStyle === 'single' ?
-            `/** ${commentToAdd.value.trim()} ` :
-            `/**\n${indent}*${commentToAdd.value.trimEnd()}\n${indent}`
-        ) +
+        const insertion = getCommentOpening(indent, commentToAdd, inlineCommentBlock) +
             `*/${'\n'.repeat((lines || 1) - 1)}`;
 
         return fixer.replaceText(
@@ -242,11 +263,7 @@ export default {
 
       /** @type {AddComment} */
       const addComment = (inlineCommentBlock, commentToAdd, indent, lines, fixer) => {
-        const insertion = (
-          inlineCommentBlock || enforceJsdocLineStyle === 'single' ?
-            `/** ${commentToAdd.value.trim()} ` :
-            `/**\n${indent}*${commentToAdd.value.trimEnd()}\n${indent}`
-        ) +
+        const insertion = getCommentOpening(indent, commentToAdd, inlineCommentBlock) +
             `*/${'\n'.repeat((lines || 1) - 1)}${lines ? `\n${indent.slice(1)}` : ' '}`;
 
         return [
@@ -268,12 +285,16 @@ export default {
       ...getContextObject(
         enforcedContexts(context, true, settings),
         checkNonJsdoc,
+        undefined,
+        true,
       ),
       ...getContextObject(
         contextsAfter,
         (_info, _handler, node) => {
           checkNonJsdocAfter(node, contextsAfter);
         },
+        undefined,
+        true,
       ),
       ...getContextObject(
         contextsBeforeAndAfter,
@@ -283,6 +304,8 @@ export default {
             checkNonJsdocAfter(node, contextsBeforeAndAfter);
           }
         },
+        undefined,
+        true,
       ),
     };
   },

--- a/src/rules/noBlankBlockDescriptions.js
+++ b/src/rules/noBlankBlockDescriptions.js
@@ -1,60 +1,115 @@
 import iterateJsdoc from '../iterateJsdoc.js';
 
-const anyWhitespaceLines = /^\s*$/v;
-const atLeastTwoLinesWhitespace = /^[ \t]*\n[ \t]*\n\s*$/v;
+const anyWhitespaceLine = /^\s*$/v;
 
 export default iterateJsdoc(({
   jsdoc,
   utils,
 }) => {
-  const {
-    description,
-    descriptions,
-    lastDescriptionLine,
-  } = utils.getDescription();
+  const hasTags = Boolean(jsdoc.tags.length);
 
-  const regex = jsdoc.tags.length ?
-    anyWhitespaceLines :
-    atLeastTwoLinesWhitespace;
+  // Gather the block-description lines (those before the first tag or the
+  //   closing delimiter).
+  let startIdx = -1;
 
-  if (descriptions.length && regex.test(description)) {
-    if (jsdoc.tags.length) {
-      utils.reportJSDoc(
-        'There should be no blank lines in block descriptions followed by tags.',
-        {
-          line: lastDescriptionLine,
-        },
-        () => {
-          utils.setBlockDescription(() => {
-            // Remove all lines
-            return [];
-          });
-        },
-      );
-    } else {
-      utils.reportJSDoc(
-        'There should be no extra blank lines in block descriptions not followed by tags.',
-        {
-          line: lastDescriptionLine,
-        },
-        () => {
-          utils.setBlockDescription((info, seedTokens) => {
-            return [
-              // Keep the starting line
-              {
-                number: 0,
-                source: '',
-                tokens: seedTokens({
-                  ...info,
-                  description: '',
-                }),
-              },
-            ];
-          });
-        },
-      );
+  /**
+   * @type {string[]}
+   */
+  const descLines = [];
+  jsdoc.source.some(({
+    tokens: {
+      delimiter,
+      description,
+      end,
+      tag,
+    },
+  }, idx) => {
+    if (delimiter === '/**') {
+      return false;
     }
+
+    if (tag || end) {
+      return true;
+    }
+
+    if (startIdx === -1) {
+      startIdx = idx;
+    }
+
+    descLines.push(description);
+
+    return false;
+  });
+
+  if (!descLines.length) {
+    return;
   }
+
+  let leadingBlankCount = 0;
+  while (
+    leadingBlankCount < descLines.length &&
+    anyWhitespaceLine.test(descLines[leadingBlankCount])
+  ) {
+    leadingBlankCount++;
+  }
+
+  const allBlank = leadingBlankCount === descLines.length;
+
+  /**
+   * Rebuilds the kept description lines after dropping `dropCount` leading
+   *   blank lines.
+   * @param {import('../iterateJsdoc.js').Integer} dropCount
+   * @returns {() => void}
+   */
+  const dropLeadingBlankLines = (dropCount) => {
+    return () => {
+      utils.setBlockDescription((info, seedTokens, descriptions, postDelimiters) => {
+        return descriptions.slice(dropCount).map((description, idx) => {
+          return {
+            number: 0,
+            source: '',
+            tokens: seedTokens({
+              ...info,
+              description,
+              postDelimiter: description ? postDelimiters[idx + dropCount] : '',
+            }),
+          };
+        });
+      });
+    };
+  };
+
+  if (hasTags) {
+    if (!leadingBlankCount) {
+      return;
+    }
+
+    utils.reportJSDoc(
+      'There should be no blank lines in block descriptions followed by tags.',
+      {
+        line: startIdx + leadingBlankCount - 1,
+      },
+      dropLeadingBlankLines(leadingBlankCount),
+    );
+
+    return;
+  }
+
+  // Without tags, only the extra (removable) leading blank lines are a problem;
+  //   a single leading blank line with no following content is allowed.
+  const removeCount = allBlank ? descLines.length - 1 : leadingBlankCount;
+
+  if (removeCount < 1) {
+    return;
+  }
+
+  utils.reportJSDoc(
+    'There should be no extra blank lines in block descriptions not followed by tags.',
+    {
+      line: startIdx + removeCount,
+    },
+    dropLeadingBlankLines(removeCount),
+  );
 }, {
   iterateAllJsdocs: true,
   meta: {

--- a/test/rules/assertions/convertToJsdocComments.js
+++ b/test/rules/assertions/convertToJsdocComments.js
@@ -503,6 +503,38 @@ export default /** @type {import('../index.js').TestCases} */ ({
         var a = []; ` + `
       `,
     },
+    {
+      code: `
+        /*
+         * Seniority levels that participate in distribution, in display
+         * order. \`custom\` is never a real distribution key. Every test shown in this
+         * modal can recruit each of these levels, so all three are always editable.
+         */
+        const SENIORITY_ORDER = ['senior', 'middle', 'specialist'];
+      `,
+      errors: [
+        {
+          line: 2,
+          message: 'Block comments should be JSDoc-style.',
+        },
+      ],
+      options: [
+        {
+          contexts: [
+            'any',
+          ],
+          lineOrBlockStyle: 'block',
+        },
+      ],
+      output: `
+        /**
+         * Seniority levels that participate in distribution, in display
+         * order. \`custom\` is never a real distribution key. Every test shown in this
+         * modal can recruit each of these levels, so all three are always editable.
+         */
+        const SENIORITY_ORDER = ['senior', 'middle', 'specialist'];
+      `,
+    },
   ],
   valid: [
     {

--- a/test/rules/assertions/noBlankBlockDescriptions.js
+++ b/test/rules/assertions/noBlankBlockDescriptions.js
@@ -42,6 +42,54 @@ export default /** @type {import('../index.js').TestCases} */ ({
       function functionWithClearName() {}
       `,
     },
+    {
+      code: `
+      /**
+       *
+       * Some text
+       * @param {number} x
+       */
+      function functionWithClearName(x) {}
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'There should be no blank lines in block descriptions followed by tags.',
+        },
+      ],
+      output: `
+      /**
+       * Some text
+       * @param {number} x
+       */
+      function functionWithClearName(x) {}
+      `,
+    },
+    {
+      code: `
+        /**
+         *
+         * Seniority levels that participate in distribution, in display
+         * order. \`custom\` is never a real distribution key. Every test shown in this
+         * modal can recruit each of these levels, so all three are always editable.
+         */
+        const SENIORITY_ORDER = ['senior', 'middle', 'specialist'];
+      `,
+      errors: [
+        {
+          line: 4,
+          message: 'There should be no extra blank lines in block descriptions not followed by tags.',
+        },
+      ],
+      output: `
+        /**
+         * Seniority levels that participate in distribution, in display
+         * order. \`custom\` is never a real distribution key. Every test shown in this
+         * modal can recruit each of these levels, so all three are always editable.
+         */
+        const SENIORITY_ORDER = ['senior', 'middle', 'specialist'];
+      `,
+    },
   ],
   valid: [
     {


### PR DESCRIPTION
fix(`convert-to-jsdoc-comments`): handle "any" context and avoid extra line break when there is already multiline text; fixes #1747

Also:
- fix(`no-blank-block-descriptions`): strip out initial line breaks when text is present (with or without tags); fixes #1748