### PR TITLE
fix(`no-undefined-types`): recognize class members from the class's own JSDoc

### DIFF
--- a/docs/rules/no-undefined-types.md
+++ b/docs/rules/no-undefined-types.md
@@ -1010,6 +1010,21 @@ class MyClass {
 }
 // Settings: {"jsdoc":{"mode":"typescript"}}
 
+/** xyz {@link property} */
+class MyClass {
+  property = true;
+}
+
+/** xyz {@link property} and {@link MyClass.property} */
+class MyClass {
+  public property: boolean;
+}
+// Settings: {"jsdoc":{"mode":"typescript"}}
+
+const MyClass = /** xyz {@link property} */ class {
+  property = true;
+};
+
 /* globals SomeGlobal, AnotherGlobal */
 import * as Ably from "ably"
 import Testing, { another as Another, stillMore as StillMore } from "testing"

--- a/src/rules/noUndefinedTypes.js
+++ b/src/rules/noUndefinedTypes.js
@@ -483,32 +483,34 @@ export default iterateJsdoc(({
     .concat(/** @type {string[]} */ (definedPreferredTypes))
     .concat((() => {
       // Other class members are not in scope, but we need them (e.g., for a
-      //   sibling property or method referenced by `{@link}`), and we grab
-      //   them here
+      //   sibling property or method referenced by `{@link}`, or a member
+      //   referenced by `{@link}` from the class's own JSDoc block), and we
+      //   grab them here
+      /** @type {import('estree').ClassBody|undefined} */
+      let classBody;
+      /** @type {string|undefined} */
+      let className;
       if (node?.type === 'MethodDefinition' || node?.type === 'PropertyDefinition') {
-        return /** @type {import('estree').ClassBody} */ (node.parent).body.flatMap((methodOrProp) => {
-          if (methodOrProp.type === 'MethodDefinition') {
-            // eslint-disable-next-line unicorn/no-lonely-if -- Pattern
-            if (methodOrProp.key.type === 'Identifier') {
-              return [
-                methodOrProp.key.name,
-                `${/** @type {import('estree').ClassDeclaration} */ (
-                  node.parent?.parent
-                )?.id?.name}.${methodOrProp.key.name}`,
-              ];
-            }
-          }
+        classBody = /** @type {import('estree').ClassBody} */ (node.parent);
+        className = /** @type {import('estree').ClassDeclaration} */ (
+          node.parent?.parent
+        )?.id?.name;
+      } else if (node?.type === 'ClassDeclaration' || node?.type === 'ClassExpression') {
+        classBody = node.body;
+        className = node.id?.name;
+      }
 
-          if (methodOrProp.type === 'PropertyDefinition') {
-            // eslint-disable-next-line unicorn/no-lonely-if -- Pattern
-            if (methodOrProp.key.type === 'Identifier') {
-              return [
-                methodOrProp.key.name,
-                `${/** @type {import('estree').ClassDeclaration} */ (
-                  node.parent?.parent
-                )?.id?.name}.${methodOrProp.key.name}`,
-              ];
-            }
+      if (classBody) {
+        return classBody.body.flatMap((methodOrProp) => {
+          if (
+            (methodOrProp.type === 'MethodDefinition' ||
+            methodOrProp.type === 'PropertyDefinition') &&
+            methodOrProp.key.type === 'Identifier'
+          ) {
+            return [
+              methodOrProp.key.name,
+              `${className}.${methodOrProp.key.name}`,
+            ];
           }
           /* c8 ignore next 2 -- Not yet built */
 

--- a/test/rules/assertions/noUndefinedTypes.js
+++ b/test/rules/assertions/noUndefinedTypes.js
@@ -1770,6 +1770,43 @@ export default /** @type {import('../index.js').TestCases} */ ({
     },
     {
       code: `
+        /** xyz {@link property} */
+        class MyClass {
+          property = true;
+        }
+      `,
+      languageOptions: {
+        ecmaVersion: 2_022,
+      },
+    },
+    {
+      code: `
+        /** xyz {@link property} and {@link MyClass.property} */
+        class MyClass {
+          public property: boolean;
+        }
+      `,
+      languageOptions: {
+        parser: typescriptEslintParser,
+      },
+      settings: {
+        jsdoc: {
+          mode: 'typescript',
+        },
+      },
+    },
+    {
+      code: `
+        const MyClass = /** xyz {@link property} */ class {
+          property = true;
+        };
+      `,
+      languageOptions: {
+        ecmaVersion: 2_022,
+      },
+    },
+    {
+      code: `
         /* globals SomeGlobal, AnotherGlobal */
         import * as Ably from "ably"
         import Testing, { another as Another, stillMore as StillMore } from "testing"


### PR DESCRIPTION
fix(`no-undefined-types`): recognize class members from the class's own JSDoc

The rule collected sibling class members (for `{@link}` and other namepath references) only when the JSDoc block was attached to a `MethodDefinition` or `PropertyDefinition`. A block on the class itself did not get the class's members, so a reference like `{@link property}` in the class's own JSDoc was reported as undefined.

Handle `ClassDeclaration` and `ClassExpression` nodes too, reading members from `node.body` and the name from `node.id`, and collapse the near-identical method/property arms into one.

Fixes #1762