### PR TITLE
fix(`require-asterisk-prefix`): avoid crashing on custom languages

### DIFF
--- a/src/iterateJsdoc.js
+++ b/src/iterateJsdoc.js
@@ -2338,6 +2338,13 @@ const iterateAllJsdocs = (iterator, ruleConfig, contexts, additiveCommentContext
         // @ts-expect-error ESLint < 10
         sourceCode = context.getSourceCode(),
       } = context;
+
+      // Custom languages provide their own `SourceCode` implementations.
+      // JSDoc traversal requires the JavaScript token API.
+      if (typeof sourceCode.getTokenBefore !== 'function') {
+        return {};
+      }
+
       settings = getSettings(context);
       if (!settings) {
         return {};

--- a/test/iterateJsdoc.js
+++ b/test/iterateJsdoc.js
@@ -85,6 +85,20 @@ describe('iterateJsdoc', () => {
       });
     });
   });
+  describe('custom language compatibility', () => {
+    it('does not iterate without the JavaScript token API', () => {
+      const rule = iterateJsdoc(() => {}, {
+        iterateAllJsdocs: true,
+        meta: {
+          type: 'suggestion',
+        },
+      });
+
+      expect(rule.create(/** @type {BadArgument} */ ({
+        sourceCode: {},
+      }))).to.deep.equal({});
+    });
+  });
   describe('parseComment', () => {
     context('Parses comments', () => {
       it('parses a comment', () => {


### PR DESCRIPTION
Closes #1754.

Prevents `require-asterisk-prefix` from crashing when it is enabled for a non-JavaScript language such as Markdown.

Native ESLint languages provide their own `SourceCode` implementations. The Markdown implementation does not expose the JavaScript-specific `getTokenBefore()` method, but the shared `iterateAllJsdocs` visitor previously called it for every non-`Program` syntax node.

Because the guard is in the shared `iterateAllJsdocs` path, it also prevents the same underlying failure in other rules that use this traversal mode.