### PR TITLE
fix(`no-undefined-types`): recognize sibling class members from a property's JSDoc

### DIFF
--- a/docs/rules/no-undefined-types.md
+++ b/docs/rules/no-undefined-types.md
@@ -995,6 +995,21 @@ class Foo {
   }
 }
 
+class MyClass {
+  property = true;
+
+  /** xyz {@link property} */
+  otherProperty = false;
+}
+
+class MyClass {
+  property: boolean;
+
+  /** xyz {@link property} and {@link MyClass.property} */
+  otherProperty: boolean;
+}
+// Settings: {"jsdoc":{"mode":"typescript"}}
+
 /* globals SomeGlobal, AnotherGlobal */
 import * as Ably from "ably"
 import Testing, { another as Another, stillMore as StillMore } from "testing"

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -482,8 +482,10 @@ export default iterateJsdoc(({
     .concat(tsModuleVariables)
     .concat(/** @type {string[]} */ (definedPreferredTypes))
     .concat((() => {
-      // Other methods are not in scope, but we need them, and we grab them here
-      if (node?.type === 'MethodDefinition') {
+      // Other class members are not in scope, but we need them (e.g., for a
+      //   sibling property or method referenced by `{@link}`), and we grab
+      //   them here
+      if (node?.type === 'MethodDefinition' || node?.type === 'PropertyDefinition') {
         return /** @type {import('estree').ClassBody} */ (node.parent).body.flatMap((methodOrProp) => {
           if (methodOrProp.type === 'MethodDefinition') {
             // eslint-disable-next-line unicorn/no-lonely-if -- Pattern

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -1739,6 +1739,37 @@ export default /** @type {import('../index.js').TestCases} */ ({
     },
     {
       code: `
+        class MyClass {
+          property = true;
+
+          /** xyz {@link property} */
+          otherProperty = false;
+        }
+      `,
+      languageOptions: {
+        ecmaVersion: 2_022,
+      },
+    },
+    {
+      code: `
+        class MyClass {
+          property: boolean;
+
+          /** xyz {@link property} and {@link MyClass.property} */
+          otherProperty: boolean;
+        }
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      settings: {
+        jsdoc: {
+          mode: 'typescript',
+        },
+      },
+    },
+    {
+      code: `
         /* globals SomeGlobal, AnotherGlobal */
         import * as Ably from "ably"
         import Testing, { another as Another, stillMore as StillMore } from "testing"


### PR DESCRIPTION
fix(`no-undefined-types`): recognize sibling class members from a property's JSDoc

The rule only collected sibling class members (for `{@link}` and other namepath references) when the JSDoc block was attached to a `MethodDefinition`. A block on a class `PropertyDefinition` did not get its siblings, so references like `{@link property}` or `{@link MyClass.property}` were reported as undefined.

Broaden the guard to also handle `PropertyDefinition`; the parent chain is identical, so the existing collection logic applies unchanged.

Fixes #1760